### PR TITLE
fix: normalize tool schema missing properties for OpenAI API

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -268,9 +268,22 @@ function translateAnthropicToolsToOpenAI(
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: tool.input_schema,
+      parameters: normalizeToolSchema(tool.input_schema),
     },
   }))
+}
+
+/**
+ * Ensures `type: "object"` schema has a `properties` field.
+ * OpenAI's API rejects object schemas without it.
+ */
+export const normalizeToolSchema = (
+  schema: Record<string, unknown>,
+): Record<string, unknown> => {
+  if (schema.type === "object" && !schema.properties) {
+    return { ...schema, properties: {} }
+  }
+  return schema
 }
 
 function translateAnthropicToolChoiceToOpenAI(

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -44,6 +44,7 @@ import {
   type AnthropicUserContentBlock,
   type AnthropicUserMessage,
 } from "./anthropic-types"
+import { normalizeToolSchema } from "./non-stream-translation"
 
 const MESSAGE_TYPE = "message"
 const COMPACTION_SIGNATURE_PREFIX = "cm1#"
@@ -446,7 +447,7 @@ const convertAnthropicTools = (
   return tools.map((tool) => ({
     type: "function",
     name: tool.name,
-    parameters: tool.input_schema,
+    parameters: normalizeToolSchema(tool.input_schema),
     strict: false,
     ...(tool.description ? { description: tool.description } : {}),
   }))


### PR DESCRIPTION
## Summary
- OpenAI API requires all `type: "object"` schemas to have a `properties` field
- Some MCP tools (e.g. Pencil MCP's `get_style_guide_tags`) have schema `{"type": "object"}` without `properties`
- Add `normalizeToolSchema` to ensure object schemas include `properties: {}`
- Applied in both Chat Completions and Responses API translation paths

## Test plan
- [x] All 30 existing tests pass
- [x] Manual: Enable Pencil MCP with GPT 5.4 model, verify no 400 error