### PR TITLE
fix: prevent premium request overcounting and model name mismatch for Claude Agent Teams feature

### DIFF
--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -50,6 +50,39 @@ import { parseSubagentMarkerFromFirstUser } from "./subagent-marker"
 
 const logger = createHandlerLogger("messages-handler")
 
+const SYSTEM_GENERATED_PATTERNS = [
+  /^<system-reminder>/,
+  /^<teammate-message\s/,
+  /^<local-command-caveat>/,
+  /^\{"type":"idle_notification"/,
+  /^\{"type":"shutdown/,
+  /^\{"type":"teammate_terminated"/,
+]
+
+const isSystemGeneratedText = (text: string): boolean => {
+  const trimmed = text.trim()
+  return SYSTEM_GENERATED_PATTERNS.some((pattern) => pattern.test(trimmed))
+}
+
+const detectSystemGeneratedInitiator = (
+  payload: AnthropicMessagesPayload,
+): "agent" | undefined => {
+  const lastUserMsg = payload.messages.at(-1)
+  if (
+    lastUserMsg?.role === "user"
+    && Array.isArray(lastUserMsg.content)
+    && lastUserMsg.content.length > 0
+    && lastUserMsg.content.every(
+      (block) =>
+        block.type === "tool_result"
+        || (block.type === "text" && isSystemGeneratedText(block.text)),
+    )
+  ) {
+    return "agent"
+  }
+  return undefined
+}
+
 const compactSystemPromptStart =
   "You are a helpful AI assistant tasked with summarizing conversations"
 
@@ -60,7 +93,8 @@ export async function handleCompletion(c: Context) {
   logger.debug("Anthropic request payload:", JSON.stringify(anthropicPayload))
 
   const subagentMarker = parseSubagentMarkerFromFirstUser(anthropicPayload)
-  const initiatorOverride = subagentMarker ? "agent" : undefined
+  let initiatorOverride: "agent" | "user" | undefined =
+    subagentMarker ? "agent" : undefined
   if (subagentMarker) {
     logger.debug("Detected Subagent marker:", JSON.stringify(subagentMarker))
   }
@@ -91,15 +125,20 @@ export async function handleCompletion(c: Context) {
     mergeToolResultForClaude(anthropicPayload)
   }
 
+  // Detect system-generated text-only user messages from Agent Teams
+  // (teammate notifications, idle notifications, system reminders)
+  // that would otherwise be counted as premium (user-initiated) requests
+  initiatorOverride ??= detectSystemGeneratedInitiator(anthropicPayload)
+
   if (state.manualApprove) {
     await awaitApproval()
   }
 
-  const selectedModel = state.models?.data.find(
-    (m) => m.id === anthropicPayload.model,
-  ) ?? state.models?.data.find(
-    (m) => m.id === normalizeModelName(anthropicPayload.model),
-  )
+  const selectedModel =
+    state.models?.data.find((m) => m.id === anthropicPayload.model)
+    ?? state.models?.data.find(
+      (m) => m.id === normalizeModelName(anthropicPayload.model),
+    )
 
   if (shouldUseMessagesApi(selectedModel)) {
     return await handleWithMessagesApi(c, anthropicPayload, {
@@ -450,7 +489,7 @@ const mergeToolResult = (
  * entries in the Copilot models list.
  */
 const normalizeModelName = (model: string): string => {
-  if (/^claude-sonnet-4[.\-]/.test(model)) return "claude-sonnet-4"
-  if (/^claude-opus-4[.\-]/.test(model)) return "claude-opus-4"
+  if (/^claude-sonnet-4[.-]/.test(model)) return "claude-sonnet-4"
+  if (/^claude-opus-4[.-]/.test(model)) return "claude-opus-4"
   return model
 }

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -97,6 +97,8 @@ export async function handleCompletion(c: Context) {
 
   const selectedModel = state.models?.data.find(
     (m) => m.id === anthropicPayload.model,
+  ) ?? state.models?.data.find(
+    (m) => m.id === normalizeModelName(anthropicPayload.model),
   )
 
   if (shouldUseMessagesApi(selectedModel)) {
@@ -440,4 +442,15 @@ const mergeToolResult = (
   return toolResults.map((tr, i) =>
     i === lastIndex ? mergeContentWithTexts(tr, textBlocks) : tr,
   )
+}
+
+/**
+ * Strip version suffixes from Claude model names so that versioned model IDs
+ * (e.g. "claude-opus-4.6", "claude-sonnet-4-20250514") can match base model
+ * entries in the Copilot models list.
+ */
+const normalizeModelName = (model: string): string => {
+  if (/^claude-sonnet-4[.\-]/.test(model)) return "claude-sonnet-4"
+  if (/^claude-opus-4[.\-]/.test(model)) return "claude-opus-4"
+  return model
 }

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -77,11 +77,13 @@ function getThinkingBudget(
 }
 
 function translateModelName(model: string): string {
-  // Subagent requests use a specific model number which Copilot doesn't support
-  if (model.startsWith("claude-sonnet-4-")) {
-    return model.replace(/^claude-sonnet-4-.*/, "claude-sonnet-4")
-  } else if (model.startsWith("claude-opus-4-")) {
-    return model.replace(/^claude-opus-4-.*/, "claude-opus-4")
+  // Subagent and agent team requests use a specific model version which Copilot
+  // doesn't support (e.g. claude-sonnet-4-20250514, claude-opus-4.6).
+  // Handle both dash- and dot-separated version suffixes.
+  if (/^claude-sonnet-4[.\-]/.test(model)) {
+    return "claude-sonnet-4"
+  } else if (/^claude-opus-4[.\-]/.test(model)) {
+    return "claude-opus-4"
   }
   return model
 }


### PR DESCRIPTION
## Problem

  Two issues when Agent Teams are active:

  **1. Excessive premium request consumption**

  The team_lead accumulates premium requests far beyond what the user actually
  initiated. Every teammate notification, idle poll, and system reminder arrives
  as a plain text user message — and the proxy's `isInitiateRequest` heuristic
  in `create-messages.ts` treats any non-tool_result user message as
  user-initiated (`X-Initiator: user`).

  Teammates are fine because they carry the subagent marker → always
  `X-Initiator: agent`. The team_lead has no marker, so it falls back to the
  heuristic and every injected system message burns a premium request.

  **2. Wrong model name sent under teammates**

  When `ANTHROPIC_DEFAULT_OPUS_MODEL` is configured (e.g. `claude-sonnet-4.6`),
  requests under teammates still go out as `claude-opus-4-6` (dot-separated
  version suffix). Claude Code sends the full versioned model ID instead of the
  base model name in teammate context, causing the proxy to not recognize it.

  Fixes #94

  ## Fix

  **Premium request fix:** After `mergeToolResultForClaude`, detect
  system-generated text-only user messages by pattern-matching known tags:

  - `<system-reminder>`
  - `<teammate-message>`
  - `<local-command-caveat>`
  - JSON protocol messages (`idle_notification`, `shutdown*`, `teammate_terminated`)

  If every text block in the last user message matches one of these patterns,
  override the initiator to `"agent"` before the request goes out. Only triggers
  when there's no subagent marker (team_lead only). Genuine user messages won't
  match any pattern and stay `X-Initiator: user`.

  **Model name fix:** `normalizeModelName` strips dot-separated version suffixes
  so `claude-opus-4-6` and `claude-opus-4.6` both resolve to `claude-opus-4`,
  allowing the proxy to correctly identify the model regardless of how Claude
  Code formats the name.

  Also fixes pre-existing `no-useless-escape` lint warnings in `normalizeModelName`.

  ## Testing

  Ran a 5+ agent swarm — premium request count only increased by ~3
  (the actual user-initiated turns) instead of spiking on every teammate
  notification.