### PR TITLE
feat: auto-refresh Copilot token on 401 and retry request

### DIFF
--- a/src/lib/with-token-refresh.ts
+++ b/src/lib/with-token-refresh.ts
@@ -1,0 +1,53 @@
+import consola from "consola"
+
+import { HTTPError } from "~/lib/error"
+import { state } from "~/lib/state"
+import { setupCopilotToken } from "~/lib/token"
+
+/**
+ * Wraps a fetch call with automatic Copilot token refresh on 401.
+ *
+ * If the initial response is 401:
+ *   - Attempts to refresh the token via setupCopilotToken().
+ *   - If refresh fails, throws an HTTPError wrapping the original 401 response
+ *     so the caller sees a controlled upstream error, not the refresh failure.
+ *   - If refresh succeeds, mutates headers["Authorization"] and retries once.
+ *
+ * Returns a Response that is guaranteed ok, or throws HTTPError.
+ */
+export const fetchWithCopilotTokenRefresh = async (
+  doRequest: () => Promise<Response>,
+  headers: Record<string, string>,
+  errorLabel: string,
+): Promise<Response> => {
+  const response = await doRequest()
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      consola.warn("Copilot token expired, refreshing and retrying...")
+      try {
+        await setupCopilotToken()
+      } catch (refreshError) {
+        consola.error(
+          `Failed to refresh Copilot token while retrying ${errorLabel}:`,
+          refreshError,
+        )
+        throw new HTTPError(`Failed to ${errorLabel}`, response)
+      }
+      headers["Authorization"] = `Bearer ${state.copilotToken}`
+      const retryResponse = await doRequest()
+      if (!retryResponse.ok) {
+        consola.error(
+          `Failed to ${errorLabel} after token refresh`,
+          retryResponse,
+        )
+        throw new HTTPError(`Failed to ${errorLabel}`, retryResponse)
+      }
+      return retryResponse
+    }
+    consola.error(`Failed to ${errorLabel}`, response)
+    throw new HTTPError(`Failed to ${errorLabel}`, response)
+  }
+
+  return response
+}

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -1,4 +1,3 @@
-import consola from "consola"
 import { events } from "fetch-event-stream"
 
 import type { SubagentMarker } from "~/routes/messages/subagent-marker"
@@ -9,9 +8,8 @@ import {
   prepareForCompact,
   prepareInteractionHeaders,
 } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
-import { setupCopilotToken } from "~/lib/token"
+import { fetchWithCopilotTokenRefresh } from "~/lib/with-token-refresh"
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
@@ -55,34 +53,16 @@ export const createChatCompletions = async (
 
   prepareForCompact(headers, options.isCompact)
 
-  const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      consola.warn("Copilot token expired, refreshing and retrying...")
-      await setupCopilotToken()
-      headers["Authorization"] = `Bearer ${state.copilotToken}`
-      const retryResponse = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
+  const response = await fetchWithCopilotTokenRefresh(
+    () =>
+      fetch(`${copilotBaseUrl(state)}/chat/completions`, {
         method: "POST",
         headers,
         body: JSON.stringify(payload),
-      })
-      if (!retryResponse.ok) {
-        consola.error("Failed to create chat completions after token refresh", retryResponse)
-        throw new HTTPError("Failed to create chat completions", retryResponse)
-      }
-      if (payload.stream) {
-        return events(retryResponse)
-      }
-      return (await retryResponse.json()) as ChatCompletionResponse
-    }
-    consola.error("Failed to create chat completions", response)
-    throw new HTTPError("Failed to create chat completions", response)
-  }
+      }),
+    headers,
+    "create chat completions",
+  )
 
   if (payload.stream) {
     return events(response)

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -11,6 +11,7 @@ import {
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import { setupCopilotToken } from "~/lib/token"
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
@@ -61,6 +62,24 @@ export const createChatCompletions = async (
   })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      consola.warn("Copilot token expired, refreshing and retrying...")
+      await setupCopilotToken()
+      headers["Authorization"] = `Bearer ${state.copilotToken}`
+      const retryResponse = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!retryResponse.ok) {
+        consola.error("Failed to create chat completions after token refresh", retryResponse)
+        throw new HTTPError("Failed to create chat completions", retryResponse)
+      }
+      if (payload.stream) {
+        return events(retryResponse)
+      }
+      return (await retryResponse.json()) as ChatCompletionResponse
+    }
     consola.error("Failed to create chat completions", response)
     throw new HTTPError("Failed to create chat completions", response)
   }

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -1,4 +1,3 @@
-import consola from "consola"
 import { events } from "fetch-event-stream"
 
 import type {
@@ -14,10 +13,9 @@ import {
   prepareInteractionHeaders,
   prepareMessageProxyHeaders,
 } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
-import { setupCopilotToken } from "~/lib/token"
 import { parseUserIdMetadata } from "~/lib/utils"
+import { fetchWithCopilotTokenRefresh } from "~/lib/with-token-refresh"
 
 export type MessagesStream = ReturnType<typeof events>
 export type CreateMessagesReturn = AnthropicResponse | MessagesStream
@@ -123,34 +121,16 @@ export const createMessages = async (
     headers["anthropic-beta"] = anthropicBeta
   }
 
-  const response = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      consola.warn("Copilot token expired, refreshing and retrying...")
-      await setupCopilotToken()
-      headers["Authorization"] = `Bearer ${state.copilotToken}`
-      const retryResponse = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
+  const response = await fetchWithCopilotTokenRefresh(
+    () =>
+      fetch(`${copilotBaseUrl(state)}/v1/messages`, {
         method: "POST",
         headers,
         body: JSON.stringify(payload),
-      })
-      if (!retryResponse.ok) {
-        consola.error("Failed to create messages after token refresh", retryResponse)
-        throw new HTTPError("Failed to create messages", retryResponse)
-      }
-      if (payload.stream) {
-        return events(retryResponse)
-      }
-      return (await retryResponse.json()) as AnthropicResponse
-    }
-    consola.error("Failed to create messages", response)
-    throw new HTTPError("Failed to create messages", response)
-  }
+      }),
+    headers,
+    "create messages",
+  )
 
   if (payload.stream) {
     return events(response)

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -16,6 +16,7 @@ import {
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import { setupCopilotToken } from "~/lib/token"
 import { parseUserIdMetadata } from "~/lib/utils"
 
 export type MessagesStream = ReturnType<typeof events>
@@ -129,6 +130,24 @@ export const createMessages = async (
   })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      consola.warn("Copilot token expired, refreshing and retrying...")
+      await setupCopilotToken()
+      headers["Authorization"] = `Bearer ${state.copilotToken}`
+      const retryResponse = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!retryResponse.ok) {
+        consola.error("Failed to create messages after token refresh", retryResponse)
+        throw new HTTPError("Failed to create messages", retryResponse)
+      }
+      if (payload.stream) {
+        return events(retryResponse)
+      }
+      return (await retryResponse.json()) as AnthropicResponse
+    }
     consola.error("Failed to create messages", response)
     throw new HTTPError("Failed to create messages", response)
   }

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -1,4 +1,3 @@
-import consola from "consola"
 import { events } from "fetch-event-stream"
 
 import type { SubagentMarker } from "~/routes/messages/subagent-marker"
@@ -9,9 +8,8 @@ import {
   prepareForCompact,
   prepareInteractionHeaders,
 } from "~/lib/api-config"
-import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
-import { setupCopilotToken } from "~/lib/token"
+import { fetchWithCopilotTokenRefresh } from "~/lib/with-token-refresh"
 
 export interface ResponsesPayload {
   model: string
@@ -387,34 +385,16 @@ export const createResponses = async (
   // service_tier is not supported by github copilot
   payload.service_tier = null
 
-  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      consola.warn("Copilot token expired, refreshing and retrying...")
-      await setupCopilotToken()
-      headers["Authorization"] = `Bearer ${state.copilotToken}`
-      const retryResponse = await fetch(`${copilotBaseUrl(state)}/responses`, {
+  const response = await fetchWithCopilotTokenRefresh(
+    () =>
+      fetch(`${copilotBaseUrl(state)}/responses`, {
         method: "POST",
         headers,
         body: JSON.stringify(payload),
-      })
-      if (!retryResponse.ok) {
-        consola.error("Failed to create responses after token refresh", retryResponse)
-        throw new HTTPError("Failed to create responses", retryResponse)
-      }
-      if (payload.stream) {
-        return events(retryResponse)
-      }
-      return (await retryResponse.json()) as ResponsesResult
-    }
-    consola.error("Failed to create responses", response)
-    throw new HTTPError("Failed to create responses", response)
-  }
+      }),
+    headers,
+    "create responses",
+  )
 
   if (payload.stream) {
     return events(response)

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -11,6 +11,7 @@ import {
 } from "~/lib/api-config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import { setupCopilotToken } from "~/lib/token"
 
 export interface ResponsesPayload {
   model: string
@@ -393,6 +394,24 @@ export const createResponses = async (
   })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      consola.warn("Copilot token expired, refreshing and retrying...")
+      await setupCopilotToken()
+      headers["Authorization"] = `Bearer ${state.copilotToken}`
+      const retryResponse = await fetch(`${copilotBaseUrl(state)}/responses`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+      })
+      if (!retryResponse.ok) {
+        consola.error("Failed to create responses after token refresh", retryResponse)
+        throw new HTTPError("Failed to create responses", retryResponse)
+      }
+      if (payload.stream) {
+        return events(retryResponse)
+      }
+      return (await retryResponse.json()) as ResponsesResult
+    }
     consola.error("Failed to create responses", response)
     throw new HTTPError("Failed to create responses", response)
   }


### PR DESCRIPTION
## Summary

- When any of the three Copilot upstream callers (`createChatCompletions`, `createMessages`, `createResponses`) receives a **HTTP 401** response, automatically refresh the token and retry the request once before surfacing an error
- Applies uniformly to all three API paths: `/chat/completions`, `/v1/messages`, and `/responses`
- On retry, the refreshed token from `state.copilotToken` is injected into the `Authorization` header before re-sending the identical payload

## Changes

**`src/lib/with-token-refresh.ts`** (new) — shared `fetchWithCopilotTokenRefresh` helper that owns the entire refresh-and-retry flow:
- On 401: calls `setupCopilotToken()` inside a `try/catch`
  - If refresh fails → throws `HTTPError` wrapping the **original 401 response**, so callers see a controlled upstream error instead of the token-fetch failure
  - If refresh succeeds → mutates `headers["Authorization"]` in place and retries once
- All other non-ok responses → throws `HTTPError` immediately

**`createChatCompletions` / `createMessages` / `createResponses`** — each had ~20 lines of duplicated 401 handling removed; now delegate to `fetchWithCopilotTokenRefresh`.

## Motivation

Copilot tokens have a limited TTL. Long-running or idle sessions can hit 401s on otherwise valid requests. Without this change the error propagates immediately. With it, the token is refreshed transparently and the request succeeds without user intervention. The refactor also ensures consistent behavior and closes the gap where a failed refresh would short-circuit with the wrong error.

## Test plan

- [ ] Start the proxy with a valid token, wait for it to expire (or manually expire it), and verify the next request succeeds without manual intervention
- [ ] Simulate a refresh failure and confirm the caller receives an `HTTPError` reflecting the original 401, not the refresh error
- [ ] Verify streaming responses work correctly after a token refresh on all three paths (`/chat/completions`, `/v1/messages`, `/responses`)
- [ ] Confirm a genuine 401 (bad credentials) still surfaces an error after the single retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)