### PR TITLE
fix: catch responses websocket stream errors and forward error event to client

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -81,13 +81,29 @@ export async function handleCompletion(c: Context) {
   return streamSSE(c, async (stream) => {
     let usage: UsageTokens = {}
 
-    for await (const chunk of response) {
-      debugJson(logger, "Streaming chunk:", chunk)
-      const parsedChunk = parseChatCompletionChunk(chunk)
-      if (parsedChunk?.usage) {
-        usage = normalizeOpenAIUsage(parsedChunk.usage)
+    try {
+      for await (const chunk of response) {
+        debugJson(logger, "Streaming chunk:", chunk)
+        const parsedChunk = parseChatCompletionChunk(chunk)
+        if (parsedChunk?.usage) {
+          usage = normalizeOpenAIUsage(parsedChunk.usage)
+        }
+        await stream.writeSSE(chunk as SSEMessage)
       }
-      await stream.writeSSE(chunk as SSEMessage)
+    } catch (streamError) {
+      logger.warn("Chat completions stream error:", streamError)
+      const errorMessage =
+        streamError instanceof Error ?
+          streamError.message
+        : "Chat completions stream error"
+      await stream.writeSSE({
+        data: JSON.stringify({
+          error: { message: errorMessage, type: "server_error", code: null },
+        }),
+      })
+      await stream.writeSSE({ data: "[DONE]" })
+      recordUsage(usage)
+      return
     }
 
     recordUsage(usage)

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -226,43 +226,60 @@ export const handleWithResponsesApi = async (
       })
       let usage: UsageTokens = {}
 
-      for await (const chunk of response) {
-        const eventName = chunk.event
-        if (eventName === "ping") {
-          await stream.writeSSE({ event: "ping", data: '{"type":"ping"}' })
-          continue
+      try {
+        for await (const chunk of response) {
+          const eventName = chunk.event
+          if (eventName === "ping") {
+            await stream.writeSSE({ event: "ping", data: '{"type":"ping"}' })
+            continue
+          }
+
+          const data = chunk.data
+          if (!data) {
+            continue
+          }
+
+          debugLazy(logger, () => ["Responses raw stream event:", data])
+
+          const responseEvent = JSON.parse(data) as ResponseStreamEvent
+          if (
+            responseEvent.type === "response.completed"
+            || responseEvent.type === "response.failed"
+            || responseEvent.type === "response.incomplete"
+          ) {
+            usage = normalizeResponsesUsage(responseEvent.response.usage)
+          }
+
+          const events = translateResponsesStreamEvent(responseEvent, streamState)
+          for (const event of events) {
+            const eventData = JSON.stringify(event)
+            debugLazy(logger, () => ["Translated Anthropic event:", eventData])
+            await stream.writeSSE({
+              event: event.type,
+              data: eventData,
+            })
+          }
+
+          if (streamState.messageCompleted) {
+            logger.debug("Message completed, ending stream")
+            break
+          }
         }
-
-        const data = chunk.data
-        if (!data) {
-          continue
-        }
-
-        debugLazy(logger, () => ["Responses raw stream event:", data])
-
-        const responseEvent = JSON.parse(data) as ResponseStreamEvent
-        if (
-          responseEvent.type === "response.completed"
-          || responseEvent.type === "response.failed"
-          || responseEvent.type === "response.incomplete"
-        ) {
-          usage = normalizeResponsesUsage(responseEvent.response.usage)
-        }
-
-        const events = translateResponsesStreamEvent(responseEvent, streamState)
-        for (const event of events) {
-          const eventData = JSON.stringify(event)
-          debugLazy(logger, () => ["Translated Anthropic event:", eventData])
+      } catch (streamError) {
+        logger.warn("Responses stream error:", streamError)
+        if (!streamState.messageCompleted) {
+          const errorMessage =
+            streamError instanceof Error ?
+              streamError.message
+            : "Responses stream error"
+          const errorEvent = buildErrorEvent(errorMessage)
           await stream.writeSSE({
-            event: event.type,
-            data: eventData,
+            event: errorEvent.type,
+            data: JSON.stringify(errorEvent),
           })
         }
-
-        if (streamState.messageCompleted) {
-          logger.debug("Message completed, ending stream")
-          break
-        }
+        recordUsage(usage)
+        return
       }
 
       if (!streamState.messageCompleted) {

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -137,30 +137,45 @@ export const handleWithChatCompletions = async (
       thinkingBlockOpen: false,
     }
 
-    for await (const rawEvent of response) {
-      debugJson(logger, "Copilot raw stream event:", rawEvent)
-      if (rawEvent.data === "[DONE]") {
-        break
-      }
+    try {
+      for await (const rawEvent of response) {
+        debugJson(logger, "Copilot raw stream event:", rawEvent)
+        if (rawEvent.data === "[DONE]") {
+          break
+        }
 
-      if (!rawEvent.data) {
-        continue
-      }
+        if (!rawEvent.data) {
+          continue
+        }
 
-      const chunk = JSON.parse(rawEvent.data) as ChatCompletionChunk
-      if (chunk.usage) {
-        usage = normalizeOpenAIUsage(chunk.usage)
-      }
-      const events = translateChunkToAnthropicEvents(chunk, streamState)
+        const chunk = JSON.parse(rawEvent.data) as ChatCompletionChunk
+        if (chunk.usage) {
+          usage = normalizeOpenAIUsage(chunk.usage)
+        }
+        const events = translateChunkToAnthropicEvents(chunk, streamState)
 
-      for (const event of events) {
-        const eventData = JSON.stringify(event)
-        debugLazy(logger, () => ["Translated Anthropic event:", eventData])
-        await stream.writeSSE({
-          event: event.type,
-          data: eventData,
-        })
+        for (const event of events) {
+          const eventData = JSON.stringify(event)
+          debugLazy(logger, () => ["Translated Anthropic event:", eventData])
+          await stream.writeSSE({
+            event: event.type,
+            data: eventData,
+          })
+        }
       }
+    } catch (streamError) {
+      logger.warn("Chat completions stream error:", streamError)
+      const errorMessage =
+        streamError instanceof Error ?
+          streamError.message
+        : "Chat completions stream error"
+      const errorEvent = buildErrorEvent(errorMessage)
+      await stream.writeSSE({
+        event: errorEvent.type,
+        data: JSON.stringify(errorEvent),
+      })
+      recordUsage(usage)
+      return
     }
 
     for (const event of flushPendingAnthropicStreamEvents(streamState)) {
@@ -355,32 +370,47 @@ export const handleWithMessagesApi = async (
     return streamSSE(c, async (stream) => {
       let usage: UsageTokens = {}
 
-      for await (const event of response) {
-        const eventName = event.event
-        const data = event.data ?? ""
-        if (data === "[DONE]") {
-          break
+      try {
+        for await (const event of response) {
+          const eventName = event.event
+          const data = event.data ?? ""
+          if (data === "[DONE]") {
+            break
+          }
+          if (!data) {
+            continue
+          }
+          debugLazy(logger, () => ["Messages raw stream event:", data])
+          const parsedEvent = parseAnthropicStreamEvent(data)
+          if (parsedEvent?.type === "message_start") {
+            usage = mergeAnthropicUsage(
+              usage,
+              normalizeAnthropicUsage(parsedEvent.message.usage),
+            )
+          } else if (parsedEvent?.type === "message_delta") {
+            usage = mergeAnthropicUsage(
+              usage,
+              normalizeAnthropicUsage(parsedEvent.usage),
+            )
+          }
+          await stream.writeSSE({
+            event: eventName,
+            data,
+          })
         }
-        if (!data) {
-          continue
-        }
-        debugLazy(logger, () => ["Messages raw stream event:", data])
-        const parsedEvent = parseAnthropicStreamEvent(data)
-        if (parsedEvent?.type === "message_start") {
-          usage = mergeAnthropicUsage(
-            usage,
-            normalizeAnthropicUsage(parsedEvent.message.usage),
-          )
-        } else if (parsedEvent?.type === "message_delta") {
-          usage = mergeAnthropicUsage(
-            usage,
-            normalizeAnthropicUsage(parsedEvent.usage),
-          )
-        }
+      } catch (streamError) {
+        logger.warn("Messages API stream error:", streamError)
+        const errorMessage =
+          streamError instanceof Error ?
+            streamError.message
+          : "Messages API stream error"
+        const errorEvent = buildErrorEvent(errorMessage)
         await stream.writeSSE({
-          event: eventName,
-          data,
+          event: errorEvent.type,
+          data: JSON.stringify(errorEvent),
         })
+        recordUsage(usage)
+        return
       }
 
       recordUsage(usage)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -107,28 +107,48 @@ export const handleResponses = async (c: Context) => {
       const idTracker = createStreamIdTracker()
       let usage: UsageTokens = {}
 
-      for await (const chunk of response) {
-        debugJson(logger, "Responses stream chunk:", chunk)
-        const parsedEvent = parseResponsesStreamEvent(chunk)
-        if (
-          parsedEvent?.type === "response.completed"
-          || parsedEvent?.type === "response.failed"
-          || parsedEvent?.type === "response.incomplete"
-        ) {
-          usage = normalizeResponsesUsage(parsedEvent.response.usage)
+      try {
+        for await (const chunk of response) {
+          debugJson(logger, "Responses stream chunk:", chunk)
+          const parsedEvent = parseResponsesStreamEvent(chunk)
+          if (
+            parsedEvent?.type === "response.completed"
+            || parsedEvent?.type === "response.failed"
+            || parsedEvent?.type === "response.incomplete"
+          ) {
+            usage = normalizeResponsesUsage(parsedEvent.response.usage)
+          }
+
+          const processedData = fixStreamIds(
+            (chunk as { data?: string }).data ?? "",
+            (chunk as { event?: string }).event,
+            idTracker,
+          )
+
+          await stream.writeSSE({
+            id: (chunk as { id?: string }).id,
+            event: (chunk as { event?: string }).event,
+            data: processedData,
+          })
         }
-
-        const processedData = fixStreamIds(
-          (chunk as { data?: string }).data ?? "",
-          (chunk as { event?: string }).event,
-          idTracker,
-        )
-
+      } catch (streamError) {
+        logger.warn("Responses stream error:", streamError)
+        const errorMessage =
+          streamError instanceof Error ?
+            streamError.message
+          : "Responses stream error"
         await stream.writeSSE({
-          id: (chunk as { id?: string }).id,
-          event: (chunk as { event?: string }).event,
-          data: processedData,
+          event: "error",
+          data: JSON.stringify({
+            type: "error",
+            code: null,
+            message: errorMessage,
+            param: null,
+            sequence_number: 0,
+          }),
         })
+        recordUsage(usage)
+        return
       }
 
       recordUsage(usage)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -106,11 +106,18 @@ export const handleResponses = async (c: Context) => {
     return streamSSE(c, async (stream) => {
       const idTracker = createStreamIdTracker()
       let usage: UsageTokens = {}
+      let lastSequenceNumber = 0
 
       try {
         for await (const chunk of response) {
           debugJson(logger, "Responses stream chunk:", chunk)
           const parsedEvent = parseResponsesStreamEvent(chunk)
+          if (typeof parsedEvent?.sequence_number === "number") {
+            lastSequenceNumber = Math.max(
+              lastSequenceNumber,
+              parsedEvent.sequence_number,
+            )
+          }
           if (
             parsedEvent?.type === "response.completed"
             || parsedEvent?.type === "response.failed"
@@ -144,7 +151,7 @@ export const handleResponses = async (c: Context) => {
             code: null,
             message: errorMessage,
             param: null,
-            sequence_number: 0,
+            sequence_number: lastSequenceNumber + 1,
           }),
         })
         recordUsage(usage)

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -254,6 +254,46 @@ describe("responses handler token usage", () => {
     expect(createResponses.mock.calls[0][0].tools?.[0]).toEqual(applyPatchTool)
   })
 
+  test("uses the next sequence number for streaming error events", async () => {
+    createResponses.mockImplementation(() =>
+      Promise.resolve(
+        (async function* () {
+          yield {
+            data: JSON.stringify({
+              type: "response.output_text.delta",
+              sequence_number: 41,
+              output_index: 0,
+              content_index: 0,
+              delta: "hel",
+            }),
+            event: "response.output_text.delta",
+            id: "event_41",
+          }
+
+          throw new Error("socket hang up")
+        })(),
+      ),
+    )
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        input: "hello",
+        model: "gpt-test",
+        stream: true,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain(
+      '{"type":"error","code":null,"message":"socket hang up","param":null,"sequence_number":42}',
+    )
+  })
+
   test("records usage from failed streaming responses and falls back to interaction id", async () => {
     createResponses.mockImplementation(() =>
       Promise.resolve(


### PR DESCRIPTION
Fixes #246

## Problem

When using `gpt-5.4` (or any model using WebSocket transport), the WebSocket connection can be terminated mid-stream by VPN software dropping the TCP/TLS connection. This causes:

```
Error: Responses websocket stream error: 
    at createResponsesWebSocketError (...)
    at WebSocket.onError (...)
    ...
  [cause]: TypeError
      at #onSocketClose (...)
      at TLSSocket.onSocketClose (...)
      at TCP.done (node:_tls_wrap:650:7)
```

The error was thrown from the `for await` loop inside `streamSSE` callback and **escaped uncaught**, causing the SSE connection to close silently — no error event was sent to the client (Claude Code), resulting in an abrupt cutoff with no feedback.

## Fix

Wrap the `for await` loop in a `try-catch` inside `handleWithResponsesApi`. When a stream error is caught:
1. Log it with `logger.warn`
2. Send an Anthropic-format `error` SSE event to the client so Claude Code receives proper feedback instead of a silent disconnect
3. Record usage and return cleanly

## Workaround (for users)

While waiting for this fix, set `"useResponsesApiWebSocket": false` in `~/.local/share/copilot-api/config.json` to force HTTP transport and avoid WebSocket entirely.