### PR TITLE
feat: periodically refresh /models cache so long-running daemons pick up new SKUs

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,9 +20,22 @@ export const sleep = (ms: number) =>
 export const isNullish = (value: unknown): value is null | undefined =>
   value === null || value === undefined
 
-export async function cacheModels(): Promise<void> {
-  const models = await getCopilotModels()
+// Periodically refresh models so long-running daemons pick up new SKUs.
+const MODELS_REFRESH_BASE_MS = 30 * 60 * 1000
+let modelsRefreshTimer: ReturnType<typeof setTimeout> | null = null
 
+export const stopModelsRefreshLoop = () => {
+  if (modelsRefreshTimer) {
+    clearTimeout(modelsRefreshTimer)
+    modelsRefreshTimer = null
+  }
+}
+
+type ModelsFetcher = typeof getCopilotModels
+
+const refreshModels = async (fetcher: ModelsFetcher) => {
+  const prevIds = new Set(state.models?.data.map((m) => m.id) ?? [])
+  const models = await fetcher()
   state.models = {
     ...models,
     data: models.data.filter(
@@ -30,6 +43,40 @@ export async function cacheModels(): Promise<void> {
         model.model_picker_enabled || model.capabilities.type === "embeddings",
     ),
   }
+  const nextIds = state.models.data.map((m) => m.id)
+  const added = nextIds.filter((id) => !prevIds.has(id))
+  if (added.length > 0) {
+    consola.info(`Models refresh: ${added.length} new -- ${added.join(", ")}`)
+  } else {
+    consola.debug(`Models refresh: no changes (${nextIds.length} total)`)
+  }
+}
+
+const scheduleModelsRefresh = (fetcher: ModelsFetcher, intervalMs: number) => {
+  const jitter = Math.floor(Math.random() * (intervalMs / 6))
+  const delay = intervalMs + jitter
+  consola.debug(
+    `Scheduling next models refresh in ${Math.round(delay / 1000)} seconds`,
+  )
+
+  stopModelsRefreshLoop()
+  modelsRefreshTimer = setTimeout(async () => {
+    try {
+      await refreshModels(fetcher)
+    } catch (error) {
+      consola.warn("Failed to refresh models, keeping previous cache.", error)
+    } finally {
+      scheduleModelsRefresh(fetcher, intervalMs)
+    }
+  }, delay)
+}
+
+export async function cacheModels(
+  fetcher: ModelsFetcher = getCopilotModels,
+  intervalMs: number = MODELS_REFRESH_BASE_MS,
+): Promise<void> {
+  await refreshModels(fetcher)
+  scheduleModelsRefresh(fetcher, intervalMs)
 }
 
 export const cacheVSCodeVersion = async () => {

--- a/tests/models-refresh.test.ts
+++ b/tests/models-refresh.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test"
+
+import { state } from "../src/lib/state"
+import { cacheModels, sleep, stopModelsRefreshLoop } from "../src/lib/utils"
+
+const makeModels = (ids: Array<string>) => ({
+  data: ids.map((id) => ({
+    id,
+    model_picker_enabled: true,
+    capabilities: { type: "chat" as const },
+  })),
+})
+
+const fetcherMock = mock(() => Promise.resolve(makeModels(["m1"])))
+
+// Short interval so the background timer fires within test timeouts; 50ms
+// is small enough for wait(200ms) to observe one tick yet not a tight loop
+// if a stray timer leaks past the afterEach.
+const TEST_INTERVAL_MS = 50
+
+beforeEach(() => {
+  state.models = undefined
+  fetcherMock.mockClear()
+  fetcherMock.mockImplementation(() => Promise.resolve(makeModels(["m1"])))
+})
+
+afterEach(() => {
+  stopModelsRefreshLoop()
+})
+
+test("cacheModels populates state.models on first call", async () => {
+  await cacheModels(fetcherMock as never, TEST_INTERVAL_MS)
+  expect(state.models?.data.map((m) => m.id)).toEqual(["m1"])
+  expect(fetcherMock).toHaveBeenCalledTimes(1)
+})
+
+test("background timer picks up newly-rolled-out models", async () => {
+  await cacheModels(fetcherMock as never, TEST_INTERVAL_MS)
+  expect(state.models?.data.map((m) => m.id)).toEqual(["m1"])
+
+  fetcherMock.mockImplementation(() =>
+    Promise.resolve(makeModels(["m1", "m2"])),
+  )
+
+  await sleep(200)
+
+  expect(fetcherMock.mock.calls.length).toBeGreaterThan(1)
+  expect(state.models?.data.map((m) => m.id)).toContain("m2")
+})
+
+test("refresh failure keeps the previous cache", async () => {
+  await cacheModels(fetcherMock as never, TEST_INTERVAL_MS)
+  const before = state.models
+
+  fetcherMock.mockImplementation(() =>
+    Promise.reject(new Error("upstream blip")),
+  )
+
+  await sleep(500)
+
+  expect(state.models).toEqual(before)
+})
+
+test("stopModelsRefreshLoop prevents further refreshes", async () => {
+  await cacheModels(fetcherMock as never, TEST_INTERVAL_MS)
+  stopModelsRefreshLoop()
+  const callsAfterStop = fetcherMock.mock.calls.length
+
+  await sleep(500)
+
+  expect(fetcherMock.mock.calls.length).toBe(callsAfterStop)
+})


### PR DESCRIPTION
## Problem

`cacheModels()` is awaited once during `runServer` startup (`src/start.ts:81`) and parked on `state.models` for the lifetime of the process. The request path only ever falls back via `if (!state.models) await cacheModels()` (`src/routes/models/route.ts:11`), and `state.models` is set on first fetch, so in practice the cache is never refreshed.

That's a great fit for the canonical short-lived CLI use case (`bun start` -> use -> exit). It breaks down when copilot-api runs as a long-lived daemon (systemd / NSSM service / docker container):

GitHub rolls out new SKUs to the Copilot backend continuously. Yesterday `claude-opus-4.8` appeared in `api.enterprise.githubcopilot.com/models` for my account, but the proxy I'd had running for ~36h kept returning the stale list. Clients had to wait for a manual restart.

## Fix

Add a periodic refresh loop following the exact shape already used by `scheduleSessionIdRefresh` in the same file (`src/lib/utils.ts:145`):

- Base 30min + jitter up to `base / 6` (5min in prod), single reusable timer, recurse via `setTimeout` (not `setInterval`, to avoid overlapping in-flight calls).
- Failures keep the prior cache and reschedule -- `state.models` must not flip to null, because the request-path fallback would then synchronously re-fetch on the hot path.
- Newly-appeared models log at `info`; no-change ticks at `debug`.

`cacheModels()` gains two optional params `(fetcher?, intervalMs?)` purely as test seams. Production call sites (`start.ts`, `routes/models/route.ts`) call it with no args and behave identically to before.

## Test plan

Added `tests/models-refresh.test.ts` -- 4 cases, ~1.3s total:
- `cacheModels` populates `state.models` on first call
- Background timer picks up newly-rolled-out models (mock fetcher swap -> wait one tick -> assert new id appears)
- Refresh failure keeps the previous cache (mock fetcher rejects -> assert `state.models` unchanged)
- `stopModelsRefreshLoop` prevents further refreshes

Full suite: `bun test` -> **242/242 pass**. Lint: `bun run lint` clean.

Also ran an end-to-end smoke test against my real GitHub Copilot account, with the interval bumped to 3s, observed:

```
ℹ Models refresh: 28 new -- claude-opus-4.7, claude-opus-4.8, ...
⚙ Scheduling next models refresh in 3 seconds
⚙ Models refresh: no changes (28 total)
⚙ Scheduling next models refresh in 3 seconds
⚙ Models refresh: no changes (28 total)
```

Stop is clean, no timer leak (process exits immediately).

## Notes

- Zero impact on the short-lived CLI use case: `cacheModels()` still resolves only after the first fetch completes; the background timer is a no-op if the process exits before it fires.
- No new public API surface beyond the optional params and `stopModelsRefreshLoop` (mirrors the existing `stopVsCodeSessionRefreshLoop`).
- I deliberately didn't extract a shared `schedulePeriodicRefresh` helper with `scheduleSessionIdRefresh` -- only two call sites, and the async/error-handling shapes differ enough that the helper would carry several flags. Happy to refactor if you'd rather.