### PR TITLE
Remove incompatible with copilot responses `service_tier` field

### DIFF
--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -22,6 +22,7 @@ export interface ResponsesPayload {
   store?: boolean | null
   reasoning?: Reasoning | null
   include?: Array<ResponseIncludable>
+  service_tier?: string | null // NOTE: Unsupported by GitHub Copilot
   [key: string]: unknown
 }
 
@@ -335,6 +336,9 @@ export const createResponses = async (
     ...copilotHeaders(state, vision),
     "X-Initiator": initiator,
   }
+
+  // service_tier is not supported by github copilot
+  payload.service_tier = null
 
   const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
     method: "POST",


### PR DESCRIPTION
This pull request makes a targeted update to the `createResponses` service to ensure compatibility with the responses endpoint. The change removes the unsupported by Copilot `service_tier` field from the request payload before making the API call.
The `service_tier` field may be passed by clients, like RooCode, when used OpenAI provider with custom base url.

API compatibility fix:

* [`src/services/copilot/create-responses.ts`](diffhunk://#diff-beecddb33837d0111e608c4b780ff8c90ebedfd71093cd443460e25c9d0a76cdR339-R345): Removes the `service_tier` property from the payload sent to the `/responses` endpoint, as this field is not supported by the Copilot API version.