### PR TITLE
feat: serve usage viewer locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY ./package.json ./bun.lock ./
 RUN bun install --frozen-lockfile --production --ignore-scripts --no-cache
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/pages ./pages
 
 EXPOSE 4141
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ After starting the server, a URL to the Copilot Usage Dashboard will be displaye
     npx @jeffreycao/copilot-api@latest start
     ```
 2.  The server will output a URL to the usage viewer. Copy and paste this URL into your browser. It will look something like this:
-    `https://ericc-ch.github.io/copilot-api?endpoint=http://localhost:4141/usage`
+    `http://localhost:4141/usage-viewer?endpoint=http://localhost:4141/usage`
     - If you use the `start.bat` script on Windows, this page will open automatically.
 
 The dashboard provides a user-friendly interface to view your Copilot usage data:
@@ -323,7 +323,7 @@ The dashboard provides a user-friendly interface to view your Copilot usage data
 - **Usage Quotas**: View a summary of your usage quotas for different services like Chat and Completions, displayed with progress bars for a quick overview.
 - **Detailed Information**: See the full JSON response from the API for a detailed breakdown of all available usage statistics.
 - **URL-based Configuration**: You can also specify the API endpoint directly in the URL using a query parameter. This is useful for bookmarks or sharing links. For example:
-  `https://ericc-ch.github.io/copilot-api?endpoint=http://your-api-server/usage`
+  `http://localhost:4141/usage-viewer?endpoint=http://your-api-server/usage`
 
 ## Using with Claude Code
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "copilot-api": "./dist/main.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "pages"
   ],
   "scripts": {
     "build": "tsdown",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
+import { readFileSync } from "node:fs"
 
 import { createAuthMiddleware } from "./lib/request-auth"
 import { completionRoutes } from "./routes/chat-completions/route"
@@ -15,9 +16,19 @@ export const server = new Hono()
 
 server.use(logger())
 server.use(cors())
-server.use("*", createAuthMiddleware())
+server.use(
+  "*",
+  createAuthMiddleware({
+    allowUnauthenticatedPaths: ["/", "/usage-viewer", "/usage-viewer/"],
+  }),
+)
 
 server.get("/", (c) => c.text("Server running"))
+server.get("/usage-viewer", (c) => {
+  const usageViewerFileUrl = new URL("../pages/index.html", import.meta.url)
+  return c.html(readFileSync(usageViewerFileUrl, "utf8"))
+})
+server.get("/usage-viewer/", (c) => c.redirect("/usage-viewer", 301))
 
 server.route("/chat/completions", completionRoutes)
 server.route("/models", modelRoutes)

--- a/src/start.ts
+++ b/src/start.ts
@@ -115,7 +115,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
   }
 
   consola.box(
-    `🌐 Usage Viewer: https://ericc-ch.github.io/copilot-api?endpoint=${serverUrl}/usage`,
+    `🌐 Usage Viewer: ${serverUrl}/usage-viewer?endpoint=${serverUrl}/usage`,
   )
 
   const { server } = await import("./server")

--- a/start.bat
+++ b/start.bat
@@ -14,7 +14,7 @@ echo Starting server...
 echo The usage viewer page will open automatically after the server starts
 echo.
 
-start "" "https://ericc-ch.github.io/copilot-api?endpoint=http://localhost:4141/usage"
+start "" "http://localhost:4141/usage-viewer?endpoint=http://localhost:4141/usage"
 bun run dev
 
 pause


### PR DESCRIPTION
## Summary
- Serve the usage dashboard at `/usage-viewer` from the API server so local runs no longer depend on GitHub Pages.
- Update startup output, Windows launcher, and README examples to point to the local viewer URL.
- Include `pages/` in npm package files and Docker runtime image so the viewer is available in packaged and containerized deployments.

## Test plan
- [x] Run `bun run lint`
- [x] Run `bun run typecheck`
- [x] Verify `/usage-viewer` route returns dashboard HTML locally
- [x] Rebuild Docker image and verify `/usage-viewer` no longer returns 404

<img width="1453" height="397" alt="Screenshot 2026-03-05 at 1 26 40 PM" src="https://github.com/user-attachments/assets/df168552-cc7d-498b-b317-4a895b7c00be" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)