### PR TITLE
fix(messages): skip claude-agent header rewrite for claude-opus-4.8

### DIFF
--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -111,7 +111,22 @@ export const createMessages = async (
     payload.metadata?.user_id,
   )
   // from claude code
-  if (safetyIdentifier && sessionId) {
+  //
+  // claude-opus-4.8 is excluded: Copilot's upstream WAF returns a generic
+  // "Access to this endpoint is forbidden" 403 whenever a request carries
+  // the Claude-Code-style user-agent without a `copilot-integration-id`
+  // header. The exact same header set is accepted on claude-opus-4.7, so
+  // the gate is a model-id rollout gap on Copilot's side. Skipping the
+  // rewrite for 4.8 keeps the default Copilot identity
+  // (copilot-integration-id: vscode-chat + GitHubCopilotChat UA +
+  // conversation-agent intent) in place; that path is 200. Remove this
+  // skip once Copilot's upstream accepts the Claude-Code identity on 4.8.
+  // Probed 2026-05-29.
+  if (
+    safetyIdentifier &&
+    sessionId &&
+    payload.model !== "claude-opus-4.8"
+  ) {
     prepareMessageProxyHeaders(headers)
   }
 


### PR DESCRIPTION
Copilot's upstream WAF returns a generic 403 ("Access to this endpoint is forbidden") whenever a request to claude-opus-4.8 carries the Claude-Code-style user-agent without a `copilot-integration-id` header. The exact same header set is accepted on claude-opus-4.7, so this is a model-id rollout gap on Copilot's side, not a policy choice ours.

Skipping prepareMessageProxyHeaders for claude-opus-4.8 keeps the default Copilot identity (copilot-integration-id: vscode-chat + GitHubCopilotChat UA + conversation-agent intent), which is accepted.

Probe matrix (claude-opus-4.8, otherwise identical Copilot base headers, tiny dummy body):

  user-agent          intent              integration-id   result
  vscode_claude_code  messages-proxy      (deleted)        403
  vscode_claude_code  conversation-agent  (deleted)        403
  vscode_claude_code  messages-proxy      vscode-chat      200
  GitHubCopilotChat   messages-proxy      (deleted)        200
  GitHubCopilotChat   conversation-agent  vscode-chat      200

Same matrix on claude-opus-4.7 returns 200 in every cell. Remove this skip once Copilot's upstream accepts the Claude-Code identity on 4.8.