### PR TITLE
fix: use default API URL when account type is individual

### DIFF
--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -14,8 +14,9 @@ const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const API_VERSION = "2025-10-01"
 
 export const copilotBaseUrl = (state: State) =>
-  `https://api.${state.accountType}.githubcopilot.com`
-
+  state.accountType === "individual" ?
+    "https://api.githubcopilot.com"
+  : `https://api.${state.accountType}.githubcopilot.com`
 export const copilotHeaders = (state: State, vision: boolean = false) => {
   const headers: Record<string, string> = {
     Authorization: `Bearer ${state.copilotToken}`,


### PR DESCRIPTION
## Problem

After recent refactoring, business users who don't explicitly specify their account type can no longer connect, breaking previous behavior.

## Solution

When account type is not specified or set to 'individual', use the default `api.githubcopilot.com` URL instead of constructing `api.individual.githubcopilot.com`.

The default URL works for both individual and business accounts, restoring the previous behavior where business users could work without the `-a business` flag.

## Changes

- Special case for `individual` account type to use default URL
- Business/enterprise account types still use their specific subdomains when explicitly set
- Maintains backward compatibility

## Testing

- ✅ Individual accounts work with default URL
- ✅ Business accounts work without specifying account type (previous behavior restored)
- ✅ Business/enterprise accounts continue to work when explicitly specified