### PR TITLE
fix: sanitize is_error tool_result non-text content for Messages API

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -478,6 +478,59 @@ const hasToolRef = (block: AnthropicToolResultBlock) => {
   )
 }
 
+// The Messages API requires all content to be type `text` when is_error is true.
+// Extract non-text content (images, documents) from is_error tool results and
+// append them at the end of the message to preserve data while keeping all
+// tool_result blocks contiguous (required by the Messages API).
+const sanitizeErrorToolResults = (payload: AnthropicMessagesPayload): void => {
+  for (const msg of payload.messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue
+
+    const sanitized: Array<AnthropicUserContentBlock> = []
+    const extractedTail: Array<AnthropicUserContentBlock> = []
+    let changed = false
+
+    for (const block of msg.content) {
+      if (block.type !== "tool_result" || !block.is_error) {
+        sanitized.push(block)
+        continue
+      }
+
+      if (typeof block.content === "string") {
+        sanitized.push(block)
+        continue
+      }
+
+      const textContent: Array<AnthropicTextBlock> = []
+      const extracted: Array<AnthropicUserContentBlock> = []
+
+      for (const inner of block.content) {
+        if (inner.type === "text") {
+          textContent.push(inner)
+        } else if (inner.type === "image" || inner.type === "document") {
+          extracted.push(inner)
+        }
+      }
+
+      if (
+        extracted.length === 0
+        && textContent.length === block.content.length
+      ) {
+        sanitized.push(block)
+        continue
+      }
+
+      changed = true
+      sanitized.push({ ...block, content: textContent })
+      extractedTail.push(...extracted)
+    }
+
+    if (changed) {
+      msg.content = [...sanitized, ...extractedTail]
+    }
+  }
+}
+
 // Strip cache_control from system content blocks as the
 // Copilot Messages API does not support them (rejects extra fields like scope).
 // commit by nicktogo
@@ -522,6 +575,7 @@ export const prepareMessagesApiPayload = (
 ): void => {
   stripCacheControl(payload)
   filterAssistantThinkingBlocks(payload)
+  sanitizeErrorToolResults(payload)
 
   const hasThinking = Boolean(payload.thinking)
 

--- a/tests/messages-preprocess-sanitize-error.test.ts
+++ b/tests/messages-preprocess-sanitize-error.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test"
+
+import type { AnthropicMessagesPayload } from "../src/routes/messages/anthropic-types"
+
+import { prepareMessagesApiPayload } from "../src/routes/messages/preprocess"
+
+describe("sanitizeErrorToolResults - extraction", () => {
+  test("extracts image from is_error tool_result to message tail", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-err",
+              is_error: true,
+              content: [
+                { type: "text", text: "error occurred" },
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: "abc",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    const content = payload.messages[0].content as Array<
+      Record<string, unknown>
+    >
+    expect(content).toHaveLength(2)
+    expect(content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "tool-err",
+      is_error: true,
+      content: [{ type: "text", text: "error occurred" }],
+    })
+    expect(content[1]).toEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "abc" },
+    })
+  })
+
+  test("strips tool_reference from is_error tool_result", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-ref-err",
+              is_error: true,
+              content: [{ type: "tool_reference", tool_name: "SomeTool" }],
+            },
+          ],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    const content = payload.messages[0].content as Array<
+      Record<string, unknown>
+    >
+    expect(content).toHaveLength(1)
+    expect(content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "tool-ref-err",
+      is_error: true,
+      content: [],
+    })
+  })
+
+  test("keeps tool_results contiguous and appends extracted attachments to tail", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-err-1",
+              is_error: true,
+              content: [
+                { type: "text", text: "fail" },
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: "img1",
+                  },
+                },
+              ],
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-ok",
+              content: "success",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-err-2",
+              is_error: true,
+              content: [
+                {
+                  type: "document",
+                  source: {
+                    type: "base64",
+                    media_type: "application/pdf",
+                    data: "pdf1",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    const content = payload.messages[0].content as Array<
+      Record<string, unknown>
+    >
+    expect(content).toHaveLength(5)
+    expect(content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tool-err-1",
+      is_error: true,
+    })
+    expect(content[1]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tool-ok",
+    })
+    expect(content[2]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tool-err-2",
+      is_error: true,
+    })
+    expect(content[3]).toMatchObject({ type: "image" })
+    expect(content[4]).toMatchObject({ type: "document" })
+  })
+})
+
+describe("sanitizeErrorToolResults - passthrough", () => {
+  test("does not modify is_error tool_result with string content", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-str",
+              is_error: true,
+              content: "plain error text",
+            },
+          ],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    const content = payload.messages[0].content as Array<
+      Record<string, unknown>
+    >
+    expect(content).toHaveLength(1)
+    expect(content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "tool-str",
+      is_error: true,
+      content: "plain error text",
+    })
+  })
+
+  test("does not modify non-error tool_result with image content", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-ok",
+              content: [
+                { type: "text", text: "result" },
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: "img",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    const content = payload.messages[0].content as Array<
+      Record<string, unknown>
+    >
+    expect(content).toHaveLength(1)
+    const inner = (content[0] as { content: Array<unknown> }).content
+    expect(inner).toHaveLength(2)
+  })
+})

--- a/tests/messages-preprocess-sanitize-error.test.ts
+++ b/tests/messages-preprocess-sanitize-error.test.ts
@@ -36,7 +36,7 @@ describe("sanitizeErrorToolResults - extraction", () => {
 
     prepareMessagesApiPayload(payload)
 
-    const content = payload.messages[0].content as Array<
+    const content = payload.messages[0].content as unknown as Array<
       Record<string, unknown>
     >
     expect(content).toHaveLength(2)
@@ -73,7 +73,7 @@ describe("sanitizeErrorToolResults - extraction", () => {
 
     prepareMessagesApiPayload(payload)
 
-    const content = payload.messages[0].content as Array<
+    const content = payload.messages[0].content as unknown as Array<
       Record<string, unknown>
     >
     expect(content).toHaveLength(1)
@@ -136,7 +136,7 @@ describe("sanitizeErrorToolResults - extraction", () => {
 
     prepareMessagesApiPayload(payload)
 
-    const content = payload.messages[0].content as Array<
+    const content = payload.messages[0].content as unknown as Array<
       Record<string, unknown>
     >
     expect(content).toHaveLength(5)
@@ -181,7 +181,7 @@ describe("sanitizeErrorToolResults - passthrough", () => {
 
     prepareMessagesApiPayload(payload)
 
-    const content = payload.messages[0].content as Array<
+    const content = payload.messages[0].content as unknown as Array<
       Record<string, unknown>
     >
     expect(content).toHaveLength(1)
@@ -223,7 +223,7 @@ describe("sanitizeErrorToolResults - passthrough", () => {
 
     prepareMessagesApiPayload(payload)
 
-    const content = payload.messages[0].content as Array<
+    const content = payload.messages[0].content as unknown as Array<
       Record<string, unknown>
     >
     expect(content).toHaveLength(1)


### PR DESCRIPTION
## Summary
- Fix 400 error when `is_error` tool_result contains non-text content (image/document/tool_reference)
- The Claude Messages API requires all content to be type `text` when `is_error` is true
- Extract non-text content from `is_error` tool results and append to message tail, preserving data without breaking tool_result contiguity

## Changes
- Add `sanitizeErrorToolResults()` in `prepareMessagesApiPayload()` — only affects Messages API path, does not impact Responses or Chat Completions endpoints
- Handle `tool_reference` blocks in `is_error` tool results (strip them as they are not valid user content)
- Add 5 regression tests covering: `is_error` + image, `is_error` + tool_reference, multiple tool_results ordering, string content passthrough, non-error tool_result passthrough

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 90 tests pass (85 existing + 5 new)
- [x] New tests verify all edge cases for `is_error` tool_result sanitization