### PR TITLE
fix: merge image blocks into tool_result to avoid extra premium consumption

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -13,10 +13,12 @@ import {
 import { getReasoningEffortForModel } from "~/lib/config"
 
 import type {
+  AnthropicImageBlock,
   AnthropicMessage,
   AnthropicMessagesPayload,
   AnthropicTextBlock,
   AnthropicToolResultBlock,
+  AnthropicUserContentBlock,
 } from "./anthropic-types"
 
 export const TOOL_REFERENCE_TURN_BOUNDARY = "Tool loaded."
@@ -164,6 +166,57 @@ export const stripToolReferenceTurnBoundary = (
   }
 }
 
+const scanUserContentBlocks = (content: Array<AnthropicUserContentBlock>) => {
+  const toolResults: Array<AnthropicToolResultBlock> = []
+  const textBlocks: Array<AnthropicTextBlock> = []
+  const imageBlocks: Array<AnthropicImageBlock> = []
+
+  for (const block of content) {
+    switch (block.type) {
+      case "tool_result": {
+        toolResults.push(block)
+        break
+      }
+      case "text": {
+        textBlocks.push(block)
+        break
+      }
+      case "image": {
+        imageBlocks.push(block)
+        break
+      }
+      default: {
+        break
+      }
+    }
+  }
+
+  return { toolResults, textBlocks, imageBlocks }
+}
+
+const mergeImageBlocksIntoToolResult = (
+  toolResults: Array<AnthropicToolResultBlock>,
+  imageBlocks: Array<AnthropicImageBlock>,
+): Array<AnthropicToolResultBlock> => {
+  const lastIndex = toolResults.length - 1
+  return toolResults.map((tr, i) => {
+    if (i !== lastIndex) return tr
+    if (hasToolRef(tr)) return tr
+
+    if (typeof tr.content === "string") {
+      return {
+        ...tr,
+        content: [{ type: "text" as const, text: tr.content }, ...imageBlocks],
+      }
+    }
+
+    return {
+      ...tr,
+      content: [...tr.content, ...imageBlocks],
+    }
+  })
+}
+
 export const mergeToolResultForClaude = (
   anthropicPayload: AnthropicMessagesPayload,
   options?: {
@@ -177,24 +230,26 @@ export const mergeToolResultForClaude = (
 
     if (msg.role !== "user" || !Array.isArray(msg.content)) continue
 
-    const toolResults: Array<AnthropicToolResultBlock> = []
-    const textBlocks: Array<AnthropicTextBlock> = []
-    let valid = true
+    const { toolResults, textBlocks, imageBlocks } = scanUserContentBlocks(
+      msg.content,
+    )
 
-    for (const block of msg.content) {
-      if (block.type === "tool_result") {
-        toolResults.push(block)
-      } else if (block.type === "text") {
-        textBlocks.push(block)
-      } else {
-        valid = false
-        break
-      }
+    if (
+      toolResults.length === 0
+      || (textBlocks.length === 0 && imageBlocks.length === 0)
+    ) {
+      continue
     }
 
-    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
+    const merged =
+      textBlocks.length > 0 ?
+        mergeToolResult(toolResults, textBlocks)
+      : [...toolResults]
 
-    msg.content = mergeToolResult(toolResults, textBlocks)
+    msg.content =
+      imageBlocks.length > 0 ?
+        mergeImageBlocksIntoToolResult(merged, imageBlocks)
+      : merged
   }
 }
 


### PR DESCRIPTION
## Summary

- When users attach screenshots in Claude Code's `AskUserQuestion` responses, the message contains `image` blocks alongside `tool_result` and `text` blocks
- The existing `mergeToolResultForClaude` function sets `valid=false` on image blocks (treated as unknown type), preventing text blocks from being merged into `tool_result`
- This leaves non-`tool_result` blocks in the message, causing `isInitiateRequest=true` → `x-initiator: "user"` → upstream counts a new premium request
- **Each screenshot attached in a tool response costs an extra premium request**

## Changes

- Extract block scanning into `scanUserContentBlocks` helper using `switch` (also reduces cyclomatic complexity)
- Collect `image` blocks during message scanning instead of aborting the merge
- Add `mergeImageBlocksIntoToolResult` helper to append image blocks into the last `tool_result`'s content array
- After merging, the message content is all `tool_result` blocks → `isInitiateRequest=false` → `x-initiator: "agent"` → no premium consumption

## Reproduction

In a single Claude Code session using a premium model (e.g., Opus 4.7):
1. User sends initial message → 1 premium consumed (expected)
2. Claude calls `AskUserQuestion` → user answers with text only → no extra premium (correct)
3. Claude calls `AskUserQuestion` → user answers **with a screenshot** → **extra premium consumed** (bug)

Each screenshot-attached response adds +1 premium. A session with 3 screenshots = 4 premium total (1 initial + 3 screenshots).

## Test plan

- [x] All 74 existing tests pass
- [x] ESLint passes (preprocess.ts has 0 errors)
- [x] TypeScript type check passes
- [ ] Manual verification: run a session with screenshot-attached AskUserQuestion responses and confirm `x-initiator` stays `"agent"` for those requests