### PR TITLE
feat: make Claude token count multiplier configurable via config.json

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -19,6 +19,7 @@ export interface AppConfig {
   useMessagesApi?: boolean
   anthropicApiKey?: string
   useResponsesApiWebSearch?: boolean
+  claudeTokenMultiplier?: number
 }
 
 export interface ModelConfig {
@@ -299,4 +300,9 @@ export function getAnthropicApiKey(): string | undefined {
 export function isResponsesApiWebSearchEnabled(): boolean {
   const config = getConfig()
   return config.useResponsesApiWebSearch ?? true
+}
+
+export function getClaudeTokenMultiplier(): number {
+  const config = getConfig()
+  return config.claudeTokenMultiplier ?? 1.15
 }

--- a/src/routes/messages/count-tokens-handler.ts
+++ b/src/routes/messages/count-tokens-handler.ts
@@ -2,7 +2,7 @@ import type { Context } from "hono"
 
 import consola from "consola"
 
-import { getAnthropicApiKey } from "~/lib/config"
+import { getAnthropicApiKey, getClaudeTokenMultiplier } from "~/lib/config"
 import { getTokenCount } from "~/lib/tokenizer"
 
 import { findEndpointModel } from "../../lib/models"
@@ -108,7 +108,7 @@ export async function handleCountTokens(c: Context) {
 
     let finalTokenCount = tokenCount.input + tokenCount.output
     if (anthropicPayload.model.startsWith("claude")) {
-      finalTokenCount = Math.round(finalTokenCount * 1.15)
+      finalTokenCount = Math.round(finalTokenCount * getClaudeTokenMultiplier())
     }
 
     consola.info("Token count:", finalTokenCount)


### PR DESCRIPTION
The hardcoded 1.15x multiplier for Claude token estimation consistently underestimates actual usage, causing tools like Claude Code to compact too late and hit token limit errors. This adds a `claudeTokenMultiplier` field to config.json so users can set a more conservative value (e.g. 1.25) without code changes. Default remains 1.15 for backwards compat.