### PR TITLE
feat(plugin): add SessionStart hook to auto-inject proxy rules

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-plugin",
-  "description": "Inject SubagentStart marker context for copilot-api initiator override",
-  "version": "1.0.0",
+  "description": "Inject copilot-api proxy rules (AskUserQuestion, no-background-agents) via SessionStart and SubagentStart marker context",
+  "version": "1.1.0",
   "author": {
     "name": "copilot-api maintainers"
   }

--- a/claude-plugin/hooks/hooks.json
+++ b/claude-plugin/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-rules.js\""
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "matcher": "*",

--- a/claude-plugin/scripts/session-start-rules.js
+++ b/claude-plugin/scripts/session-start-rules.js
@@ -1,0 +1,29 @@
+async function readStdin() {
+  let input = "";
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  return input.trim();
+}
+
+await readStdin();
+
+const rules = `Prohibited from directly asking questions to users, MUST use AskUserQuestion tool.
+Once you can confirm that the task is complete, MUST use AskUserQuestion tool to make user confirm. The user may respond with feedback if they are not satisfied with the result, which you can use to make improvements and try again.
+
+## Subagent Execution Rules
+
+**CRITICAL — This project uses a third-party API proxy (copilot-api). Background agents WILL FAIL with "No task found" errors due to proxy latency causing TaskOutput timeouts.**
+
+### Mandatory Rules
+- **NEVER** set \`run_in_background: true\` when spawning agents via the Agent tool
+- **ALWAYS** run agents in foreground and wait for their results before proceeding`;
+
+const payload = {
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: rules,
+  },
+};
+
+process.stdout.write(`${JSON.stringify(payload)}\n`);

--- a/claude-plugin/scripts/session-start-rules.js
+++ b/claude-plugin/scripts/session-start-rules.js
@@ -8,16 +8,8 @@ async function readStdin() {
 
 await readStdin();
 
-const rules = `Prohibited from directly asking questions to users, MUST use AskUserQuestion tool.
-Once you can confirm that the task is complete, MUST use AskUserQuestion tool to make user confirm. The user may respond with feedback if they are not satisfied with the result, which you can use to make improvements and try again.
-
-## Subagent Execution Rules
-
-**CRITICAL — This project uses a third-party API proxy (copilot-api). Background agents WILL FAIL with "No task found" errors due to proxy latency causing TaskOutput timeouts.**
-
-### Mandatory Rules
-- **NEVER** set \`run_in_background: true\` when spawning agents via the Agent tool
-- **ALWAYS** run agents in foreground and wait for their results before proceeding`;
+const rules = `MUST use AskUserQuestion tool (never ask users directly). Confirm task completion via AskUserQuestion.
+NEVER set \`run_in_background: true\` on Agent tool — proxy latency causes "No task found" errors. ALWAYS run agents foreground.`;
 
 const payload = {
   hookSpecificOutput: {


### PR DESCRIPTION
## Summary

- Add `SessionStart` hook to the Claude plugin that auto-injects critical proxy-specific rules into every session via `additionalContext`
- Bump plugin version from 1.0.0 → 1.1.0
- Update plugin description to reflect expanded scope

## Problem

When using copilot-api as a third-party proxy for GitHub Copilot, Claude Code sessions encounter two issues that waste premium request quota:

### 1. Plain text questions waste premium requests

When Claude asks users questions via plain text output, each follow-up turn consumes a premium request from the GitHub Copilot quota. By enforcing `AskUserQuestion` tool usage, user interaction is handled via structured UI prompts — significantly reducing the number of premium requests consumed per session.

### 2. Background agents fail with "No task found" errors

When `run_in_background: true` is set on the Agent tool, Claude Code returns a task ID and polls via `TaskOutput` to retrieve results. Through a third-party proxy like copilot-api, API latency is 2–5× higher than direct API access. This causes:

1. Long-running agents exceed `TaskOutput` polling timeout
2. The task tracker gets cleaned up before results can be retrieved
3. Claude Code reports **"No task found with ID: xxx"** error
4. All agent work is lost — wasting the premium requests already consumed

**Foreground agents bypass this entirely** by waiting inline for the result — no task ID polling needed.

Currently, users must manually configure these rules in `CLAUDE.md` or system prompts for every project. This is error-prone and easy to forget.

## Solution

Add a `SessionStart` hook alongside the existing `SubagentStart` hook. The new hook runs `session-start-rules.js` which outputs rules via `hookSpecificOutput.additionalContext`, automatically injecting them at session startup.

## Changes

| File | Change |
|------|--------|
| `claude-plugin/.claude-plugin/plugin.json` | Bump version to 1.1.0, update description |
| `claude-plugin/hooks/hooks.json` | Add `SessionStart` hook entry |
| `claude-plugin/scripts/session-start-rules.js` | **New** — outputs proxy rules via additionalContext |

## How it works

```
SessionStart event
  → hooks.json triggers session-start-rules.js
    → script outputs JSON with additionalContext
      → Claude Code injects rules into session context
```

The injected rules (~60 tokens):
```
MUST use AskUserQuestion tool (never ask users directly). Confirm task completion via AskUserQuestion.
NEVER set `run_in_background: true` on Agent tool — proxy latency causes "No task found" errors. ALWAYS run agents foreground.
```

## Recommended CLAUDE.md / AGENTS.md Content

For users of copilot-api, we recommend including the following in `CLAUDE.md` or `AGENTS.md`:

```
- Prohibited from directly asking questions to users, MUST use AskUserQuestion tool.
- Once you can confirm that the task is complete, MUST use AskUserQuestion tool to make user confirm.
  The user may respond with feedback if they are not satisfied with the result,
  which you can use to make improvements and try again.
  After trying again, MUST use AskUserQuestion tool to make user confirm again.
```

**Why:** Each plain text question from Claude triggers a new turn that consumes a GitHub Copilot premium request. Using `AskUserQuestion` consolidates user interaction into structured prompts, reducing premium request quota consumption.

## Verification

To verify these rules work correctly, spawn 5 complex foreground agents in one message (each reading a file + analyzing it). Expected result: all 5 return results inline, zero "No task found" errors.

## Backward Compatibility

- Non-breaking: only adds a new hook; existing `SubagentStart` hook is unchanged
- The rules are proxy-relevant but harmless for direct API usage