### PR TITLE
feat: convert tool_reference blocks to text for proxy compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.5.3-beta.2",
+  "version": "1.5.3-beta.3",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -42,6 +42,11 @@ export interface AnthropicImageBlock {
   }
 }
 
+export interface AnthropicToolReferenceBlock {
+  type: "tool_reference"
+  tool_name: string
+}
+
 export interface AnthropicToolResultBlock {
   type: "tool_result"
   tool_use_id: string

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -16,7 +16,11 @@ import {
   handleWithMessagesApi,
   handleWithResponsesApi,
 } from "./api-flows"
-import { isCompactRequest, mergeToolResultForClaude } from "./preprocess"
+import {
+  isCompactRequest,
+  mergeToolResultForClaude,
+  convertToolReferenceBlocks,
+} from "./preprocess"
 import { parseSubagentMarkerFromFirstUser } from "./subagent-marker"
 
 const logger = createHandlerLogger("messages-handler")
@@ -26,6 +30,9 @@ export async function handleCompletion(c: Context) {
 
   const anthropicPayload = await c.req.json<AnthropicMessagesPayload>()
   debugJson(logger, "Anthropic request payload:", anthropicPayload)
+
+  // Convert tool_reference blocks early, before any other processing
+  convertToolReferenceBlocks(anthropicPayload)
 
   const subagentMarker = parseSubagentMarkerFromFirstUser(anthropicPayload)
   if (subagentMarker) {

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -183,6 +183,35 @@ const filterAssistantThinkingBlocks = (
   }
 }
 
+// Convert tool_reference content blocks to text blocks.
+// The Copilot Messages API does not support tool_reference blocks
+// (used by Claude Code's ENABLE_TOOL_SEARCH / MCP tool lazy-loading).
+// Runs on the raw payload before type-narrowing, so uses runtime checks.
+export const convertToolReferenceBlocks = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  for (const msg of payload.messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
+    for (const block of msg.content) {
+      if (block.type !== "tool_result" || typeof block.content === "string")
+        continue
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      block.content = (block.content as Array<any>).map((inner: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (inner.type === "tool_reference") {
+          return {
+            type: "text" as const,
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            text: `[tool_reference: ${inner.tool_name}]`,
+          }
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return inner
+      }) as typeof block.content
+    }
+  }
+}
+
 export const prepareMessagesApiPayload = (
   payload: AnthropicMessagesPayload,
   selectedModel?: Model,


### PR DESCRIPTION
## Summary

- Adds support for `tool_reference` content blocks inside `tool_result` messages by converting them to `text` blocks early in the request pipeline
- Claude Code's `ENABLE_TOOL_SEARCH` (MCP tool lazy-loading) returns results as `tool_reference` content blocks, which the Copilot Messages API rejects as unknown types
- Conversion runs before all other preprocessing to avoid breaking `mergeToolResultForClaude`

## Context

When `ENABLE_TOOL_SEARCH=true`, Claude Code defers MCP tool definitions and loads them on demand via a `ToolSearch` meta-tool. The results are returned as `{type: "tool_reference", tool_name: "..."}` content blocks inside `tool_result` messages. This is an Anthropic API content block type that the Copilot Messages API does not support, causing 503 errors.

The fix converts these blocks to `{type: "text", text: "[tool_reference: tool_name]"}` before the payload reaches the API. This is lossless -- Claude Code tracks discovered tools client-side and manages the `tools` array independently.

## Test plan

- [x] Verified `ENABLE_TOOL_SEARCH=true` with MCP tools (Context7, alphaxiv) through copilot-api -- no more 503 errors
- [x] Verified ToolSearch deferred tool loading works end-to-end
- [x] Build passes (`bun run build`)
- [x] Lint passes (lint-staged ran on commit)