### PR TITLE
Improve `/v1/models` endpoint

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -44,7 +44,7 @@ export async function handleCompletion(c: Context) {
   if (isNullish(payload.max_tokens)) {
     payload = {
       ...payload,
-      max_tokens: selectedModel?.capabilities.limits.max_output_tokens,
+      max_tokens: selectedModel?.capabilities.limits?.max_output_tokens,
     }
     logger.debug("Set max_tokens to:", JSON.stringify(payload.max_tokens))
   }

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -16,11 +16,14 @@ modelRoutes.get("/", async (c) => {
     const models = state.models?.data.map((model) => ({
       id: model.id,
       object: "model",
-      type: "model",
+      type: model.capabilities.type || "chat",
       created: 0, // No date available from source
       created_at: new Date(0).toISOString(), // No date available from source
       owned_by: model.vendor,
       display_name: model.name,
+      ...(model.capabilities.limits && model.capabilities.limits.max_context_window_tokens && {
+        context_length: model.capabilities.limits.max_context_window_tokens,
+      }),
     }))
 
     return c.json({

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -35,7 +35,7 @@ interface ModelSupports {
 
 interface ModelCapabilities {
   family: string
-  limits: ModelLimits
+  limits?: ModelLimits
   object: string
   supports: ModelSupports
   tokenizer: string


### PR DESCRIPTION
- fix the `type` field - it's must be a model type, like 'chat' or 'embeddings'
- add field `context_length` - its used by most clients, what supports reading context size from `/v1/models`