### PR TITLE
feat: implement routing for models supporting Responses API and add response translation utilities

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -8,11 +8,26 @@ import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
 import { getTokenCount } from "~/lib/tokenizer"
 import { generateRequestIdFromPayload, getUUID, isNullish } from "~/lib/utils"
+import { getResponsesRequestOptions } from "~/routes/responses/utils"
 import {
   createChatCompletions,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
+import {
+  createResponses,
+  type ResponseStreamEvent,
+  type ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+import {
+  CHAT_COMPLETIONS_ENDPOINT,
+  RESPONSES_ENDPOINT_PATH,
+  createResponsesCompletionStreamState,
+  translateChatCompletionsToResponsesPayload,
+  translateResponsesEventToChunks,
+  translateResponsesResultToChatCompletion,
+} from "./responses-fallback"
 
 const logger = createHandlerLogger("chat-completions-handler")
 
@@ -56,6 +71,22 @@ export async function handleCompletion(c: Context) {
   const sessionId = getUUID(requestId)
   logger.debug("Extracted session ID:", sessionId)
 
+  // If the model doesn't support /chat/completions but supports /responses,
+  // translate and route through the Responses API
+  const endpoints = selectedModel?.supported_endpoints
+  const supportsChatCompletions =
+    !endpoints || endpoints.includes(CHAT_COMPLETIONS_ENDPOINT)
+  const supportsResponses =
+    endpoints?.includes(RESPONSES_ENDPOINT_PATH) ?? false
+
+  if (!supportsChatCompletions && supportsResponses) {
+    logger.debug(
+      "Model only supports Responses API, routing via /responses:",
+      payload.model,
+    )
+    return handleViaResponsesApi(c, payload, { requestId, sessionId })
+  }
+
   const response = await createChatCompletions(payload, {
     requestId,
     sessionId,
@@ -75,6 +106,50 @@ export async function handleCompletion(c: Context) {
   })
 }
 
+const handleViaResponsesApi = async (
+  c: Context,
+  payload: ChatCompletionsPayload,
+  options: { requestId: string; sessionId: string },
+) => {
+  const { requestId, sessionId } = options
+  const responsesPayload = translateChatCompletionsToResponsesPayload(payload)
+  const { vision, initiator } = getResponsesRequestOptions(responsesPayload)
+
+  const response = await createResponses(responsesPayload, {
+    vision,
+    initiator,
+    requestId,
+    sessionId,
+  })
+
+  if (isResponsesNonStreaming(response)) {
+    logger.debug("Non-streaming Responses result")
+    return c.json(translateResponsesResultToChatCompletion(response))
+  }
+
+  logger.debug("Streaming Responses response")
+  const streamState = createResponsesCompletionStreamState(payload.model)
+  return streamSSE(c, async (stream) => {
+    for await (const chunk of response) {
+      if (chunk.event === "ping") continue
+      if (!chunk.data) continue
+
+      const event = JSON.parse(chunk.data) as ResponseStreamEvent
+      const sseMessages = translateResponsesEventToChunks(event, streamState)
+      for (const msg of sseMessages) {
+        logger.debug("Responses→completion chunk:", msg.data)
+        await stream.writeSSE(msg)
+      }
+
+      if (streamState.finishReason !== null) break
+    }
+  })
+}
+
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,
 ): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
+
+const isResponsesNonStreaming = (
+  response: Awaited<ReturnType<typeof createResponses>>,
+): response is ResponsesResult => Object.hasOwn(response, "output")

--- a/src/routes/chat-completions/responses-fallback.ts
+++ b/src/routes/chat-completions/responses-fallback.ts
@@ -1,0 +1,367 @@
+import type { SSEMessage } from "hono/streaming"
+
+import type {
+  ChatCompletionChunk,
+  ChatCompletionResponse,
+  ChatCompletionsPayload,
+  ToolCall,
+} from "~/services/copilot/create-chat-completions"
+import type {
+  ResponseFunctionCallOutputItem,
+  ResponseFunctionToolCallItem,
+  ResponseInputContent,
+  ResponseInputItem,
+  ResponseInputMessage,
+  ResponsesPayload,
+  ResponsesResult,
+  ResponseStreamEvent,
+  ToolChoiceFunction,
+  ToolChoiceOptions,
+} from "~/services/copilot/create-responses"
+
+import {
+  getExtraPromptForModel,
+  getReasoningEffortForModel,
+} from "~/lib/config"
+
+export const CHAT_COMPLETIONS_ENDPOINT = "/chat/completions"
+export const RESPONSES_ENDPOINT_PATH = "/responses"
+
+export const translateChatCompletionsToResponsesPayload = (
+  payload: ChatCompletionsPayload,
+): ResponsesPayload => {
+  const systemMessages = payload.messages.filter(
+    (m) => m.role === "system" || m.role === "developer",
+  )
+  const conversationMessages = payload.messages.filter(
+    (m) => m.role !== "system" && m.role !== "developer",
+  )
+
+  const systemText = systemMessages
+    .map((m) => {
+      if (typeof m.content === "string") return m.content
+      if (Array.isArray(m.content)) {
+        return m.content
+          .filter((c) => c.type === "text")
+          .map((c) => (c as { type: "text"; text: string }).text)
+          .join("")
+      }
+      return ""
+    })
+    .join("\n")
+
+  const extraPrompt = getExtraPromptForModel(payload.model)
+  const rawInstructions = systemText ? systemText + extraPrompt : extraPrompt
+  const instructions = rawInstructions.trim() || null
+
+  const input: Array<ResponseInputItem> = []
+  for (const msg of conversationMessages) {
+    input.push(...translateChatMessage(msg))
+  }
+
+  const tools =
+    payload.tools?.length ?
+      payload.tools.map((t) => ({
+        type: "function" as const,
+        name: t.function.name,
+        description: t.function.description ?? null,
+        parameters: t.function.parameters,
+        strict: false as null,
+      }))
+    : null
+
+  let toolChoice: ToolChoiceOptions | ToolChoiceFunction = "auto"
+  if (payload.tool_choice) {
+    toolChoice =
+      typeof payload.tool_choice === "string" ?
+        (payload.tool_choice as ToolChoiceOptions)
+      : { type: "function", name: payload.tool_choice.function.name }
+  }
+
+  return {
+    model: payload.model,
+    input,
+    instructions,
+    temperature: 1,
+    top_p: payload.top_p ?? null,
+    max_output_tokens: payload.max_tokens ?? null,
+    tools,
+    tool_choice: toolChoice,
+    stream: payload.stream ?? null,
+    store: false,
+    parallel_tool_calls: true,
+    reasoning: {
+      effort: getReasoningEffortForModel(payload.model),
+      summary: "detailed",
+    },
+    include: ["reasoning.encrypted_content"],
+  }
+}
+
+type ChatMessage = ChatCompletionsPayload["messages"][number]
+
+const translateChatMessage = (msg: ChatMessage): Array<ResponseInputItem> => {
+  if (msg.role === "tool") {
+    const item: ResponseFunctionCallOutputItem = {
+      type: "function_call_output",
+      call_id: msg.tool_call_id ?? "",
+      output:
+        typeof msg.content === "string" ?
+          msg.content
+        : JSON.stringify(msg.content),
+      status: "completed",
+    }
+    return [item]
+  }
+
+  if (msg.role === "assistant" && msg.tool_calls?.length) {
+    const items: Array<ResponseInputItem> = []
+    if (msg.content) {
+      const text =
+        typeof msg.content === "string" ?
+          msg.content
+        : msg.content
+            .filter((c) => c.type === "text")
+            .map((c) => (c as { text: string }).text)
+            .join("")
+      if (text) {
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text, annotations: [] }],
+        } as ResponseInputMessage)
+      }
+    }
+
+    for (const tc of msg.tool_calls) {
+      const item: ResponseFunctionToolCallItem = {
+        type: "function_call",
+        call_id: tc.id,
+        name: tc.function.name,
+        arguments: tc.function.arguments,
+        status: "completed",
+      }
+      items.push(item)
+    }
+    return items
+  }
+
+  const role = msg.role as "user" | "assistant"
+  const content = buildMessageContent(msg, role)
+  const responseMsg: ResponseInputMessage = {
+    type: "message",
+    role,
+    content,
+  }
+  return [responseMsg]
+}
+
+const buildMessageContent = (
+  msg: ChatMessage,
+  role: "user" | "assistant",
+): string | Array<ResponseInputContent> => {
+  if (typeof msg.content === "string") return msg.content
+  if (!Array.isArray(msg.content)) return ""
+
+  const parts: Array<ResponseInputContent> = []
+  for (const part of msg.content) {
+    if (part.type === "text") {
+      parts.push({
+        type: role === "assistant" ? "output_text" : "input_text",
+        text: part.text,
+      } as ResponseInputContent)
+    } else {
+      parts.push({
+        type: "input_image",
+        image_url: part.image_url.url,
+        detail: part.image_url.detail,
+      })
+    }
+  }
+  return parts.length > 0 ? parts : ""
+}
+
+export const translateResponsesResultToChatCompletion = (
+  result: ResponsesResult,
+): ChatCompletionResponse => {
+  let content: string | null = null
+  const toolCalls: Array<ToolCall> = []
+
+  for (const item of result.output) {
+    if (item.type === "message" && item.content) {
+      for (const block of item.content) {
+        if (
+          typeof (block as { text?: unknown }).text === "string"
+          && (block as { type?: unknown }).type === "output_text"
+        ) {
+          content = (content ?? "") + (block as { text: string }).text
+        }
+      }
+    } else if (item.type === "function_call") {
+      toolCalls.push({
+        id: item.call_id,
+        type: "function",
+        function: { name: item.name, arguments: item.arguments },
+      })
+    }
+  }
+
+  if (!content && result.output_text) content = result.output_text
+
+  let finishReason: "stop" | "tool_calls" | "length" = "stop"
+  if (toolCalls.length > 0) {
+    finishReason = "tool_calls"
+  } else if (result.status === "incomplete") {
+    finishReason = "length"
+  }
+
+  return {
+    id: result.id,
+    object: "chat.completion",
+    created: result.created_at,
+    model: result.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content,
+          ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+        logprobs: null,
+        finish_reason: finishReason,
+      },
+    ],
+    ...(result.usage ?
+      {
+        usage: {
+          prompt_tokens: result.usage.input_tokens,
+          completion_tokens: result.usage.output_tokens ?? 0,
+          total_tokens: result.usage.total_tokens,
+        },
+      }
+    : {}),
+  }
+}
+
+export interface ResponsesCompletionStreamState {
+  messageId: string
+  model: string
+  created: number
+  toolCallCounter: number
+  outputIndexToToolCallIndex: Map<number, number>
+  finishReason: "stop" | "tool_calls" | "length" | null
+}
+
+export const createResponsesCompletionStreamState = (
+  model: string,
+): ResponsesCompletionStreamState => ({
+  messageId: `chatcmpl-${Math.random().toString(36).slice(2)}`,
+  model,
+  created: Math.floor(Date.now() / 1000),
+  toolCallCounter: 0,
+  outputIndexToToolCallIndex: new Map(),
+  finishReason: null,
+})
+
+const makeChunk = (
+  state: ResponsesCompletionStreamState,
+  delta: ChatCompletionChunk["choices"][0]["delta"],
+  finishReason: ChatCompletionChunk["choices"][0]["finish_reason"] = null,
+): ChatCompletionChunk => ({
+  id: state.messageId,
+  object: "chat.completion.chunk",
+  created: state.created,
+  model: state.model,
+  choices: [{ index: 0, delta, finish_reason: finishReason, logprobs: null }],
+})
+
+export const translateResponsesEventToChunks = (
+  event: ResponseStreamEvent,
+  state: ResponsesCompletionStreamState,
+): Array<SSEMessage> => {
+  const sseMessages: Array<SSEMessage> = []
+
+  const emit = (chunk: ChatCompletionChunk) => {
+    sseMessages.push({ data: JSON.stringify(chunk) })
+  }
+
+  switch (event.type) {
+    case "response.created": {
+      emit(makeChunk(state, { role: "assistant" }))
+      break
+    }
+
+    case "response.output_item.added": {
+      const item = event.item
+      if (item.type === "function_call") {
+        const toolCallIndex = state.toolCallCounter++
+        state.outputIndexToToolCallIndex.set(event.output_index, toolCallIndex)
+        emit(
+          makeChunk(state, {
+            tool_calls: [
+              {
+                index: toolCallIndex,
+                id: item.call_id,
+                type: "function",
+                function: { name: item.name, arguments: "" },
+              },
+            ],
+          }),
+        )
+      }
+      break
+    }
+
+    case "response.output_text.delta": {
+      emit(makeChunk(state, { content: event.delta }))
+      break
+    }
+
+    case "response.function_call_arguments.delta": {
+      const toolCallIndex = state.outputIndexToToolCallIndex.get(
+        event.output_index,
+      )
+      if (toolCallIndex !== undefined) {
+        emit(
+          makeChunk(state, {
+            tool_calls: [
+              { index: toolCallIndex, function: { arguments: event.delta } },
+            ],
+          }),
+        )
+      }
+      break
+    }
+
+    case "response.completed": {
+      const hasToolCalls = event.response.output.some(
+        (item) => item.type === "function_call",
+      )
+      state.finishReason = hasToolCalls ? "tool_calls" : "stop"
+      emit(makeChunk(state, {}, state.finishReason))
+      sseMessages.push({ data: "[DONE]" })
+      break
+    }
+
+    case "response.incomplete": {
+      state.finishReason = "length"
+      emit(makeChunk(state, {}, "length"))
+      sseMessages.push({ data: "[DONE]" })
+      break
+    }
+
+    case "response.failed": {
+      state.finishReason = "stop"
+      emit(makeChunk(state, {}, "stop"))
+      sseMessages.push({ data: "[DONE]" })
+      break
+    }
+
+    default: {
+      break
+    }
+  }
+
+  return sseMessages
+}


### PR DESCRIPTION
This pull request introduces a fallback mechanism for the `/chat/completions` endpoint, allowing it to route requests through the `/responses` API when the selected model does not support `/chat/completions` directly but does support `/responses`. The changes include translation utilities between the two APIs, streaming support, and logic to determine which endpoint to use. This enables broader model compatibility and seamless integration for clients using the chat completions interface.

### Endpoint Routing and Fallback Logic

* Added logic in `handleCompletion` to detect if the selected model supports `/chat/completions` or only `/responses`, and route requests accordingly. If only `/responses` is supported, requests are translated and sent to the `/responses` API.

### Translation Utilities Between APIs

* Implemented `responses-fallback.ts` with functions to translate chat completions payloads to responses payloads, and responses results/events back to chat completions format, including support for tool calls and streaming.

### Streaming Support

* Added streaming handling for responses API, including conversion of response stream events to SSE messages compatible with chat completions streaming protocol. [[1]](diffhunk://#diff-69b88a1121f93c66647c09fb2f734f3386319d103e8d685c924d0b783d23b7a8R109-R155) [[2]](diffhunk://#diff-bf0209f32cd77a73f5773f96b5b6413ea67e31e8f4066e3e5deab7c1cb74822aR1-R367)

### Type and Helper Additions

* Introduced new types and helper functions for managing stream state and translating between message formats, ensuring compatibility and correct mapping of tool calls, message content, and finish reasons.

### Integration and Imports

* Updated imports and integrated translation and fallback utilities into the chat completions handler for seamless operation.