### PR TITLE
feat: append [1m] suffix to 1M context window models in /v1/models

### DIFF
--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -13,16 +13,22 @@ modelRoutes.get("/", async (c) => {
       await cacheModels()
     }
 
-    const models = state.models?.data.map((model) => ({
-      ...model,
-      id: model.id,
-      object: "model",
-      type: "model",
-      created: 0, // No date available from source
-      created_at: new Date(0).toISOString(), // No date available from source
-      owned_by: model.vendor,
-      display_name: model.name,
-    }))
+    const models = state.models?.data.map((model) => {
+      // limits is typed as required but is missing for embedding models at runtime
+      const is1m =
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        model.capabilities.limits?.max_context_window_tokens === 1_000_000
+      return {
+        ...model,
+        id: is1m ? `${model.id}[1m]` : model.id,
+        object: "model",
+        type: "model",
+        created: 0, // No date available from source
+        created_at: new Date(0).toISOString(), // No date available from source
+        owned_by: model.vendor,
+        display_name: model.name,
+      }
+    })
 
     return c.json({
       object: "list",


### PR DESCRIPTION
## Summary

Claude Code (CC) uses the `[1m]` suffix on model IDs to identify models with a 1M-token context window in its `/model` picker. Without the suffix, models served via `/v1/models` from this gateway are not treated as 1M-context capable by CC, even when the upstream Copilot model truly has a 1M context window.

This change appends `[1m]` to the `id` returned by `/v1/models` when the upstream model's `capabilities.limits.max_context_window_tokens === 1_000_000`. All other models are unchanged.

CC strips the `[1m]` suffix before sending the model in API requests, so no incoming-side handling is required.

### Example output

Before:
```
claude-opus-4.6-1m              ctx_window=1000000
claude-opus-4.7-1m-internal     ctx_window=1000000
claude-opus-4.6                 ctx_window=200000
```

After:
```
claude-opus-4.6-1m[1m]            ctx_window=1000000
claude-opus-4.7-1m-internal[1m]   ctx_window=1000000
claude-opus-4.6                   ctx_window=200000
```

## Test plan

- [x] Built Docker image from rebased branch (on top of `dev`) and replaced running container
- [x] Verified `GET /v1/models` returns `[1m]` suffix only on models with `max_context_window_tokens === 1_000_000`
- [x] Verified other models (200k, 400k, 128k context) are unchanged
- [x] Verified end-to-end with Claude Code: `/model` picker shows the `[1m]`-tagged variant and selecting it correctly routes to the upstream 1M model