### PR TITLE
fix(responses): guard input images against 413 payload errors

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -21,6 +21,7 @@ import {
   type ResponsesResult,
   type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
+import { HTTPError } from "~/lib/error"
 
 import { createStreamIdTracker, fixStreamIds } from "./stream-id-sync"
 import {
@@ -28,6 +29,8 @@ import {
   compactInputByLatestCompaction,
   getResponsesTransportForModel,
   getResponsesRequestOptions,
+  sanitizeAllInputImages,
+  sanitizeOversizedInputImages,
 } from "./utils"
 
 const logger = createHandlerLogger("responses-handler")
@@ -91,6 +94,16 @@ export const handleResponses = async (c: Context) => {
     )
   }
 
+  const sanitizedImageCount = sanitizeOversizedInputImages(
+    payload,
+    selectedModel?.capabilities.limits.vision?.max_prompt_image_size,
+  )
+  if (sanitizedImageCount > 0) {
+    logger.warn(
+      `Omitted ${sanitizedImageCount} oversized input image(s) before forwarding to Copilot Responses`,
+    )
+  }
+
   applyResponsesApiContextManagement(
     payload,
     selectedModel?.capabilities.limits.max_prompt_tokens,
@@ -104,13 +117,41 @@ export const handleResponses = async (c: Context) => {
     await awaitApproval()
   }
 
-  const response = await responsesHandlerDependencies.createResponses(payload, {
+  const responseOptions = {
     vision,
     initiator,
     requestId,
     sessionId: sessionId,
     transport: responsesTransport,
-  })
+  }
+  let response: Awaited<ReturnType<typeof createCopilotResponses>>
+  try {
+    response = await responsesHandlerDependencies.createResponses(
+      payload,
+      responseOptions,
+    )
+  } catch (error) {
+    if (!(error instanceof HTTPError) || error.response.status !== 413) {
+      throw error
+    }
+
+    const retrySanitizedImageCount = sanitizeAllInputImages(payload)
+    if (retrySanitizedImageCount === 0) {
+      throw error
+    }
+
+    logger.warn(
+      `Omitted ${retrySanitizedImageCount} input image(s) after Copilot Responses rejected the payload as too large`,
+    )
+    const retryOptions = {
+      ...responseOptions,
+      vision: getResponsesRequestOptions(payload).vision,
+    }
+    response = await responsesHandlerDependencies.createResponses(
+      payload,
+      retryOptions,
+    )
+  }
 
   if (isStreamingRequested(payload) && isAsyncIterable(response)) {
     logger.debug("Forwarding native Responses stream")

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -80,6 +80,26 @@ export const hasVisionInput = (payload: ResponsesPayload): boolean => {
 const DATA_URL_PREFIX = "data:"
 const BASE64_MARKER = ";base64,"
 const IMAGE_MEDIA_TYPE_PATTERN = /^image\/[a-zA-Z0-9.+-]+$/
+// Static 96x32 PNG reading "Image too large / Redacted".
+const REDACTED_IMAGE_PLACEHOLDER_DATA_URL =
+  "data:image/png;base64,"
+  + [
+    "iVBORw0KGgoAAAANSUhEUgAAAGAAAAAgCAMAAADaHo1mAAADAFBMVEX///8fKTfR1dsAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "AAAAAAAAAAAAAAAAAAAAAACae8QWAAAAvElEQVR42u1WixKAIAhj/f9Hdz2BXJiVed3pVSYtpgwsGSo3GaRq6wSd4F8EyIJx",
+    "ydSUAMB8il51sHT2fiVQu8czguQwXWAyFvswIJhmoS9gmzYlcFiHj1aAgzcJVgCyguYhAhNZmMhYQZs1EJnnIAqKiuHjSrZT",
+    "ucSQ4s8JkKDDIYr3IuR8vEWgqroKP9b1bYKk2wfgeVmqATQLXdXamsXdEKkz3QXEEeTTuWWImMhW6qci94/+hwSVf99HqVoD",
+    "OAuj2SEAAAAASUVORK5CYII=",
+  ].join("")
 
 export const sanitizeOversizedInputImages = (
   payload: ResponsesPayload,
@@ -97,7 +117,7 @@ export const sanitizeOversizedInputImages = (
   let count = 0
   for (const image of collectInputImageDataUrls(payload.input)) {
     if (limit !== undefined && image.decodedBytes > limit) {
-      replaceInputImageWithText(image, `max ${limit} bytes`)
+      replaceInputImageWithPlaceholder(image)
       count += 1
     }
   }
@@ -112,7 +132,7 @@ export const sanitizeAllInputImages = (payload: ResponsesPayload): number => {
 
   let count = 0
   for (const image of collectInputImageDataUrls(payload.input)) {
-    replaceInputImageWithText(image, "upstream rejected payload as too large")
+    replaceInputImageWithPlaceholder(image)
     count += 1
   }
   return count
@@ -204,15 +224,12 @@ const getBase64DecodedByteLength = (
   return Math.max(0, Math.floor((base64Length * 3) / 4) - padding)
 }
 
-const replaceInputImageWithText = (
-  image: InputImageDataUrl,
-  reason: string,
-): void => {
-  image.record.type = "input_text"
-  image.record.text = `[omitted input image: ${image.mediaType}, ${image.decodedBytes} bytes, ${reason}]`
-  delete image.record.image_url
+const replaceInputImageWithPlaceholder = (image: InputImageDataUrl): void => {
+  image.record.type = "input_image"
+  image.record.image_url = REDACTED_IMAGE_PLACEHOLDER_DATA_URL
+  image.record.detail = "low"
+  delete image.record.text
   delete image.record.file_id
-  delete image.record.detail
 }
 
 export const resolveResponsesCompactThreshold = (

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -77,7 +77,9 @@ export const hasVisionInput = (payload: ResponsesPayload): boolean => {
   return values.some((item) => containsVisionContent(item))
 }
 
-const IMAGE_DATA_URL_PATTERN = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.*)$/s
+const DATA_URL_PREFIX = "data:"
+const BASE64_MARKER = ";base64,"
+const IMAGE_MEDIA_TYPE_PATTERN = /^image\/[a-zA-Z0-9.+-]+$/
 
 export const sanitizeOversizedInputImages = (
   payload: ResponsesPayload,
@@ -163,19 +165,43 @@ const getInputImageDataUrl = (
     return null
   }
 
-  const match = record.image_url.match(IMAGE_DATA_URL_PATTERN)
-  if (!match) {
+  const imageUrl = record.image_url
+  const base64MarkerIndex = imageUrl.indexOf(BASE64_MARKER)
+  if (
+    !imageUrl.startsWith(DATA_URL_PREFIX)
+    || base64MarkerIndex <= DATA_URL_PREFIX.length
+  ) {
     return null
   }
 
-  const mediaType = match[1]
-  const decodedBytes = Buffer.byteLength(match[2], "base64")
+  const mediaType = imageUrl.slice(DATA_URL_PREFIX.length, base64MarkerIndex)
+  if (!IMAGE_MEDIA_TYPE_PATTERN.test(mediaType)) {
+    return null
+  }
+
+  const decodedBytes = getBase64DecodedByteLength(
+    imageUrl,
+    base64MarkerIndex + BASE64_MARKER.length,
+  )
 
   return {
     decodedBytes,
     mediaType,
     record,
   }
+}
+
+const getBase64DecodedByteLength = (
+  value: string,
+  base64Start: number,
+): number => {
+  const base64Length = value.length - base64Start
+  const padding =
+    value.endsWith("==") ? 2
+    : value.endsWith("=") ? 1
+    : 0
+
+  return Math.max(0, Math.floor((base64Length * 3) / 4) - padding)
 }
 
 const replaceInputImageWithText = (

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -77,6 +77,118 @@ export const hasVisionInput = (payload: ResponsesPayload): boolean => {
   return values.some((item) => containsVisionContent(item))
 }
 
+const IMAGE_DATA_URL_PATTERN = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.*)$/s
+
+export const sanitizeOversizedInputImages = (
+  payload: ResponsesPayload,
+  maxPromptImageSize?: number,
+): number => {
+  const limit =
+    typeof maxPromptImageSize === "number" && maxPromptImageSize > 0 ?
+      maxPromptImageSize
+    : undefined
+
+  if (!payload.input) {
+    return 0
+  }
+
+  let count = 0
+  for (const image of collectInputImageDataUrls(payload.input)) {
+    if (limit !== undefined && image.decodedBytes > limit) {
+      replaceInputImageWithText(image, `max ${limit} bytes`)
+      count += 1
+    }
+  }
+
+  return count
+}
+
+export const sanitizeAllInputImages = (payload: ResponsesPayload): number => {
+  if (!payload.input) {
+    return 0
+  }
+
+  let count = 0
+  for (const image of collectInputImageDataUrls(payload.input)) {
+    replaceInputImageWithText(image, "upstream rejected payload as too large")
+    count += 1
+  }
+  return count
+}
+
+interface InputImageDataUrl {
+  decodedBytes: number
+  mediaType: string
+  record: Record<string, unknown>
+}
+
+const collectInputImageDataUrls = (
+  value: unknown,
+  images: Array<InputImageDataUrl> = [],
+): Array<InputImageDataUrl> => {
+  if (!value) {
+    return images
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectInputImageDataUrls(entry, images)
+    }
+    return images
+  }
+
+  if (typeof value !== "object") {
+    return images
+  }
+
+  const record = value as Record<string, unknown>
+  const image = getInputImageDataUrl(record)
+  if (image) {
+    images.push(image)
+    return images
+  }
+
+  for (const key of Object.keys(record)) {
+    collectInputImageDataUrls(record[key], images)
+  }
+  return images
+}
+
+const getInputImageDataUrl = (
+  record: Record<string, unknown>,
+): InputImageDataUrl | null => {
+  const type =
+    typeof record.type === "string" ? record.type.toLowerCase() : undefined
+  if (type !== "input_image" || typeof record.image_url !== "string") {
+    return null
+  }
+
+  const match = record.image_url.match(IMAGE_DATA_URL_PATTERN)
+  if (!match) {
+    return null
+  }
+
+  const mediaType = match[1]
+  const decodedBytes = Buffer.byteLength(match[2], "base64")
+
+  return {
+    decodedBytes,
+    mediaType,
+    record,
+  }
+}
+
+const replaceInputImageWithText = (
+  image: InputImageDataUrl,
+  reason: string,
+): void => {
+  image.record.type = "input_text"
+  image.record.text = `[omitted input image: ${image.mediaType}, ${image.decodedBytes} bytes, ${reason}]`
+  delete image.record.image_url
+  delete image.record.file_id
+  delete image.record.detail
+}
+
 export const resolveResponsesCompactThreshold = (
   maxPromptTokens?: number,
 ): number => {

--- a/src/services/copilot/get-models.ts
+++ b/src/services/copilot/get-models.ts
@@ -31,6 +31,11 @@ interface ModelLimits {
   max_output_tokens?: number
   max_prompt_tokens?: number
   max_inputs?: number
+  vision?: {
+    max_prompt_image_size?: number
+    max_prompt_images?: number
+    supported_media_types?: Array<string>
+  }
 }
 
 interface ModelSupports {

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 
 import type { createResponses as createCopilotResponses } from "../src/services/copilot/create-responses"
+import { HTTPError } from "../src/lib/error"
 
 let responsesApiWebSocketEnabled = true
 
@@ -27,6 +28,17 @@ const createResponsesResult = (model: string) => ({
   top_p: null,
   usage: null,
 })
+
+const createPayloadTooLargeError = () =>
+  new HTTPError(
+    "Failed to create responses",
+    new Response(
+      JSON.stringify({
+        error: { code: "", message: "failed to parse request" },
+      }),
+      { status: 413 },
+    ),
+  )
 
 const { state } = await import("../src/lib/state")
 const { closeUsageStore } = await import("../src/lib/token-usage")
@@ -252,6 +264,201 @@ describe("responses handler token usage", () => {
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(1)
     expect(createResponses.mock.calls[0][0].tools?.[0]).toEqual(applyPatchTool)
+  })
+
+  test("omits oversized input images before forwarding to Copilot Responses", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: {
+            limits: {
+              max_prompt_tokens: 128000,
+              vision: {
+                max_prompt_image_size: 8,
+              },
+            },
+          },
+          id: "gpt-test",
+          supported_endpoints: ["/responses"],
+        },
+      ],
+    } as typeof state.models
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          {
+            content: [
+              { text: "look", type: "input_text" },
+              {
+                image_url: `data:image/png;base64,${"A".repeat(16)}`,
+                type: "input_image",
+              },
+            ],
+            role: "user",
+          },
+        ],
+        model: "gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][0].input).toEqual([
+      {
+        content: [
+          { text: "look", type: "input_text" },
+          {
+            text: "[omitted input image: image/png, 12 bytes, max 8 bytes]",
+            type: "input_text",
+          },
+        ],
+        role: "user",
+      },
+    ])
+  })
+
+  test("preserves multiple input images before forwarding to Copilot Responses", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: {
+            limits: {
+              max_prompt_tokens: 128000,
+              vision: {
+                max_prompt_image_size: 1024,
+                max_prompt_images: 1,
+              },
+            },
+          },
+          id: "gpt-test",
+          supported_endpoints: ["/responses"],
+        },
+      ],
+    } as typeof state.models
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const firstImageUrl = `data:image/png;base64,${"A".repeat(8)}`
+    const secondImageUrl = `data:image/png;base64,${"B".repeat(8)}`
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          {
+            content: [
+              { text: "look", type: "input_text" },
+              {
+                detail: "low",
+                image_url: firstImageUrl,
+                type: "input_image",
+              },
+              {
+                detail: "low",
+                image_url: secondImageUrl,
+                type: "input_image",
+              },
+            ],
+            role: "user",
+          },
+        ],
+        model: "gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][0].input).toEqual([
+      {
+        content: [
+          { text: "look", type: "input_text" },
+          { detail: "low", image_url: firstImageUrl, type: "input_image" },
+          { detail: "low", image_url: secondImageUrl, type: "input_image" },
+        ],
+        role: "user",
+      },
+    ])
+  })
+
+  test("retries once without remaining input images after Copilot rejects payload as too large", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: {
+            limits: {
+              max_prompt_tokens: 128000,
+              vision: {
+                max_prompt_image_size: 1024,
+                max_prompt_images: 10,
+              },
+            },
+          },
+          id: "gpt-test",
+          supported_endpoints: ["/responses"],
+        },
+      ],
+    } as typeof state.models
+    createResponses
+      .mockImplementationOnce(() =>
+        Promise.reject(createPayloadTooLargeError()),
+      )
+      .mockImplementationOnce((payload) =>
+        Promise.resolve(createResponsesResult(payload.model)),
+      )
+
+    const app = createApp()
+    const imageUrl = `data:image/png;base64,${"A".repeat(8)}`
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          {
+            content: [
+              { text: "look", type: "input_text" },
+              { detail: "low", image_url: imageUrl, type: "input_image" },
+            ],
+            role: "user",
+          },
+        ],
+        model: "gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(2)
+    expect(createResponses.mock.calls[1][0].input).toEqual([
+      {
+        content: [
+          { text: "look", type: "input_text" },
+          {
+            text: "[omitted input image: image/png, 6 bytes, upstream rejected payload as too large]",
+            type: "input_text",
+          },
+        ],
+        role: "user",
+      },
+    ])
+    expect(createResponses.mock.calls[1][1]?.vision).toBe(false)
   })
 
   test("records usage from failed streaming responses and falls back to interaction id", async () => {

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -313,18 +313,20 @@ describe("responses handler token usage", () => {
 
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(1)
-    expect(createResponses.mock.calls[0][0].input).toEqual([
-      {
-        content: [
-          { text: "look", type: "input_text" },
-          {
-            text: "[omitted input image: image/png, 12 bytes, max 8 bytes]",
-            type: "input_text",
-          },
-        ],
-        role: "user",
-      },
-    ])
+    const image = (
+      createResponses.mock.calls[0][0].input as Array<{
+        content: Array<{
+          detail?: string
+          image_url?: string
+          text?: string
+          type: string
+        }>
+      }>
+    )[0].content[1]
+    expect(image.type).toBe("input_image")
+    expect(image.detail).toBe("low")
+    expect(image.image_url?.startsWith("data:image/png;base64,")).toBe(true)
+    expect(image.text).toBeUndefined()
   })
 
   test("preserves multiple input images before forwarding to Copilot Responses", async () => {
@@ -446,19 +448,24 @@ describe("responses handler token usage", () => {
 
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(2)
-    expect(createResponses.mock.calls[1][0].input).toEqual([
-      {
-        content: [
-          { text: "look", type: "input_text" },
-          {
-            text: "[omitted input image: image/png, 6 bytes, upstream rejected payload as too large]",
-            type: "input_text",
-          },
-        ],
-        role: "user",
-      },
-    ])
-    expect(createResponses.mock.calls[1][1]?.vision).toBe(false)
+    const retryImage = (
+      createResponses.mock.calls[1][0].input as Array<{
+        content: Array<{
+          detail?: string
+          image_url?: string
+          text?: string
+          type: string
+        }>
+      }>
+    )[0].content[1]
+    expect(retryImage.type).toBe("input_image")
+    expect(retryImage.detail).toBe("low")
+    expect(retryImage.image_url?.startsWith("data:image/png;base64,")).toBe(
+      true,
+    )
+    expect(retryImage.image_url).not.toBe(imageUrl)
+    expect(retryImage.text).toBeUndefined()
+    expect(createResponses.mock.calls[1][1]?.vision).toBe(true)
   })
 
   test("records usage from failed streaming responses and falls back to interaction id", async () => {

--- a/tests/responses-image-sanitizer.test.ts
+++ b/tests/responses-image-sanitizer.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test"
+
+import type { ResponsesPayload } from "~/services/copilot/create-responses"
+
+import {
+  sanitizeAllInputImages,
+  sanitizeOversizedInputImages,
+} from "~/routes/responses/utils"
+
+const imageDataUrl = (base64Length: number): string =>
+  `data:image/png;base64,${"A".repeat(base64Length)}`
+
+const makePayload = (imageUrl: string): ResponsesPayload =>
+  ({
+    input: [
+      {
+        content: [
+          { text: "look", type: "input_text" },
+          { detail: "low", image_url: imageUrl, type: "input_image" },
+        ],
+        role: "user",
+      },
+    ],
+    model: "gpt-test",
+  }) as unknown as ResponsesPayload
+
+describe("sanitizeOversizedInputImages", () => {
+  test("replaces oversized input images with text markers", () => {
+    const payload = makePayload(imageDataUrl(16))
+
+    const sanitized = sanitizeOversizedInputImages(payload, 8)
+
+    expect(sanitized).toBe(1)
+    expect(payload.input).toEqual([
+      {
+        content: [
+          { text: "look", type: "input_text" },
+          {
+            text: "[omitted input image: image/png, 12 bytes, max 8 bytes]",
+            type: "input_text",
+          },
+        ],
+        role: "user",
+      },
+    ])
+  })
+
+  test("keeps input images within the model size limit", () => {
+    const imageUrl = imageDataUrl(8)
+    const payload = makePayload(imageUrl)
+
+    const sanitized = sanitizeOversizedInputImages(payload, 8)
+
+    expect(sanitized).toBe(0)
+    expect(
+      (
+        payload.input as Array<{
+          content: Array<{ detail?: string; image_url?: string; type: string }>
+        }>
+      )[0].content[1],
+    ).toEqual({ detail: "low", image_url: imageUrl, type: "input_image" })
+  })
+
+  test("removes all input images for a retry after payload rejection", () => {
+    const payload = {
+      input: [
+        {
+          content: [
+            { text: "look", type: "input_text" },
+            {
+              detail: "low",
+              image_url: imageDataUrl(1024),
+              type: "input_image",
+            },
+            {
+              detail: "low",
+              image_url: imageDataUrl(1024),
+              type: "input_image",
+            },
+          ],
+          role: "user",
+        },
+      ],
+      model: "gpt-test",
+    } as unknown as ResponsesPayload
+
+    const sanitized = sanitizeAllInputImages(payload)
+
+    expect(sanitized).toBe(2)
+    expect(JSON.stringify(payload)).not.toContain("data:image/png;base64")
+  })
+})

--- a/tests/responses-image-sanitizer.test.ts
+++ b/tests/responses-image-sanitizer.test.ts
@@ -28,24 +28,27 @@ const makePayload = (imageUrl: string): ResponsesPayload =>
   }) as unknown as ResponsesPayload
 
 describe("sanitizeOversizedInputImages", () => {
-  test("replaces oversized input images with text markers", () => {
+  test("replaces oversized input images with placeholder images", () => {
     const payload = makePayload(tinyPngDataUrl)
 
     const sanitized = sanitizeOversizedInputImages(payload, 67)
 
     expect(sanitized).toBe(1)
-    expect(payload.input).toEqual([
-      {
-        content: [
-          { text: "look", type: "input_text" },
-          {
-            text: "[omitted input image: image/png, 68 bytes, max 67 bytes]",
-            type: "input_text",
-          },
-        ],
-        role: "user",
-      },
-    ])
+    const image = (
+      payload.input as Array<{
+        content: Array<{
+          detail?: string
+          image_url?: string
+          text?: string
+          type: string
+        }>
+      }>
+    )[0].content[1]
+    expect(image.type).toBe("input_image")
+    expect(image.detail).toBe("low")
+    expect(image.image_url?.startsWith("data:image/png;base64,")).toBe(true)
+    expect(image.image_url).not.toBe(tinyPngDataUrl)
+    expect(image.text).toBeUndefined()
   })
 
   test("keeps input images within the model size limit", () => {
@@ -64,7 +67,9 @@ describe("sanitizeOversizedInputImages", () => {
     ).toEqual({ detail: "low", image_url: imageUrl, type: "input_image" })
   })
 
-  test("removes all input images for a retry after payload rejection", () => {
+  test("replaces all input images for a retry after payload rejection", () => {
+    const firstImageUrl = imageDataUrl(1024)
+    const secondImageUrl = imageDataUrl(1024)
     const payload = {
       input: [
         {
@@ -72,12 +77,12 @@ describe("sanitizeOversizedInputImages", () => {
             { text: "look", type: "input_text" },
             {
               detail: "low",
-              image_url: imageDataUrl(1024),
+              image_url: firstImageUrl,
               type: "input_image",
             },
             {
               detail: "low",
-              image_url: imageDataUrl(1024),
+              image_url: secondImageUrl,
               type: "input_image",
             },
           ],
@@ -90,6 +95,8 @@ describe("sanitizeOversizedInputImages", () => {
     const sanitized = sanitizeAllInputImages(payload)
 
     expect(sanitized).toBe(2)
-    expect(JSON.stringify(payload)).not.toContain("data:image/png;base64")
+    expect(JSON.stringify(payload)).not.toContain(firstImageUrl)
+    expect(JSON.stringify(payload)).not.toContain(secondImageUrl)
+    expect(JSON.stringify(payload)).toContain("data:image/png;base64")
   })
 })

--- a/tests/responses-image-sanitizer.test.ts
+++ b/tests/responses-image-sanitizer.test.ts
@@ -10,6 +10,9 @@ import {
 const imageDataUrl = (base64Length: number): string =>
   `data:image/png;base64,${"A".repeat(base64Length)}`
 
+const tinyPngDataUrl =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+
 const makePayload = (imageUrl: string): ResponsesPayload =>
   ({
     input: [
@@ -26,9 +29,9 @@ const makePayload = (imageUrl: string): ResponsesPayload =>
 
 describe("sanitizeOversizedInputImages", () => {
   test("replaces oversized input images with text markers", () => {
-    const payload = makePayload(imageDataUrl(16))
+    const payload = makePayload(tinyPngDataUrl)
 
-    const sanitized = sanitizeOversizedInputImages(payload, 8)
+    const sanitized = sanitizeOversizedInputImages(payload, 67)
 
     expect(sanitized).toBe(1)
     expect(payload.input).toEqual([
@@ -36,7 +39,7 @@ describe("sanitizeOversizedInputImages", () => {
         content: [
           { text: "look", type: "input_text" },
           {
-            text: "[omitted input image: image/png, 12 bytes, max 8 bytes]",
+            text: "[omitted input image: image/png, 68 bytes, max 67 bytes]",
             type: "input_text",
           },
         ],


### PR DESCRIPTION
## Summary

Prevent `copilot-api` `/v1/responses` requests from getting stuck in repeated `413 Payload Too Large` failures when inline base64 `input_image` data URLs make the request body too large.

This PR guards the Copilot Responses proxy path in two places:

- before forwarding, replace inline images that exceed the model's `max_prompt_image_size` with a tiny valid placeholder image
- after an upstream 413, replace the remaining inline images with the same placeholder and retry once

## Problem

The failure this PR targets is a 413 payload-size loop on the `copilot-api` `/v1/responses` route. When a client sends inline `input_image` data URLs through `POST /v1/responses`, GitHub Copilot can reject the request with:

```text
unexpected status 413 Payload Too Large:
{"error":{"message":"failed to parse request","code":""}},
url: http://localhost:4141/v1/responses
```

One concrete way to hit this is Codex usage: images from tools such as `view_image` are stored in the thread history as inline base64 `input_image` data URLs. Once a large image is in history, every retry/resume sends the same oversized payload again. Codex retries 5 times and fails each time. Manual compaction may not recover the thread either, because the compaction request still has to send the same image-containing history before a compacted summary can be produced.

In practice this can make the affected session unusable until the inline image data is removed from the payload.

## Investigation

Copilot model metadata exposes vision limits under `capabilities.limits.vision`, including:

```ts
vision?: {
  max_prompt_image_size?: number
  max_prompt_images?: number
  supported_media_types?: string[]
}
```

For affected models used in this flow, `max_prompt_image_size` was `3145728` bytes.

Local payload checks showed:

- a single valid inline image below the per-image limit was accepted
- a valid image above the per-image limit reproduced the 413 behavior
- multiple tiny images were accepted, so image count alone was not the direct trigger
- larger total request bodies could trigger 413 even when individual images were valid

The most important failure mode was historical `view_image` tool output being replayed as `function_call_output.output[].input_image` data URLs. Those inline image payloads are expensive in the JSON request body and can be resent on every retry/resume.

## Fix

This PR adds two defensive checks in the `/v1/responses` route:

1. Before forwarding to Copilot, replace inline `input_image` data URLs whose decoded bytes exceed the model's `max_prompt_image_size`.
2. If Copilot still rejects the request with HTTP 413, replace the remaining inline `input_image` data URLs and retry once.

The replacement keeps `type: "input_image"` and `detail: "low"`, but swaps the original large `image_url` for a tiny valid PNG placeholder that reads `Image too large / Redacted`.

The size check estimates decoded bytes from the data URL string length and base64 padding, without decoding or capturing the full base64 payload.

## Local Validation

This was first patched into a local `copilot-api` install and used against an affected client session that was repeatedly failing with 413.

Before the patch, the session retried the same oversized payload until the turn failed:

```text
Reconnecting... 1/5 (unexpected status 413 Payload Too Large ...)
...
Reconnecting... 5/5 (unexpected status 413 Payload Too Large ...)
turn.failed
```

After the patch, the same session resumed successfully and continued producing responses. The local proxy logged image omission before forwarding the recovered request:

```text
Omitted 8 input image(s) after Copilot Responses rejected the payload as too large
```

The source changes are covered by focused unit tests for:

- replacing images above `max_prompt_image_size`
- preserving multiple small images before any 413
- retrying once with readable placeholder images after a 413 response
- estimating base64 decoded bytes from data URL length and padding

I also tested the readable PNG placeholder against the real Copilot `/responses` endpoint and it was accepted.

## Reference

The Copilot SDK image-input documentation describes richer runtime behavior: images that exceed model constraints may be resized while preserving aspect ratio, quality-reduced, or skipped if they still cannot be brought within limits. It also documents `capabilities.limits.vision.max_prompt_images` and `max_prompt_image_size` as model vision limits:

- https://docs.github.com/en/copilot/how-tos/copilot-sdk/image-input
- https://github.com/github/copilot-sdk/blob/eb3c54c3a6871a5a654ae230555c042501b13018/nodejs/src/types.ts#L2323-L2327

This PR takes the smaller dependency-free approach of replacing inline image data URLs when they cannot be safely forwarded. A possible follow-up would be to discuss whether `copilot-api` should also attempt image compression, resizing, or downsampling before replacement. That could preserve more visual context, but it would also add image-processing behavior to the proxy.
