### PR TITLE
fix: add fetch retry with connection pool reset on network errors

### DIFF
--- a/src/lib/fetch-retry.ts
+++ b/src/lib/fetch-retry.ts
@@ -1,0 +1,56 @@
+import consola from "consola"
+
+import { resetAgent } from "./proxy"
+
+const RETRYABLE_CODES = new Set([
+  "ENETUNREACH",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_SOCKET",
+  "UND_ERR_CONNECT_TIMEOUT",
+])
+
+const MAX_RETRIES = 2
+const RETRY_DELAYS = [500, 1500]
+
+function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false
+  const cause = (error as { cause?: { code?: string } }).cause
+  if (cause?.code && RETRYABLE_CODES.has(cause.code)) return true
+  if (error.message === "fetch failed") return true
+  return false
+}
+
+export async function fetchWithRetry(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Promise<Response> {
+  let lastError: unknown
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fetch(input, init)
+    } catch (error) {
+      lastError = error
+      if (!isNetworkError(error) || attempt === MAX_RETRIES) {
+        throw error
+      }
+
+      const causeCode =
+        (error as { cause?: { code?: string } }).cause?.code ?? ""
+      consola.warn(
+        `Network error (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying in ${RETRY_DELAYS[attempt]}ms: ${(error as Error).message} ${causeCode}`,
+      )
+
+      if (attempt === 0) {
+        resetAgent()
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAYS[attempt]))
+    }
+  }
+
+  throw lastError
+}

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -2,65 +2,114 @@ import consola from "consola"
 import { getProxyForUrl } from "proxy-from-env"
 import { Agent, ProxyAgent, setGlobalDispatcher, type Dispatcher } from "undici"
 
-export function initProxyFromEnv(): void {
-  if (typeof Bun !== "undefined") return
+const AGENT_OPTIONS: Agent.Options = {
+  keepAliveTimeout: 30_000,
+  keepAliveMaxTimeout: 60_000,
+  connect: {
+    timeout: 15_000,
+  },
+}
 
-  try {
-    const direct = new Agent()
-    const proxies = new Map<string, ProxyAgent>()
+let directAgent: Agent | null = null
+let proxyMode = false
+let proxies: Map<string, ProxyAgent> | null = null
 
-    // We only need a minimal dispatcher that implements `dispatch` at runtime.
-    // Typing the object as `Dispatcher` forces TypeScript to require many
-    // additional methods. Instead, keep a plain object and cast when passing
-    // to `setGlobalDispatcher`.
-    const dispatcher = {
-      dispatch(
-        options: Dispatcher.DispatchOptions,
-        handler: Dispatcher.DispatchHandler,
-      ) {
-        try {
-          const origin =
-            typeof options.origin === "string" ?
-              new URL(options.origin)
-            : (options.origin as URL)
-          const get = getProxyForUrl as unknown as (
-            u: string,
-          ) => string | undefined
-          const raw = get(origin.toString())
-          const proxyUrl = raw && raw.length > 0 ? raw : undefined
-          if (!proxyUrl) {
-            consola.debug(`HTTP proxy bypass: ${origin.hostname}`)
-            return (direct as unknown as Dispatcher).dispatch(options, handler)
-          }
-          let agent = proxies.get(proxyUrl)
-          if (!agent) {
-            agent = new ProxyAgent(proxyUrl)
-            proxies.set(proxyUrl, agent)
-          }
-          let label = proxyUrl
-          try {
-            const u = new URL(proxyUrl)
-            label = `${u.protocol}//${u.host}`
-          } catch {
-            /* noop */
-          }
-          consola.debug(`HTTP proxy route: ${origin.hostname} via ${label}`)
-          return (agent as unknown as Dispatcher).dispatch(options, handler)
-        } catch {
+function isBun(): boolean {
+  return typeof Bun !== "undefined"
+}
+
+function createDispatcher(
+  direct: Agent,
+  proxyMap: Map<string, ProxyAgent>,
+): object {
+  return {
+    dispatch(
+      options: Dispatcher.DispatchOptions,
+      handler: Dispatcher.DispatchHandler,
+    ) {
+      try {
+        const origin =
+          typeof options.origin === "string" ?
+            new URL(options.origin)
+          : (options.origin as URL)
+        const get = getProxyForUrl as unknown as (
+          u: string,
+        ) => string | undefined
+        const raw = get(origin.toString())
+        const proxyUrl = raw && raw.length > 0 ? raw : undefined
+        if (!proxyUrl) {
+          consola.debug(`HTTP proxy bypass: ${origin.hostname}`)
           return (direct as unknown as Dispatcher).dispatch(options, handler)
         }
-      },
-      close() {
-        return direct.close()
-      },
-      destroy() {
-        return direct.destroy()
-      },
-    }
+        let agent = proxyMap.get(proxyUrl)
+        if (!agent) {
+          agent = new ProxyAgent(proxyUrl)
+          proxyMap.set(proxyUrl, agent)
+        }
+        let label = proxyUrl
+        try {
+          const u = new URL(proxyUrl)
+          label = `${u.protocol}//${u.host}`
+        } catch {
+          /* noop */
+        }
+        consola.debug(`HTTP proxy route: ${origin.hostname} via ${label}`)
+        return (agent as unknown as Dispatcher).dispatch(options, handler)
+      } catch {
+        return (direct as unknown as Dispatcher).dispatch(options, handler)
+      }
+    },
+    close() {
+      return direct.close()
+    },
+    destroy() {
+      return direct.destroy()
+    },
+  }
+}
+
+export function initDefaultAgent(): void {
+  if (isBun()) return
+
+  directAgent = new Agent(AGENT_OPTIONS)
+  setGlobalDispatcher(directAgent as unknown as Dispatcher)
+  consola.debug("Default HTTP agent configured with keep-alive timeouts")
+}
+
+export function initProxyFromEnv(): void {
+  if (isBun()) return
+
+  try {
+    directAgent = new Agent(AGENT_OPTIONS)
+    proxies = new Map<string, ProxyAgent>()
+    proxyMode = true
+
+    const dispatcher = createDispatcher(directAgent, proxies)
 
     setGlobalDispatcher(dispatcher as unknown as Dispatcher)
     consola.debug("HTTP proxy configured from environment (per-URL)")
   } catch (err) {
     consola.debug("Proxy setup skipped:", err)
   }
+}
+
+export function resetAgent(): void {
+  if (isBun()) return
+
+  const oldAgent = directAgent
+  if (oldAgent) {
+    oldAgent.close().catch(() => {})
+  }
+
+  directAgent = new Agent(AGENT_OPTIONS)
+
+  if (proxyMode) {
+    proxies = new Map<string, ProxyAgent>()
+    const dispatcher = createDispatcher(directAgent, proxies)
+    setGlobalDispatcher(dispatcher as unknown as Dispatcher)
+  } else {
+    setGlobalDispatcher(directAgent as unknown as Dispatcher)
+  }
+
+  consola.debug("HTTP agent reset: connection pool cleared")
 }

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -10,6 +10,7 @@ import {
   prepareInteractionHeaders,
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export const createChatCompletions = async (
@@ -54,11 +55,14 @@ export const createChatCompletions = async (
 
   prepareForCompact(headers, options.isCompact)
 
-  const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const response = await fetchWithRetry(
+    `${copilotBaseUrl(state)}/chat/completions`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+  )
 
   if (!response.ok) {
     consola.error("Failed to create chat completions", response)

--- a/src/services/copilot/create-embeddings.ts
+++ b/src/services/copilot/create-embeddings.ts
@@ -1,11 +1,12 @@
 import { copilotHeaders, copilotBaseUrl } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export const createEmbeddings = async (payload: EmbeddingRequest) => {
   if (!state.copilotToken) throw new Error("Copilot token not found")
 
-  const response = await fetch(`${copilotBaseUrl(state)}/embeddings`, {
+  const response = await fetchWithRetry(`${copilotBaseUrl(state)}/embeddings`, {
     method: "POST",
     headers: copilotHeaders(state),
     body: JSON.stringify(payload),

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -14,6 +14,7 @@ import {
   prepareInteractionHeaders,
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export type MessagesStream = ReturnType<typeof events>
@@ -107,11 +108,14 @@ export const createMessages = async (
     headers["anthropic-beta"] = anthropicBeta
   }
 
-  const response = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const response = await fetchWithRetry(
+    `${copilotBaseUrl(state)}/v1/messages`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+  )
 
   if (!response.ok) {
     consola.error("Failed to create messages", response)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -10,6 +10,7 @@ import {
   prepareInteractionHeaders,
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export interface ResponsesPayload {
@@ -386,7 +387,7 @@ export const createResponses = async (
   // service_tier is not supported by github copilot
   payload.service_tier = null
 
-  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+  const response = await fetchWithRetry(`${copilotBaseUrl(state)}/responses`, {
     method: "POST",
     headers,
     body: JSON.stringify(payload),

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -1,9 +1,10 @@
 import { copilotBaseUrl, copilotHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export const getModels = async () => {
-  const response = await fetch(`${copilotBaseUrl(state)}/models`, {
+  const response = await fetchWithRetry(`${copilotBaseUrl(state)}/models`, {
     headers: copilotHeaders(state),
   })
 

--- a/src/services/github/get-copilot-token.ts
+++ b/src/services/github/get-copilot-token.ts
@@ -1,9 +1,10 @@
 import { getGitHubApiBaseUrl, githubHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export const getCopilotToken = async () => {
-  const response = await fetch(
+  const response = await fetchWithRetry(
     `${getGitHubApiBaseUrl()}/copilot_internal/v2/token`,
     {
       headers: githubHeaders(state),

--- a/src/services/github/get-copilot-usage.ts
+++ b/src/services/github/get-copilot-usage.ts
@@ -1,9 +1,10 @@
 import { getGitHubApiBaseUrl, githubHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export const getCopilotUsage = async (): Promise<CopilotUsageResponse> => {
-  const response = await fetch(
+  const response = await fetchWithRetry(
     `${getGitHubApiBaseUrl()}/copilot_internal/user`,
     {
       headers: githubHeaders(state),

--- a/src/services/github/get-device-code.ts
+++ b/src/services/github/get-device-code.ts
@@ -1,11 +1,12 @@
 import { getOauthAppConfig, getOauthUrls } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 
 export async function getDeviceCode(): Promise<DeviceCodeResponse> {
   const { clientId, headers, scope } = getOauthAppConfig()
   const { deviceCodeUrl } = getOauthUrls()
 
-  const response = await fetch(deviceCodeUrl, {
+  const response = await fetchWithRetry(deviceCodeUrl, {
     method: "POST",
     headers,
     body: JSON.stringify({

--- a/src/services/github/get-user.ts
+++ b/src/services/github/get-user.ts
@@ -1,9 +1,10 @@
 import { getGitHubApiBaseUrl, standardHeaders } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
+import { fetchWithRetry } from "~/lib/fetch-retry"
 import { state } from "~/lib/state"
 
 export async function getGitHubUser() {
-  const response = await fetch(`${getGitHubApiBaseUrl()}/user`, {
+  const response = await fetchWithRetry(`${getGitHubApiBaseUrl()}/user`, {
     headers: {
       authorization: `token ${state.githubToken}`,
       ...standardHeaders(),

--- a/src/start.ts
+++ b/src/start.ts
@@ -8,7 +8,7 @@ import invariant from "tiny-invariant"
 
 import { mergeConfigWithDefaults } from "./lib/config"
 import { ensurePaths } from "./lib/paths"
-import { initProxyFromEnv } from "./lib/proxy"
+import { initDefaultAgent, initProxyFromEnv } from "./lib/proxy"
 import { generateEnvScript } from "./lib/shell"
 import { state } from "./lib/state"
 import { setupCopilotToken, setupGitHubToken } from "./lib/token"
@@ -35,6 +35,8 @@ interface RunServerOptions {
 export async function runServer(options: RunServerOptions): Promise<void> {
   // Ensure config is merged with defaults at startup
   mergeConfigWithDefaults()
+
+  initDefaultAgent()
 
   if (options.proxyEnv) {
     initProxyFromEnv()


### PR DESCRIPTION
## Summary

Fixes recurring `ENETUNREACH` / `ECONNREFUSED` errors when connecting to GitHub's Copilot API that previously required a full server restart to resolve.

## Root Cause

Node.js's `fetch()` is backed by **undici**, which maintains a persistent HTTP connection pool via a global `Agent`. The default Agent has **no keep-alive timeout**, so once a TCP connection to a GitHub IP (e.g. `140.82.113.22`) is established, it stays in the pool indefinitely.

When GitHub rotates IPs or a network route changes, the cached connection becomes stale but undici keeps trying to reuse it — resulting in `ENETUNREACH`. Every subsequent request fails because they all go through the same stale pool. Restarting the server works because it destroys the process (and the pool), forcing fresh DNS resolution and new connections.

This was especially problematic without the `--proxy-env` flag, because in that case **no custom Agent was configured at all** — the server ran on undici's bare defaults.

## Fix

Two-pronged approach:

### 1. Global Agent with proper timeouts (`src/lib/proxy.ts`)

- **`keepAliveTimeout: 30s`** — idle connections are automatically evicted after 30 seconds, preventing stale connections from lingering
- **`keepAliveMaxTimeout: 60s`** — hard upper bound on keep-alive
- **`connect.timeout: 15s`** — connection attempts don't hang forever
- `initDefaultAgent()` is now called **unconditionally** at startup (not gated behind `--proxy-env`), ensuring every server instance gets a properly configured Agent
- `resetAgent()` function that closes the old Agent/pool and creates a fresh one — works in both direct and proxy modes

### 2. `fetchWithRetry` wrapper (`src/lib/fetch-retry.ts`)

A drop-in replacement for `fetch()` that retries on network-level errors:

- **Detects network errors**: `ENETUNREACH`, `ECONNREFUSED`, `ECONNRESET`, `EPIPE`, `ETIMEDOUT`, `UND_ERR_SOCKET`, `UND_ERR_CONNECT_TIMEOUT`
- **Max 2 retries** (3 total attempts) with delays of 500ms and 1500ms
- **Resets the connection pool** on first retry via `resetAgent()` — this is effectively what a restart does, but without restarting
- **Only retries network errors** — HTTP errors (4xx/5xx) are never retried, they pass through as before
- **Safe for streaming**: retry only triggers when `fetch()` itself throws (before any Response body exists)

### Call sites updated (9 files)

All copilot and GitHub service fetch calls now use `fetchWithRetry`:
- `create-messages.ts`, `create-responses.ts`, `create-chat-completions.ts`, `create-embeddings.ts`, `get-models.ts`
- `get-copilot-token.ts`, `get-copilot-usage.ts`, `get-user.ts`, `get-device-code.ts`

### Excluded (already have their own error handling)
- `poll-access-token.ts` — has its own retry loop
- `anthropic-proxy.ts` — external provider, not affected by our connection pool
- `count-tokens-handler.ts` — already falls back to local estimation on failure

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] Type-check passes (no new errors in modified files)
- [ ] Manual test: start server, make requests, verify normal operation
- [ ] Monitor logs for retry messages (`Network error (attempt X/3), retrying...`) during transient network issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)