### PR TITLE
feat: implement real-time model availability probing for CLI selection

### DIFF
--- a/src/services/copilot/check-model.ts
+++ b/src/services/copilot/check-model.ts
@@ -1,0 +1,29 @@
+import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
+import { state } from "~/lib/state"
+
+/**
+ * Probes the availability of a model by sending a minimal chat completion request.
+ * Returns true if the model is available (200 OK), false otherwise.
+ */
+export async function checkModelAvailability(modelId: string): Promise<boolean> {
+  if (!state.copilotToken) return false
+
+  try {
+    const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
+      method: "POST",
+      headers: {
+        ...copilotHeaders(state),
+        "x-initiator": "user",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      }),
+    })
+
+    return response.ok
+  } catch {
+    return false
+  }
+}

--- a/src/start.ts
+++ b/src/start.ts
@@ -18,6 +18,7 @@ import {
   cacheVSCodeVersion,
   cacheVsCodeSessionId,
 } from "./lib/utils"
+import { checkModelAvailability } from "./services/copilot/check-model"
 
 interface RunServerOptions {
   port: number
@@ -85,11 +86,34 @@ export async function runServer(options: RunServerOptions): Promise<void> {
 
     invariant(state.models, "Models should be loaded by now")
 
+    consola.start("Probing model availability...")
+    const concurrency = 10
+    const results: Record<string, boolean> = {}
+    const modelIds = state.models.data.map((m) => m.id)
+
+    for (let i = 0; i < modelIds.length; i += concurrency) {
+      const chunk = modelIds.slice(i, i + concurrency)
+      await Promise.all(
+        chunk.map(async (id) => {
+          results[id] = await checkModelAvailability(id)
+        }),
+      )
+    }
+    consola.success("Model probing complete.")
+
+    const modelOptions = state.models.data
+      .map((model) => ({
+        label: `${model.id} ${results[model.id] ? "✅" : "❌"}`,
+        value: model.id,
+        available: results[model.id],
+      }))
+      .sort((a, b) => (a.available === b.available ? 0 : a.available ? -1 : 1))
+
     const selectedModel = await consola.prompt(
       "Select a model to use with Claude Code",
       {
         type: "select",
-        options: state.models.data.map((model) => model.id),
+        options: modelOptions,
       },
     )
 
@@ -97,7 +121,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
       "Select a small model to use with Claude Code",
       {
         type: "select",
-        options: state.models.data.map((model) => model.id),
+        options: modelOptions,
       },
     )
 

--- a/src/start.ts
+++ b/src/start.ts
@@ -109,21 +109,31 @@ export async function runServer(options: RunServerOptions): Promise<void> {
       }))
       .sort((a, b) => (a.available === b.available ? 0 : a.available ? -1 : 1))
 
-    const selectedModel = await consola.prompt(
+    const selectedModel = (await consola.prompt(
       "Select a model to use with Claude Code",
       {
         type: "select",
         options: modelOptions,
       },
-    )
+    )) as string | undefined
 
-    const selectedSmallModel = await consola.prompt(
+    if (!selectedModel || typeof selectedModel !== "string") {
+      consola.info("Model selection cancelled.")
+      return
+    }
+
+    const selectedSmallModel = (await consola.prompt(
       "Select a small model to use with Claude Code",
       {
         type: "select",
         options: modelOptions,
       },
-    )
+    )) as string | undefined
+
+    if (!selectedSmallModel || typeof selectedSmallModel !== "string") {
+      consola.info("Model selection cancelled.")
+      return
+    }
 
     const command = generateEnvScript(
       {


### PR DESCRIPTION
Summary
  This PR introduces a real-time availability probing feature during the --claude-code setup process to ensure users select
  models that are actually accessible to their GitHub account and network environment.

  Key Changes
   - Probing Service: Added checkModelAvailability to verify model access by sending a minimal request (max_tokens: 1) to the
     Copilot API.
   - Parallel Probing: Implemented parallel checks in the CLI with a concurrency limit of 10 to balance speed and stability.
   - UI Enhancements:
       - Added status indicators (✅ Available / ❌ Unavailable) to the model selection list.
       - Automatically sort available models to the top for a better user experience.
   - Improved Robustness: Added graceful handling for selection cancellation (Ctrl+C).

  Benefit
  Eliminates configuration errors caused by selecting models that are restricted by GitHub permissions or regional network
  issues, making the setup process more reliable.