### PR TITLE
fix: preserve Claude thinking blocks for Claude Code

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -1,3 +1,5 @@
+import type { ChatCompletionChunk } from "~/services/copilot/create-chat-completions"
+
 // Anthropic API Types
 
 export interface AnthropicMessagesPayload {
@@ -197,10 +199,12 @@ export type AnthropicStreamEventData =
 
 // State for streaming translation
 export interface AnthropicStreamState {
+  currentModel?: string
   messageStartSent: boolean
   contentBlockIndex: number
   contentBlockOpen: boolean
   thinkingBlockOpen: boolean
+  pendingChunksAfterThinking: Array<ChatCompletionChunk>
   toolCalls: {
     [openAIToolIndex: number]: {
       id: string

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -1,5 +1,6 @@
 import type { Context } from "hono"
 
+import consola from "consola"
 import { streamSSE } from "hono/streaming"
 
 import type { Model } from "~/services/copilot/get-models"
@@ -36,7 +37,9 @@ import {
 } from "~/services/copilot/create-responses"
 
 import {
+  type AnthropicAssistantContentBlock,
   type AnthropicMessagesPayload,
+  type AnthropicStreamEventData,
   type AnthropicStreamState,
   type AnthropicTextBlock,
   type AnthropicToolResultBlock,
@@ -52,6 +55,195 @@ const logger = createHandlerLogger("messages-handler")
 
 const compactSystemPromptStart =
   "You are a helpful AI assistant tasked with summarizing conversations"
+
+type ThinkingStreamTracker = {
+  activeIndexes: Set<number>
+  textCharsByIndex: Map<number, number>
+  deltaCountsByIndex: Map<number, number>
+  signatureCharsByIndex: Map<number, number>
+}
+
+const createThinkingStreamTracker = (): ThinkingStreamTracker => ({
+  activeIndexes: new Set<number>(),
+  textCharsByIndex: new Map<number, number>(),
+  deltaCountsByIndex: new Map<number, number>(),
+  signatureCharsByIndex: new Map<number, number>(),
+})
+
+const logThinkingTelemetry = (
+  message: string,
+  details?: Record<string, unknown>,
+): void => {
+  const serialized = details ? JSON.stringify(details) : undefined
+  if (serialized) {
+    logger.info("[thinking]", message, serialized)
+  } else {
+    logger.info("[thinking]", message)
+  }
+
+  if (!state.verbose) {
+    return
+  }
+
+  if (serialized) {
+    consola.info(`[thinking] ${message} ${serialized}`)
+    return
+  }
+
+  consola.info(`[thinking] ${message}`)
+}
+
+const isThinkingBlock = (
+  block: AnthropicAssistantContentBlock,
+): block is Extract<AnthropicAssistantContentBlock, { type: "thinking" }> =>
+  block.type === "thinking"
+
+const countAssistantThinkingBlocks = (
+  payload: AnthropicMessagesPayload,
+): number => {
+  return payload.messages.reduce((count, message) => {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      return count
+    }
+
+    return (
+      count + message.content.filter((block) => isThinkingBlock(block)).length
+    )
+  }, 0)
+}
+
+const logThinkingRequestSummary = (
+  route: "messages" | "chat-completions" | "responses",
+  payload: AnthropicMessagesPayload,
+  options?: {
+    filteredThinkingBlocks?: number
+    anthropicBetaHeader?: string
+  },
+): void => {
+  const assistantHistoryThinkingBlocks = countAssistantThinkingBlocks(payload)
+  const thinkingRequested = Boolean(payload.thinking)
+  const filteredThinkingBlocks = options?.filteredThinkingBlocks ?? 0
+
+  if (
+    !thinkingRequested
+    && assistantHistoryThinkingBlocks === 0
+    && filteredThinkingBlocks === 0
+  ) {
+    return
+  }
+
+  logThinkingTelemetry(`${route} request`, {
+    model: payload.model,
+    stream: payload.stream ?? false,
+    thinking_requested: thinkingRequested,
+    thinking_type: payload.thinking?.type ?? null,
+    thinking_budget_tokens: payload.thinking?.budget_tokens ?? null,
+    assistant_history_thinking_blocks: assistantHistoryThinkingBlocks,
+    filtered_thinking_blocks: filteredThinkingBlocks,
+    anthropic_beta: options?.anthropicBetaHeader ?? null,
+  })
+}
+
+const logThinkingResponseSummary = (
+  route: "messages" | "chat-completions" | "responses",
+  content: Array<AnthropicAssistantContentBlock>,
+): void => {
+  const thinkingBlocks = content.filter((block) => isThinkingBlock(block))
+  if (thinkingBlocks.length === 0) {
+    return
+  }
+
+  logThinkingTelemetry(`${route} response`, {
+    thinking_blocks: thinkingBlocks.length,
+    blocks: thinkingBlocks.map((block, index) => ({
+      index,
+      chars: block.thinking.length,
+      signature_present: block.signature.length > 0,
+    })),
+  })
+}
+
+const logThinkingStreamEvent = (
+  route: "messages" | "chat-completions" | "responses",
+  event: AnthropicStreamEventData,
+  tracker: ThinkingStreamTracker,
+): void => {
+  if (
+    event.type === "content_block_start"
+    && event.content_block.type === "thinking"
+  ) {
+    tracker.activeIndexes.add(event.index)
+    tracker.textCharsByIndex.set(event.index, 0)
+    tracker.deltaCountsByIndex.set(event.index, 0)
+    tracker.signatureCharsByIndex.set(event.index, 0)
+    logThinkingTelemetry(`${route} thinking block started`, {
+      index: event.index,
+    })
+    return
+  }
+
+  if (
+    event.type === "content_block_delta"
+    && event.delta.type === "thinking_delta"
+  ) {
+    const chars = event.delta.thinking.length
+    tracker.textCharsByIndex.set(
+      event.index,
+      (tracker.textCharsByIndex.get(event.index) ?? 0) + chars,
+    )
+    tracker.deltaCountsByIndex.set(
+      event.index,
+      (tracker.deltaCountsByIndex.get(event.index) ?? 0) + 1,
+    )
+    return
+  }
+
+  if (
+    event.type === "content_block_delta"
+    && event.delta.type === "signature_delta"
+  ) {
+    if (!tracker.activeIndexes.has(event.index)) {
+      return
+    }
+
+    tracker.signatureCharsByIndex.set(event.index, event.delta.signature.length)
+    logThinkingTelemetry(`${route} thinking signature`, {
+      index: event.index,
+      signature_chars: event.delta.signature.length,
+    })
+    return
+  }
+
+  if (
+    event.type === "content_block_stop"
+    && tracker.activeIndexes.has(event.index)
+  ) {
+    logThinkingTelemetry(`${route} thinking block stopped`, {
+      index: event.index,
+      delta_count: tracker.deltaCountsByIndex.get(event.index) ?? 0,
+      total_chars: tracker.textCharsByIndex.get(event.index) ?? 0,
+      signature_chars: tracker.signatureCharsByIndex.get(event.index) ?? 0,
+    })
+    tracker.activeIndexes.delete(event.index)
+    tracker.textCharsByIndex.delete(event.index)
+    tracker.deltaCountsByIndex.delete(event.index)
+    tracker.signatureCharsByIndex.delete(event.index)
+  }
+}
+
+const tryParseAnthropicStreamEvent = (
+  data: string,
+): AnthropicStreamEventData | undefined => {
+  if (!data) {
+    return undefined
+  }
+
+  try {
+    return JSON.parse(data) as AnthropicStreamEventData
+  } catch {
+    return undefined
+  }
+}
 
 export async function handleCompletion(c: Context) {
   await checkRateLimit(state)
@@ -123,6 +315,7 @@ const handleWithChatCompletions = async (
   initiatorOverride?: "agent" | "user",
 ) => {
   const openAIPayload = translateToOpenAI(anthropicPayload)
+  logThinkingRequestSummary("chat-completions", anthropicPayload)
   logger.debug(
     "Translated OpenAI request payload:",
     JSON.stringify(openAIPayload),
@@ -138,6 +331,7 @@ const handleWithChatCompletions = async (
       JSON.stringify(response),
     )
     const anthropicResponse = translateToAnthropic(response)
+    logThinkingResponseSummary("chat-completions", anthropicResponse.content)
     logger.debug(
       "Translated Anthropic response:",
       JSON.stringify(anthropicResponse),
@@ -147,12 +341,15 @@ const handleWithChatCompletions = async (
 
   logger.debug("Streaming response from Copilot")
   return streamSSE(c, async (stream) => {
+    const thinkingTracker = createThinkingStreamTracker()
     const streamState: AnthropicStreamState = {
+      currentModel: undefined,
       messageStartSent: false,
       contentBlockIndex: 0,
       contentBlockOpen: false,
       toolCalls: {},
       thinkingBlockOpen: false,
+      pendingChunksAfterThinking: [],
     }
 
     for await (const rawEvent of response) {
@@ -169,6 +366,7 @@ const handleWithChatCompletions = async (
       const events = translateChunkToAnthropicEvents(chunk, streamState)
 
       for (const event of events) {
+        logThinkingStreamEvent("chat-completions", event, thinkingTracker)
         logger.debug("Translated Anthropic event:", JSON.stringify(event))
         await stream.writeSSE({
           event: event.type,
@@ -186,6 +384,7 @@ const handleWithResponsesApi = async (
 ) => {
   const responsesPayload =
     translateAnthropicMessagesToResponsesPayload(anthropicPayload)
+  logThinkingRequestSummary("responses", anthropicPayload)
   logger.debug(
     "Translated Responses payload:",
     JSON.stringify(responsesPayload),
@@ -200,6 +399,7 @@ const handleWithResponsesApi = async (
   if (responsesPayload.stream && isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Responses API)")
     return streamSSE(c, async (stream) => {
+      const thinkingTracker = createThinkingStreamTracker()
       const streamState = createResponsesStreamState()
 
       for await (const chunk of response) {
@@ -222,6 +422,7 @@ const handleWithResponsesApi = async (
         )
         for (const event of events) {
           const eventData = JSON.stringify(event)
+          logThinkingStreamEvent("responses", event, thinkingTracker)
           logger.debug("Translated Anthropic event:", eventData)
           await stream.writeSSE({
             event: event.type,
@@ -257,6 +458,7 @@ const handleWithResponsesApi = async (
   const anthropicResponse = translateResponsesResultToAnthropic(
     response as ResponsesResult,
   )
+  logThinkingResponseSummary("responses", anthropicResponse.content)
   logger.debug(
     "Translated Anthropic response:",
     JSON.stringify(anthropicResponse),
@@ -275,6 +477,8 @@ const handleWithMessagesApi = async (
 ) => {
   const { anthropicBetaHeader, initiatorOverride, selectedModel } =
     options ?? {}
+  const thinkingBlocksBeforeFilter =
+    countAssistantThinkingBlocks(anthropicPayload)
   // Pre-request processing: filter thinking blocks for Claude models so only
   // valid thinking blocks are sent to the Copilot Messages API.
   for (const msg of anthropicPayload.messages) {
@@ -290,6 +494,8 @@ const handleWithMessagesApi = async (
       })
     }
   }
+  const filteredThinkingBlocks =
+    thinkingBlocksBeforeFilter - countAssistantThinkingBlocks(anthropicPayload)
 
   if (selectedModel?.capabilities.supports.adaptive_thinking) {
     anthropicPayload.thinking = {
@@ -300,6 +506,11 @@ const handleWithMessagesApi = async (
     }
   }
 
+  logThinkingRequestSummary("messages", anthropicPayload, {
+    filteredThinkingBlocks,
+    anthropicBetaHeader,
+  })
+
   logger.debug("Translated Messages payload:", JSON.stringify(anthropicPayload))
 
   const response = await createMessages(anthropicPayload, anthropicBetaHeader, {
@@ -309,9 +520,14 @@ const handleWithMessagesApi = async (
   if (isAsyncIterable(response)) {
     logger.debug("Streaming response from Copilot (Messages API)")
     return streamSSE(c, async (stream) => {
+      const thinkingTracker = createThinkingStreamTracker()
       for await (const event of response) {
         const eventName = event.event
         const data = event.data ?? ""
+        const parsedEvent = tryParseAnthropicStreamEvent(data)
+        if (parsedEvent) {
+          logThinkingStreamEvent("messages", parsedEvent, thinkingTracker)
+        }
         logger.debug("Messages raw stream event:", data)
         await stream.writeSSE({
           event: eventName,
@@ -325,6 +541,7 @@ const handleWithMessagesApi = async (
     "Non-streaming Messages result:",
     JSON.stringify(response).slice(-400),
   )
+  logThinkingResponseSummary("messages", response.content)
   return c.json(response)
 }
 

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -29,6 +29,10 @@ import { mapOpenAIStopReasonToAnthropic } from "./utils"
 // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we need add a default thinking text
 export const THINKING_TEXT = "Thinking..."
 
+function isClaudeModel(model: string): boolean {
+  return model.toLowerCase().startsWith("claude")
+}
+
 // Payload translation
 export function translateToOpenAI(
   payload: AnthropicMessagesPayload,
@@ -217,7 +221,7 @@ function handleAssistantMessage(
     (block): block is AnthropicThinkingBlock => block.type === "thinking",
   )
 
-  if (modelId.startsWith("claude")) {
+  if (isClaudeModel(modelId)) {
     thinkingBlocks = thinkingBlocks.filter(
       (b) =>
         b.thinking
@@ -369,6 +373,7 @@ export function translateToAnthropic(
     const thinkBlocks = getAnthropicThinkBlocks(
       choice.message.reasoning_text,
       choice.message.reasoning_opaque,
+      response.model,
     )
     const toolUseBlocks = getAnthropicToolUseBlocks(choice.message.tool_calls)
 
@@ -421,6 +426,7 @@ function getAnthropicTextBlocks(
 function getAnthropicThinkBlocks(
   reasoningText: string | null | undefined,
   reasoningOpaque: string | null | undefined,
+  model: string,
 ): Array<AnthropicThinkingBlock> {
   if (reasoningText && reasoningText.length > 0) {
     return [
@@ -431,7 +437,7 @@ function getAnthropicThinkBlocks(
       },
     ]
   }
-  if (reasoningOpaque && reasoningOpaque.length > 0) {
+  if (reasoningOpaque && reasoningOpaque.length > 0 && !isClaudeModel(model)) {
     return [
       {
         type: "thinking",

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -26,6 +26,7 @@ export function translateChunkToAnthropicEvents(
   state: AnthropicStreamState,
 ): Array<AnthropicStreamEventData> {
   const events: Array<AnthropicStreamEventData> = []
+  state.currentModel = chunk.model
 
   if (chunk.choices.length === 0) {
     return events
@@ -37,6 +38,16 @@ export function translateChunkToAnthropicEvents(
   handleMessageStart(state, events, chunk)
 
   handleThinkingText(delta, state, events)
+
+  if (shouldBufferChunkUntilReasoningSignature(choice, state)) {
+    state.pendingChunksAfterThinking.push(cloneChunkWithoutReasoningText(chunk))
+    return events
+  }
+
+  if (shouldCloseThinkingBlock(choice, state)) {
+    closeThinkingBlock(state, events, delta.reasoning_opaque ?? "")
+    drainPendingChunksAfterThinking(state, events)
+  }
 
   handleContent(delta, state, events)
 
@@ -93,6 +104,96 @@ function handleFinish(
         type: "message_stop",
       },
     )
+  }
+}
+
+function isClaudeModel(model: string): boolean {
+  return model.toLowerCase().startsWith("claude")
+}
+
+function cloneChunkWithoutReasoningText(
+  chunk: ChatCompletionChunk,
+): ChatCompletionChunk {
+  return {
+    ...chunk,
+    choices: chunk.choices.map((choice) => ({
+      ...choice,
+      delta: {
+        ...choice.delta,
+        reasoning_text: undefined,
+      },
+    })),
+  }
+}
+
+function shouldBufferChunkUntilReasoningSignature(
+  choice: Choice,
+  state: AnthropicStreamState,
+): boolean {
+  const hasPostThinkingOutput =
+    Boolean(choice.delta.content && choice.delta.content.length > 0)
+    || Boolean(choice.delta.tool_calls && choice.delta.tool_calls.length > 0)
+
+  return (
+    state.thinkingBlockOpen
+    && hasPostThinkingOutput
+    && !choice.delta.reasoning_opaque
+    && !choice.finish_reason
+  )
+}
+
+function shouldCloseThinkingBlock(
+  choice: Choice,
+  state: AnthropicStreamState,
+): boolean {
+  return (
+    state.thinkingBlockOpen
+    && Boolean(choice.delta.reasoning_opaque || choice.finish_reason)
+  )
+}
+
+function closeThinkingBlock(
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+  signature: string,
+): void {
+  if (!state.thinkingBlockOpen) {
+    return
+  }
+
+  events.push(
+    {
+      type: "content_block_delta",
+      index: state.contentBlockIndex,
+      delta: {
+        type: "signature_delta",
+        signature,
+      },
+    },
+    {
+      type: "content_block_stop",
+      index: state.contentBlockIndex,
+    },
+  )
+  state.contentBlockIndex++
+  state.thinkingBlockOpen = false
+}
+
+function drainPendingChunksAfterThinking(
+  state: AnthropicStreamState,
+  events: Array<AnthropicStreamEventData>,
+): void {
+  if (state.pendingChunksAfterThinking.length === 0) {
+    return
+  }
+
+  const bufferedChunks = state.pendingChunksAfterThinking.splice(0)
+  for (const bufferedChunk of bufferedChunks) {
+    const bufferedChoice = bufferedChunk.choices[0]
+
+    handleContent(bufferedChoice.delta, state, events)
+    handleToolCalls(bufferedChoice.delta, state, events)
+    handleFinish(bufferedChoice, state, { events, chunk: bufferedChunk })
   }
 }
 
@@ -279,6 +380,10 @@ function handleReasoningOpaque(
   state: AnthropicStreamState,
 ) {
   if (delta.reasoning_opaque && delta.reasoning_opaque.length > 0) {
+    if (state.currentModel && isClaudeModel(state.currentModel)) {
+      return
+    }
+
     events.push(
       {
         type: "content_block_start",
@@ -356,22 +461,7 @@ function closeThinkingBlockIfOpen(
   events: Array<AnthropicStreamEventData>,
 ): void {
   if (state.thinkingBlockOpen) {
-    events.push(
-      {
-        type: "content_block_delta",
-        index: state.contentBlockIndex,
-        delta: {
-          type: "signature_delta",
-          signature: "",
-        },
-      },
-      {
-        type: "content_block_stop",
-        index: state.contentBlockIndex,
-      },
-    )
-    state.contentBlockIndex++
-    state.thinkingBlockOpen = false
+    closeThinkingBlock(state, events, "")
   }
 }
 

--- a/tests/anthropic-response.test.ts
+++ b/tests/anthropic-response.test.ts
@@ -67,6 +67,18 @@ function isValidAnthropicStreamEvent(payload: unknown): boolean {
   return anthropicStreamEventSchema.safeParse(payload).success
 }
 
+function createStreamState(): AnthropicStreamState {
+  return {
+    currentModel: undefined,
+    messageStartSent: false,
+    contentBlockIndex: 0,
+    contentBlockOpen: false,
+    toolCalls: {},
+    thinkingBlockOpen: false,
+    pendingChunksAfterThinking: [],
+  }
+}
+
 describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
   test("should translate a simple text response correctly", () => {
     const openAIResponse: ChatCompletionResponse = {
@@ -189,6 +201,36 @@ describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
     expect(isValidAnthropicResponse(anthropicResponse)).toBe(true)
     expect(anthropicResponse.stop_reason).toBe("max_tokens")
   })
+
+  test("should skip signature-only thinking blocks for claude responses", () => {
+    const openAIResponse: ChatCompletionResponse = {
+      id: "chatcmpl-opaque-only",
+      object: "chat.completion",
+      created: 1677652288,
+      model: "claude-sonnet-4",
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: "assistant",
+            content: "Done",
+            reasoning_opaque: "opaque-signature",
+          },
+          finish_reason: "stop",
+          logprobs: null,
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+    }
+
+    const anthropicResponse = translateToAnthropic(openAIResponse)
+
+    expect(anthropicResponse.content).toEqual([{ type: "text", text: "Done" }])
+  })
 })
 
 describe("OpenAI to Anthropic Streaming Response Translation", () => {
@@ -247,13 +289,7 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
       },
     ]
 
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
-    }
+    const streamState = createStreamState()
     const translatedStream = openAIStream.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),
     )
@@ -348,13 +384,7 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
     ]
 
     // Streaming translation requires state
-    const streamState: AnthropicStreamState = {
-      messageStartSent: false,
-      contentBlockIndex: 0,
-      contentBlockOpen: false,
-      toolCalls: {},
-      thinkingBlockOpen: false,
-    }
+    const streamState = createStreamState()
     const translatedStream = openAIStream.flatMap((chunk) =>
       translateChunkToAnthropicEvents(chunk, streamState),
     )
@@ -363,5 +393,193 @@ describe("OpenAI to Anthropic Streaming Response Translation", () => {
     for (const event of translatedStream) {
       expect(isValidAnthropicStreamEvent(event)).toBe(true)
     }
+  })
+})
+
+describe("Claude streaming thinking translation", () => {
+  test("should buffer claude text until reasoning signature arrives", () => {
+    const openAIStream: Array<ChatCompletionChunk> = [
+      {
+        id: "cmpl-claude-think",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      },
+      {
+        id: "cmpl-claude-think",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: { reasoning_text: "Let me think through this." },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      },
+      {
+        id: "cmpl-claude-think",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "First answer." },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      },
+      {
+        id: "cmpl-claude-think",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              reasoning_opaque: "claude-signature",
+              content: " Second answer.",
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      },
+      {
+        id: "cmpl-claude-think",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: "stop",
+            logprobs: null,
+          },
+        ],
+      },
+    ]
+
+    const streamState = createStreamState()
+
+    const translatedStream = openAIStream.flatMap((chunk) =>
+      translateChunkToAnthropicEvents(chunk, streamState),
+    )
+
+    const thinkingStartIndex = translatedStream.findIndex(
+      (event) =>
+        event.type === "content_block_start"
+        && event.content_block.type === "thinking",
+    )
+    const signatureIndex = translatedStream.findIndex(
+      (event) =>
+        event.type === "content_block_delta"
+        && event.delta.type === "signature_delta"
+        && event.delta.signature === "claude-signature",
+    )
+    const textStartIndex = translatedStream.findIndex(
+      (event) =>
+        event.type === "content_block_start"
+        && event.content_block.type === "text",
+    )
+
+    expect(thinkingStartIndex).toBeGreaterThan(-1)
+    expect(signatureIndex).toBeGreaterThan(thinkingStartIndex)
+    expect(textStartIndex).toBeGreaterThan(signatureIndex)
+
+    const textDeltas = translatedStream.filter(
+      (event) =>
+        event.type === "content_block_delta"
+        && event.delta.type === "text_delta",
+    )
+    expect(textDeltas).toEqual([
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: {
+          type: "text_delta",
+          text: "First answer.",
+        },
+      },
+      {
+        type: "content_block_delta",
+        index: 1,
+        delta: {
+          type: "text_delta",
+          text: " Second answer.",
+        },
+      },
+    ])
+  })
+
+  test("should not emit placeholder thinking blocks for claude opaque-only tool calls", () => {
+    const openAIStream: Array<ChatCompletionChunk> = [
+      {
+        id: "cmpl-claude-tool",
+        object: "chat.completion.chunk",
+        created: 1677652288,
+        model: "claude-sonnet-4",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: "assistant",
+              reasoning_opaque: "opaque-only",
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_opaque",
+                  type: "function",
+                  function: {
+                    name: "get_weather",
+                    arguments: "{}",
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+            logprobs: null,
+          },
+        ],
+      },
+    ]
+
+    const streamState = createStreamState()
+
+    const translatedStream = openAIStream.flatMap((chunk) =>
+      translateChunkToAnthropicEvents(chunk, streamState),
+    )
+
+    const thinkingEvents = translatedStream.filter(
+      (event) =>
+        event.type === "content_block_start"
+        && event.content_block.type === "thinking",
+    )
+
+    expect(thinkingEvents).toHaveLength(0)
+    expect(translatedStream).toContainEqual({
+      type: "content_block_start",
+      index: 0,
+      content_block: {
+        type: "tool_use",
+        id: "call_opaque",
+        name: "get_weather",
+        input: {},
+      },
+    })
   })
 })


### PR DESCRIPTION
## Summary
- fix Claude-model thinking translation so Claude Code no longer receives malformed placeholder or signature-only thinking blocks from Copilot reasoning streams
- buffer Claude streaming output until the reasoning signature arrives, and align the non-streaming path with the same behavior
- add safe thinking telemetry plus regression coverage for Claude reasoning compatibility

## Verification
- bun run lint
- bun test