### PR TITLE
fix: exclude is_error tool_result from attachment merge

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -168,7 +168,7 @@ const getMergeableToolResultIndices = (
   toolResults: Array<AnthropicToolResultBlock>,
 ): Array<number> => {
   return toolResults.flatMap((block, index) =>
-    hasToolRef(block) ? [] : [index],
+    block.is_error || hasToolRef(block) ? [] : [index],
   )
 }
 


### PR DESCRIPTION
## Summary
- Prevent non-text content (images, documents) from being merged into `is_error` tool_result blocks
- The Claude Messages API requires all content to be type `text` when `is_error` is true
- One-line fix as suggested by @caozhiyuan in #195

## Changes
- Add `block.is_error` check in `getMergeableToolResultIndices()` to exclude error tool results from attachment merge targets

## Trade-off
- This approach may cause image/document attachments to be silently dropped when the only available tool_result targets have `is_error: true`
- See PR #196 for an alternative approach that preserves attachments by extracting them to the message tail

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test` — 85 tests pass

Closes #195