### PR TITLE
fix(stream): send valid JSON in SSE ping events to prevent AI_JSONParseError

### DIFF
--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -193,7 +193,7 @@ const handleWithResponsesApi = async (
       for await (const chunk of response) {
         const eventName = chunk.event
         if (eventName === "ping") {
-          await stream.writeSSE({ event: "ping", data: "" })
+          await stream.writeSSE({ event: "ping", data: '{"type":"ping"}' })
           continue
         }
 


### PR DESCRIPTION
## Problem

When using models like `gpt-5.2` through the `/v1/messages` endpoint, clients built on `@ai-sdk/anthropic` (e.g., [OpenCode](https://github.com/sst/opencode)) intermittently error with `AI_JSONParseError: Unexpected EOF`.

### Root cause

The `@ai-sdk/provider-utils` SSE parser calls `JSON.parse()` on **every** SSE `data` field. The only value it skips is the literal string `[DONE]`. When the server sends a ping event with `data: ""` (empty string), `JSON.parse("")` throws `Unexpected EOF`.

Stack trace from OpenCode logs:

```
AI_JSONParseError: JSON parsing failed: Text: .
Error message: JSON Parse error: Unexpected EOF
    at safeParseJSON (@ai-sdk/provider-utils/dist/index.mjs:653:61)
    at transform (@ai-sdk/provider-utils/dist/index.mjs:681:34)
```

### Relevant code in `@ai-sdk/provider-utils`

The SSE stream parser at `provider-utils/dist/index.mjs:677-681` runs `safeParseJSON` unconditionally on every SSE data line. It does **not** have special handling for empty strings or ping events — only `[DONE]` is skipped.

## Fix

One-line change: replace `data: ""` with `data: '{"type":"ping"}'` in the `handleWithResponsesApi` streaming path (`src/routes/messages/handler.ts`).

This sends valid JSON that `@ai-sdk/anthropic` can parse without error, and `{"type":"ping"}` matches Anthropic's own SSE event schema convention.

## Test plan

- [ ] Start server, connect with OpenCode using `gpt-5.2` via `/v1/messages`
- [ ] Verify no `AI_JSONParseError` in OpenCode logs during streaming
- [ ] Verify ping events are still received and keep the connection alive