### PR TITLE
fix: Fix missing object attribute in openai /chat/completions

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -74,7 +74,12 @@ export async function handleCompletion(c: Context) {
   if (isNonStreaming(response)) {
     debugJson(logger, "Non-streaming response:", response)
     recordUsage(normalizeOpenAIUsage(response.usage))
-    return c.json(response)
+    // Ensure the response includes the required "object" field for OpenAI compatibility
+    const completionResponse = {
+      ...response,
+      object: "chat.completion" as const,
+    }
+    return c.json(completionResponse)
   }
 
   logger.debug("Streaming response")

--- a/tests/chat-completions-handler.test.ts
+++ b/tests/chat-completions-handler.test.ts
@@ -118,4 +118,25 @@ describe("chat completions handler", () => {
     })
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  test("non-streaming response includes object: 'chat.completion'", async () => {
+    const app = createApp()
+    const response = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-test",
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    const json = await response.json()
+    expect(json).toHaveProperty("object", "chat.completion")
+    // Optionally, check other required fields
+    expect(json).toHaveProperty("id")
+    expect(json).toHaveProperty("choices")
+  })
 })


### PR DESCRIPTION
## Description
Fix missing `"object": "chat.completion"` field in `/v1/chat/completions` endpoint response.

## Problem
The endpoint returns JSON without the required `"object": "chat.completion"` field, causing validation errors in OpenAI-compatible clients (Pydantic-AI, LangChain, etc.).

## Solution
Explicitly add `"object": "chat.completion"` to the response before returning it to ensure full OpenAI API specification compliance.

## Testing
Clients like Pydantic-AI no longer fail with:

```shell
Input should be 'chat.completion' [type=literal_error, input_value=None, input_type=NoneType]
```