### PR TITLE
feat: use Anthropic API for accurate Claude token counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Compared with routing everything through plain Chat Completions compatibility, t
 - **GitHub Enterprise Support**: Connect to GHE.com by setting `COPILOT_API_ENTERPRISE_URL` environment variable (e.g., `company.ghe.com`) or using `--enterprise-url=company.ghe.com` command line option.
 - **Custom Data Directory**: Change the default data directory (where tokens and config are stored) by setting `COPILOT_API_HOME` environment variable or using `--api-home=/path/to/dir` command line option.
 - **Multi-Provider Anthropic Proxy Routes**: Add global provider configs and call external Anthropic-compatible APIs via `/:provider/v1/messages` and `/:provider/v1/models`.
+- **Accurate Claude Token Counting**: Optionally forward `/v1/messages/count_tokens` requests for Claude models to Anthropic's free token counting endpoint for exact counts instead of GPT tokenizer estimation.
 
 ## Better Agent Semantics
 
@@ -105,6 +106,23 @@ For subagent-based clients, this project can preserve root session context and c
 The marker flow uses `__SUBAGENT_MARKER__...` inside a `<system-reminder>` block together with root `x-session-id` propagation. When a marker is detected, the proxy can keep the parent session identity, infer `x-initiator: agent`, and tag the interaction as subagent traffic instead of a fresh top-level request.
 
 Optional marker producers are included for both Claude Code and opencode; see [Subagent Marker Integration](#subagent-marker-integration-optional) below for setup details.
+
+### Accurate Claude token counting
+
+By default, `/v1/messages/count_tokens` estimates Claude token counts using the GPT `o200k_base` tokenizer with a 1.15x multiplier. This consistently underestimates actual Claude token usage, which can cause tools like Claude Code to compact too late and hit "prompt token count exceeds limit" errors.
+
+When an Anthropic API key is configured, the proxy forwards Claude model token counting requests to [Anthropic's real `/v1/messages/count_tokens` endpoint](https://docs.anthropic.com/en/docs/build-with-claude/token-counting) instead. This returns exact counts and eliminates the estimation mismatch. Non-Claude models and failures fall back to the GPT tokenizer estimation automatically.
+
+**Setup:**
+
+1. Create an Anthropic API account at [console.anthropic.com](https://console.anthropic.com) and add a minimum $5 credit balance (required to activate the API key, but the token counting endpoint itself is free)
+2. Create an API key from Settings > API Keys
+3. Configure the key via **one** of:
+   - `config.json`: set `"anthropicApiKey": "sk-ant-..."`
+   - Environment variable: `ANTHROPIC_API_KEY=sk-ant-...`
+
+> [!NOTE]
+> Anthropic's `/v1/messages/count_tokens` endpoint is **free** (no per-token cost). It is rate-limited to 100 RPM at Tier 1. The $5 credit purchase is only needed to activate API access — the token counting calls themselves cost nothing.
 
 ## Demo
 
@@ -290,7 +308,8 @@ The following command line options are available for the `start` command:
       "gpt-5.4": "xhigh"
     },
     "useFunctionApplyPatch": true,
-    "useMessagesApi": true
+    "useMessagesApi": true,
+    "anthropicApiKey": ""
   }
   ```
 - **auth.apiKeys:** API keys used for request authentication. Supports multiple keys for rotation. Requests can authenticate with either `x-api-key: <key>` or `Authorization: Bearer <key>`. If empty or omitted, authentication is disabled.
@@ -309,6 +328,7 @@ The following command line options are available for the `start` command:
 - **modelReasoningEfforts:** Per-model `reasoning.effort` sent to the Copilot Responses API. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. If a model isn’t listed, `high` is used by default.
 - **useFunctionApplyPatch:** When `true`, the server will convert any custom tool named `apply_patch` in Responses payloads into an OpenAI-style function tool (`type: "function"`) with a parameter schema so assistants can call it using function-calling semantics to edit files. Set to `false` to leave tools unchanged. Defaults to `true`.
 - **useMessagesApi:** When `true`, Claude-family models that support Copilot's native `/v1/messages` endpoint will use the Messages API; otherwise they fall back to `/chat/completions`. Set to `false` to disable Messages API routing and always use `/chat/completions`. Defaults to `true`.
+- **anthropicApiKey:** Anthropic API key used for accurate Claude token counting (see [Accurate Claude Token Counting](#accurate-claude-token-counting) below). Can also be set via the `ANTHROPIC_API_KEY` environment variable. If not set, token counting falls back to GPT tokenizer estimation.
 
 Edit this file to customize prompts or swap in your own fast model. Restart the server (or rerun the command) after changes so the cached config is refreshed.
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,6 +17,7 @@ export interface AppConfig {
   >
   useFunctionApplyPatch?: boolean
   useMessagesApi?: boolean
+  anthropicApiKey?: string
 }
 
 export interface ModelConfig {
@@ -286,4 +287,9 @@ export function listEnabledProviders(): Array<string> {
 export function isMessagesApiEnabled(): boolean {
   const config = getConfig()
   return config.useMessagesApi ?? true
+}
+
+export function getAnthropicApiKey(): string | undefined {
+  const config = getConfig()
+  return config.anthropicApiKey ?? process.env.ANTHROPIC_API_KEY ?? undefined
 }

--- a/src/routes/messages/count-tokens-handler.ts
+++ b/src/routes/messages/count-tokens-handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono"
 
 import consola from "consola"
 
+import { getAnthropicApiKey } from "~/lib/config"
 import { getTokenCount } from "~/lib/tokenizer"
 
 import { findEndpointModel } from "../../lib/models"
@@ -9,10 +10,62 @@ import { type AnthropicMessagesPayload } from "./anthropic-types"
 import { translateToOpenAI } from "./non-stream-translation"
 
 /**
- * Handles token counting for Anthropic messages
+ * Forwards token counting to Anthropic's real /v1/messages/count_tokens endpoint.
+ * Returns the result on success, or null to fall through to estimation.
+ */
+async function countTokensViaAnthropic(c: Context): Promise<Response | null> {
+  const apiKey = getAnthropicApiKey()
+  if (!apiKey) return null
+
+  const payload = await c.req.json<AnthropicMessagesPayload>()
+  // Copilot uses dotted names (claude-opus-4.6) but Anthropic requires dashes (claude-opus-4-6)
+  const model = payload.model.replaceAll(".", "-")
+
+  if (!model.startsWith("claude")) return null
+
+  const res = await fetch(
+    "https://api.anthropic.com/v1/messages/count_tokens",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "token-counting-2024-11-01",
+      },
+      body: JSON.stringify({ ...payload, model }),
+    },
+  )
+
+  if (!res.ok) {
+    consola.warn(
+      "Anthropic count_tokens failed:",
+      res.status,
+      await res.text().catch(() => ""),
+      "- falling back to estimation",
+    )
+    return null
+  }
+
+  const result = (await res.json()) as { input_tokens: number }
+  consola.info("Token count (Anthropic API):", result.input_tokens)
+  return c.json(result)
+}
+
+/**
+ * Handles token counting for Anthropic messages.
+ *
+ * When an Anthropic API key is available (via config or ANTHROPIC_API_KEY env var)
+ * and the model is a Claude model, forwards to Anthropic's free /v1/messages/count_tokens
+ * endpoint for accurate counts. Otherwise falls back to GPT tokenizer estimation.
  */
 export async function handleCountTokens(c: Context) {
   try {
+    // Try Anthropic's real endpoint first (Claude models only)
+    const anthropicResult = await countTokensViaAnthropic(c)
+    if (anthropicResult) return anthropicResult
+
+    // Fallback: GPT tokenizer estimation (also used for non-Claude models)
     const anthropicBeta = c.req.header("anthropic-beta")
 
     const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()


### PR DESCRIPTION
## Summary

The current `/v1/messages/count_tokens` endpoint estimates Claude token counts using the GPT `o200k_base` tokenizer with a 1.15× multiplier. This consistently underestimates actual Claude token usage, causing tools like Claude Code to compact too late and hit "prompt token count exceeds limit" errors.

This PR adds an optional integration with [Anthropic's free `/v1/messages/count_tokens` endpoint](https://docs.anthropic.com/en/docs/build-with-claude/token-counting) for exact token counts on Claude models.

## How it works

- When an Anthropic API key is configured (via `anthropicApiKey` in config.json or `ANTHROPIC_API_KEY` env var), Claude model token counting requests are forwarded to the real Anthropic endpoint
- Non-Claude models (gpt, grok, etc.) skip the Anthropic call entirely and use the existing GPT tokenizer estimation
- If the Anthropic API call fails, it falls back to the existing estimation automatically
- Copilot's dotted model names (`claude-opus-4.6`) are converted to dashed names (`claude-opus-4-6`) that Anthropic accepts

## Setup for users

1. Create an Anthropic API account and add $5 credits (required to activate the key)
2. Create an API key
3. Set `"anthropicApiKey": "sk-ant-..."` in config.json or export `ANTHROPIC_API_KEY`

> **Note**: Anthropic's token counting endpoint is **free** — no per-token cost. It's rate-limited to 100 RPM at Tier 1. The $5 credit purchase only activates API access.

## Changes

- **`src/routes/messages/count-tokens-handler.ts`**: Added `countTokensViaAnthropic()` helper that forwards to Anthropic's endpoint for Claude models. The existing estimation logic is preserved as fallback.
- **`src/lib/config.ts`**: Added `anthropicApiKey` to `AppConfig` interface and `getAnthropicApiKey()` getter (checks config first, then `ANTHROPIC_API_KEY` env var).
- **`README.md`**: Added feature bullet, config option docs, and "Accurate Claude token counting" section with setup instructions.