### PR TITLE
fix: filter unsupported context-1m beta header

### DIFF
--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -48,7 +48,10 @@ export const createMessages = async (
     const filteredBeta = anthropicBetaHeader
       .split(",")
       .map((item) => item.trim())
-      .filter((item) => item !== "claude-code-20250219")
+      .filter(
+        (item) =>
+          item !== "claude-code-20250219" && !item.startsWith("context-1m-"),
+      )
       .join(",")
     if (filteredBeta) {
       headers["anthropic-beta"] = filteredBeta


### PR DESCRIPTION
## Summary

- Filter out `context-1m-*` prefixed beta headers when forwarding requests to the upstream Copilot API
- Claude Code sends `context-1m-2025-08-07` in the `anthropic-beta` header when using 1M context models (e.g., `claude-opus-4.6-1m`), but the upstream API does not support this, causing **400 errors** with `unsupported beta header(s): context-1m-2025-08-07`
- Uses `startsWith("context-1m-")` prefix matching to future-proof against date suffix changes

## Error before fix

```
ERROR  HTTP error: { error:
   { message: 'unsupported beta header(s): context-1m-2025-08-07',
     code: 'invalid_request_body' } }
```

## Test plan

- [ ] Verify requests with `context-1m-2025-08-07` beta header no longer return 400
- [ ] Verify other valid beta headers are still forwarded correctly
- [ ] Verify thinking mode fallback (`interleaved-thinking-2025-05-14`) still works when no beta header is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)