### PR TITLE
fix: sync stream IDs for @ai-sdk/openai compatibility with Responses API

### DIFF
--- a/src/routes/responses/stream-id-sync.ts
+++ b/src/routes/responses/stream-id-sync.ts
@@ -1,0 +1,194 @@
+/**
+ * Stream ID Synchronization for @ai-sdk/openai compatibility
+ *
+ * Problem: GitHub Copilot's Responses API returns different IDs for the same
+ * item in 'added' vs 'done' events. This breaks @ai-sdk/openai which expects
+ * consistent IDs across the stream lifecycle.
+ *
+ * Errors without this fix:
+ * - "activeReasoningPart.summaryParts" undefined
+ * - "text part not found"
+ *
+ * Use case: OpenCode (AI coding assistant) using Codex models (gpt-5.2-codex)
+ * via @ai-sdk/openai provider requires the Responses API endpoint.
+ */
+
+interface StreamIdTracker {
+  outputItems: Map<number, string>
+  contentParts: Map<string, string>
+  messageItems: Map<number, string>
+}
+
+interface StreamEventData {
+  item?: {
+    id?: string
+    type?: string
+    summary?: Array<unknown>
+  }
+  output_index?: number
+  content_index?: number
+  item_id?: string
+  response?: {
+    output?: Array<{
+      type?: string
+      summary?: Array<unknown>
+    }>
+  }
+}
+
+export const createStreamIdTracker = (): StreamIdTracker => ({
+  outputItems: new Map(),
+  contentParts: new Map(),
+  messageItems: new Map(),
+})
+
+export const fixStreamIds = (
+  data: string,
+  event: string | undefined,
+  tracker: StreamIdTracker,
+): string => {
+  if (!data) return data
+
+  try {
+    const parsed = JSON.parse(data) as StreamEventData
+
+    switch (event) {
+      case "response.output_item.added": {
+        return handleOutputItemAdded(parsed, tracker)
+      }
+      case "response.output_item.done": {
+        return handleOutputItemDone(parsed, tracker)
+      }
+      case "response.content_part.added": {
+        return handleContentPartAdded(parsed, tracker)
+      }
+      case "response.content_part.done": {
+        return handleContentPartDone(parsed, tracker)
+      }
+      case "response.output_text.delta":
+      case "response.output_text.done": {
+        return handleOutputText(parsed, tracker)
+      }
+      case "response.completed":
+      case "response.incomplete": {
+        return handleResponseCompleted(parsed)
+      }
+      default: {
+        return data
+      }
+    }
+  } catch {
+    return data
+  }
+}
+
+const handleOutputItemAdded = (
+  parsed: StreamEventData,
+  tracker: StreamIdTracker,
+): string => {
+  if (!parsed.item?.id) return JSON.stringify(parsed)
+
+  const outputIndex = parsed.output_index ?? 0
+  tracker.outputItems.set(outputIndex, parsed.item.id)
+
+  if (parsed.item.type === "message") {
+    tracker.messageItems.set(outputIndex, parsed.item.id)
+  }
+  if (
+    parsed.item.type === "reasoning"
+    && Array.isArray(parsed.item.summary)
+    && parsed.item.summary.length === 0
+  ) {
+    delete parsed.item.summary
+  }
+  return JSON.stringify(parsed)
+}
+
+const handleOutputItemDone = (
+  parsed: StreamEventData,
+  tracker: StreamIdTracker,
+): string => {
+  if (!parsed.item) return JSON.stringify(parsed)
+
+  const outputIndex = parsed.output_index ?? 0
+  const originalId = tracker.outputItems.get(outputIndex)
+  if (originalId) {
+    parsed.item.id = originalId
+  }
+  if (
+    parsed.item.type === "reasoning"
+    && Array.isArray(parsed.item.summary)
+    && parsed.item.summary.length === 0
+  ) {
+    delete parsed.item.summary
+  }
+  return JSON.stringify(parsed)
+}
+
+const handleContentPartAdded = (
+  parsed: StreamEventData,
+  tracker: StreamIdTracker,
+): string => {
+  const outputIndex = parsed.output_index ?? 0
+  const contentIndex = parsed.content_index ?? 0
+  const key = `${outputIndex}:${contentIndex}`
+
+  if (parsed.item_id) {
+    tracker.contentParts.set(key, parsed.item_id)
+  }
+
+  const messageId = tracker.messageItems.get(outputIndex)
+  if (messageId) {
+    parsed.item_id = messageId
+  }
+  return JSON.stringify(parsed)
+}
+
+const handleContentPartDone = (
+  parsed: StreamEventData,
+  tracker: StreamIdTracker,
+): string => {
+  const outputIndex = parsed.output_index ?? 0
+  const contentIndex = parsed.content_index ?? 0
+  const key = `${outputIndex}:${contentIndex}`
+
+  const messageId = tracker.messageItems.get(outputIndex)
+  if (messageId) {
+    parsed.item_id = messageId
+  } else {
+    const originalItemId = tracker.contentParts.get(key)
+    if (originalItemId) {
+      parsed.item_id = originalItemId
+    }
+  }
+
+  tracker.contentParts.delete(key)
+  return JSON.stringify(parsed)
+}
+
+const handleOutputText = (
+  parsed: StreamEventData,
+  tracker: StreamIdTracker,
+): string => {
+  const outputIndex = parsed.output_index ?? 0
+  const messageId = tracker.messageItems.get(outputIndex)
+  if (messageId) {
+    parsed.item_id = messageId
+  }
+  return JSON.stringify(parsed)
+}
+
+const handleResponseCompleted = (parsed: StreamEventData): string => {
+  if (!parsed.response?.output) return JSON.stringify(parsed)
+
+  for (const item of parsed.response.output) {
+    if (
+      item.type === "reasoning"
+      && Array.isArray(item.summary)
+      && item.summary.length === 0
+    ) {
+      delete item.summary
+    }
+  }
+  return JSON.stringify(parsed)
+}


### PR DESCRIPTION
## Summary

This PR fixes stream ID synchronization issues that cause `@ai-sdk/openai` to crash when using GitHub Copilot's Responses API.

## Problem

When using **OpenCode** (or any client built on `@ai-sdk/openai`) with Copilot's **Codex models** (e.g., `gpt-5.2-codex`) via the Responses API, the following errors occur:

```
undefined is not an object (evaluating 'activeReasoningPart.summaryParts')
```
```
text part not found
```

### Root Cause

GitHub Copilot's Responses API returns **different IDs** for the same item in `added` vs `done` events:

```json
// response.output_item.added
{"item": {"id": "item_abc123", ...}}

// response.output_item.done  
{"item": {"id": "item_xyz789", ...}}  // Different ID!
```

The `@ai-sdk/openai` SDK expects consistent IDs across the stream lifecycle. When IDs don't match, it cannot find the corresponding parts and throws errors.

Additionally, Copilot returns empty `summary: []` arrays on reasoning items, which causes:
```
activeReasoningPart.summaryParts undefined
```

## Solution

Added `stream-id-sync.ts` module that:

1. **Tracks IDs from `added` events** and reuses them in corresponding `done` events
2. **Removes empty `summary` arrays** from `reasoning` type items
3. **Synchronizes `item_id`** for message-type outputs across `content_part.*` and `output_text.*` events
4. **Handles `response.completed/incomplete`** events to clean up empty summaries in final output

### Events Handled

| Event | Action |
|-------|--------|
| `response.output_item.added` | Track `output_index` → `item.id`, remove empty summary |
| `response.output_item.done` | Reuse tracked ID, remove empty summary |
| `response.content_part.added` | Track content part, sync message ID |
| `response.content_part.done` | Reuse tracked IDs |
| `response.output_text.delta/done` | Sync message ID |
| `response.completed/incomplete` | Remove empty summaries from output array |

## Use Case

This fix enables **OpenCode** (AI coding assistant) to use Copilot's Codex models (`gpt-5.2-codex`) through the `@ai-sdk/openai` provider, which requires the Responses API endpoint.

## Testing

- Verified with OpenCode's Oracle agent using `gpt-5.2-codex` model
- Confirmed no `activeReasoningPart.summaryParts` errors after fix
- Confirmed tool calls and text responses work correctly

## Files Changed

- `src/routes/responses/handler.ts` - Integrate stream ID sync into SSE stream
- `src/routes/responses/stream-id-sync.ts` - New module with ID tracking and fixing logic