### PR TITLE
fix: skip [DONE] terminator in messages API stream

### DIFF
--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -252,6 +252,12 @@ export const handleWithMessagesApi = async (
       for await (const event of response) {
         const eventName = event.event
         const data = event.data ?? ""
+        if (data === "[DONE]") {
+          break
+        }
+        if (!data) {
+          continue
+        }
         debugLazy(logger, () => ["Messages raw stream event:", data])
         await stream.writeSSE({
           event: eventName,


### PR DESCRIPTION
When streaming through the `/v1/messages` endpoint (`handleWithMessagesApi`), the backend appends a `data: [DONE]` terminator after `message_stop`: an openAI streaming convention.

added skipping `[DONE]` and empty `data` lines in the messages API flow, matching the existing behavior in `handleWithChatCompletions` which already handled this.