### PR TITLE
Remove incompatible with copilot responses `service_tier` field (#45)

### DIFF
--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -22,6 +22,7 @@ export interface ResponsesPayload {
   store?: boolean | null
   reasoning?: Reasoning | null
   include?: Array<ResponseIncludable>
+  service_tier?: string | null // NOTE: Unsupported by GitHub Copilot
   [key: string]: unknown
 }
 
@@ -335,6 +336,9 @@ export const createResponses = async (
     ...copilotHeaders(state, vision),
     "X-Initiator": initiator,
   }
+
+  // service_tier is not supported by github copilot
+  payload.service_tier = null
 
   const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
     method: "POST",


### PR DESCRIPTION
Some clients, like RooCode may send `service_tier` to `/responses` endpoint, but Copilot do not support this field and returns error