### PR TITLE
Strip context_management from Messages API payload

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -218,11 +218,27 @@ const filterAssistantThinkingBlocks = (
   }
 }
 
+// Strip fields from the top-level payload that the Copilot Messages API
+// rejects with "Extra inputs are not permitted". These are valid Anthropic API
+// fields but not (yet) supported by the Copilot Messages endpoint.
+const stripUnsupportedPayloadFields = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  // Valid Anthropic API fields not yet supported by the Copilot Messages endpoint.
+  // They arrive at runtime via JSON pass-through despite not being in our type.
+  for (const key of ["context_management"]) {
+    if (key in payload) {
+      Reflect.deleteProperty(payload, key)
+    }
+  }
+}
+
 export const prepareMessagesApiPayload = (
   payload: AnthropicMessagesPayload,
   selectedModel?: Model,
 ): void => {
   stripCacheControl(payload)
+  stripUnsupportedPayloadFields(payload)
   filterAssistantThinkingBlocks(payload)
 
   // https://platform.claude.com/docs/en/build-with-claude/extended-thinking#extended-thinking-with-tool-use


### PR DESCRIPTION
## Summary

- Strip `context_management` field from Messages API payloads before forwarding to the Copilot Messages endpoint
- The upstream Copilot API rejects this field with "Extra inputs are not permitted"
- Claude Code started sending `context_management` recently; this fix prevents 400 errors

## Context

`context_management` is a valid Anthropic API field but is not supported by the Copilot Messages endpoint. Since `AnthropicMessagesPayload` doesn't declare it, TypeScript doesn't catch it at compile time, but the field passes through `JSON.stringify(payload)` at runtime.

The fix adds a `stripUnsupportedPayloadFields` function in `preprocess.ts` that removes unsupported top-level fields before the request is sent. This is extensible for future fields that may need stripping.

## Test plan

- [ ] Verify Claude Code sessions work without "Extra inputs are not permitted" errors
- [ ] Verify no regression in existing message preprocessing (thinking blocks, cache control, tool results)
- [ ] Run `npm run lint` and `npm run build` to confirm no type/lint errors