### PR TITLE
feat(responses): detect Codex subagent requests

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -15,6 +15,7 @@ import {
   type UsageTokens,
 } from "~/lib/token-usage"
 import { generateRequestIdFromPayload, getUUID } from "~/lib/utils"
+import type { SubagentMarker } from "~/lib/subagent"
 import {
   createResponses as createCopilotResponses,
   type ResponsesPayload,
@@ -54,15 +55,24 @@ export const handleResponses = async (c: Context) => {
   debugJson(logger, "Responses request payload:", payload)
   await responsesHandlerDependencies.checkRateLimit(state)
 
-  // not support subagent marker for now , set sessionId = getUUID(requestId)
-  const requestId = generateRequestIdFromPayload({ messages: payload.input })
+  const subagentMarker = getCodexResponsesSubagentMarker(c)
+  if (subagentMarker) {
+    debugJson(logger, "Detected Codex subagent headers:", subagentMarker)
+  }
+  const incomingSessionId =
+    subagentMarker ? getIncomingResponsesSessionId(c) : undefined
+  const sessionId = incomingSessionId ? getUUID(incomingSessionId) : undefined
+  const requestId = generateRequestIdFromPayload(
+    { messages: payload.input },
+    sessionId,
+  )
   logger.debug("Generated request ID:", requestId)
 
-  const sessionId = getUUID(requestId)
-  logger.debug("Extracted session ID:", sessionId)
+  const fallbackSessionId = sessionId ?? getUUID(requestId)
+  logger.debug("Extracted session ID:", fallbackSessionId)
   const recordUsage = createCopilotTokenUsageRecorder({
     endpoint: "responses",
-    fallbackSessionId: sessionId,
+    fallbackSessionId,
     model: payload.model,
   })
 
@@ -109,7 +119,9 @@ export const handleResponses = async (c: Context) => {
 
   debugJson(logger, "Translated Responses payload:", payload)
 
-  const { vision, initiator } = getResponsesRequestOptions(payload)
+  const { vision, initiator: inferredInitiator } =
+    getResponsesRequestOptions(payload)
+  const initiator = subagentMarker ? "agent" : inferredInitiator
 
   if (state.manualApprove) {
     await awaitApproval()
@@ -118,8 +130,9 @@ export const handleResponses = async (c: Context) => {
   const response = await responsesHandlerDependencies.createResponses(payload, {
     vision,
     initiator,
+    subagentMarker,
     requestId,
-    sessionId: sessionId,
+    sessionId: fallbackSessionId,
     transport: responsesTransport,
   })
 
@@ -212,4 +225,41 @@ export const removeUnsupportedTools = (payload: ResponsesPayload): void => {
   if (dropped.length > 0) {
     logger.debug("Removed unsupported tools:", dropped)
   }
+}
+
+const getIncomingResponsesSessionId = (c: Context): string | undefined =>
+  getTrimmedHeader(c, "session-id") ?? getTrimmedHeader(c, "x-session-id")
+
+const codexSubagentHeaderValues = new Set([
+  "collab_spawn",
+  "compact",
+  "memory_consolidation",
+  "review",
+])
+
+const getCodexResponsesSubagentMarker = (c: Context): SubagentMarker | null => {
+  const agentType = getTrimmedHeader(c, "x-openai-subagent")
+  if (!agentType || !codexSubagentHeaderValues.has(agentType)) {
+    return null
+  }
+
+  const threadId = getTrimmedHeader(c, "thread-id")
+  const rootSessionId = getIncomingResponsesSessionId(c)
+  const parentThreadId = getTrimmedHeader(c, "x-codex-parent-thread-id")
+  if (!threadId && !rootSessionId && !parentThreadId) {
+    return null
+  }
+
+  const agentId = threadId ?? parentThreadId ?? rootSessionId ?? agentType
+
+  return {
+    agent_id: agentId,
+    agent_type: agentType,
+    session_id: threadId ?? rootSessionId ?? agentId,
+  }
+}
+
+const getTrimmedHeader = (c: Context, name: string): string | undefined => {
+  const value = c.req.header(name)?.trim()
+  return value ? value : undefined
 }

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -123,6 +123,36 @@ describe("createResponses", () => {
     expect(body.type).toBeUndefined()
   })
 
+  test("sets subagent interaction headers for HTTP responses requests", async () => {
+    const payload: ResponsesPayload = {
+      input: "hello",
+      model: "gpt-test",
+    }
+
+    await createResponses(payload, {
+      initiator: "agent",
+      requestId: "request-1",
+      sessionId: "interaction-1",
+      subagentMarker: {
+        agent_id: "agent-1",
+        agent_type: "collab_spawn",
+        session_id: "sub-session",
+      },
+      vision: false,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0]
+    const requestInit = init as RequestInit & {
+      headers: Record<string, string>
+    }
+    expect(requestInit.headers["x-initiator"]).toBe("agent")
+    expect(requestInit.headers["x-interaction-id"]).toBe("interaction-1")
+    expect(requestInit.headers["x-interaction-type"]).toBe(
+      "conversation-subagent",
+    )
+  })
+
   test("uses HTTP when websocket transport is requested without stream=true", async () => {
     const payload: ResponsesPayload = {
       input: "hello",

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -50,13 +50,18 @@ const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
 
 const originalState = {
+  accountType: state.accountType,
   copilotToken: state.copilotToken,
   lastRequestTimestamp: state.lastRequestTimestamp,
+  macMachineId: state.macMachineId,
   manualApprove: state.manualApprove,
   models: state.models,
   rateLimitSeconds: state.rateLimitSeconds,
   rateLimitWait: state.rateLimitWait,
   verbose: state.verbose,
+  vsCodeDeviceId: state.vsCodeDeviceId,
+  vsCodeSessionId: state.vsCodeSessionId,
+  vsCodeVersion: state.vsCodeVersion,
 }
 
 function createApp(): Hono {
@@ -78,11 +83,16 @@ beforeEach(async () => {
   await closeUsageStore()
 
   state.copilotToken = "test-token"
+  state.accountType = "individual"
+  state.macMachineId = "machine-1"
   state.manualApprove = false
   state.verbose = false
   state.rateLimitSeconds = undefined
   state.rateLimitWait = false
   state.lastRequestTimestamp = undefined
+  state.vsCodeDeviceId = "device-1"
+  state.vsCodeSessionId = "session-1"
+  state.vsCodeVersion = "1.120.0"
   state.models = {
     object: "list",
     data: [
@@ -112,11 +122,16 @@ afterEach(async () => {
   Reflect.deleteProperty(process.env, DB_PATH_ENV)
 
   state.copilotToken = originalState.copilotToken
+  state.accountType = originalState.accountType
+  state.macMachineId = originalState.macMachineId
   state.manualApprove = originalState.manualApprove
   state.verbose = originalState.verbose
   state.rateLimitSeconds = originalState.rateLimitSeconds
   state.rateLimitWait = originalState.rateLimitWait
   state.lastRequestTimestamp = originalState.lastRequestTimestamp
+  state.vsCodeDeviceId = originalState.vsCodeDeviceId
+  state.vsCodeSessionId = originalState.vsCodeSessionId
+  state.vsCodeVersion = originalState.vsCodeVersion
   state.models = originalState.models
   Object.assign(
     responsesHandlerDependencies,
@@ -160,6 +175,8 @@ describe("responses handler token usage", () => {
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(1)
     expect(createResponses.mock.calls[0][1]?.transport).toBe("websocket")
+    expect(createResponses.mock.calls[0][1]?.initiator).toBe("user")
+    expect(createResponses.mock.calls[0][1]?.subagentMarker).toBeNull()
   })
 
   test("keeps HTTP transport for dual-endpoint models when websocket is disabled", async () => {
@@ -252,6 +269,164 @@ describe("responses handler token usage", () => {
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(1)
     expect(createResponses.mock.calls[0][0].tools?.[0]).toEqual(applyPatchTool)
+  })
+
+  test("uses Codex subagent headers for Responses request attribution", async () => {
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const payload = {
+      input: [
+        {
+          content: [{ text: "SUBAGENT_PROBE", type: "input_text" }],
+          role: "user",
+        },
+      ],
+      model: "gpt-test",
+    }
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "session-id": "root-session",
+        "thread-id": "child-thread",
+        "x-codex-parent-thread-id": "parent-thread",
+        "x-openai-subagent": "collab_spawn",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+
+    const options = createResponses.mock.calls[0][1]
+    const expectedSessionId = getUUID("root-session")
+    expect(options?.initiator).toBe("agent")
+    expect(options?.sessionId).toBe(expectedSessionId)
+    expect(options?.requestId).toBe(
+      generateRequestIdFromPayload(
+        { messages: payload.input },
+        expectedSessionId,
+      ),
+    )
+    expect(options?.subagentMarker).toEqual({
+      agent_id: "child-thread",
+      agent_type: "collab_spawn",
+      session_id: "child-thread",
+    })
+  })
+
+  test("ignores session headers when Codex subagent header is missing", async () => {
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const payload = {
+      input: [
+        {
+          content: [{ text: "hello", type: "input_text" }],
+          role: "user",
+        },
+      ],
+      model: "gpt-test",
+    }
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "session-id": "root-session",
+        "thread-id": "child-thread",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+
+    const options = createResponses.mock.calls[0][1]
+    const expectedRequestId = generateRequestIdFromPayload({
+      messages: payload.input,
+    })
+    expect(options?.initiator).toBe("user")
+    expect(options?.requestId).toBe(expectedRequestId)
+    expect(options?.sessionId).toBe(getUUID(expectedRequestId))
+    expect(options?.subagentMarker).toBeNull()
+  })
+
+  test("ignores unknown x-openai-subagent values", async () => {
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const payload = {
+      input: [
+        {
+          content: [{ text: "hello", type: "input_text" }],
+          role: "user",
+        },
+      ],
+      model: "gpt-test",
+    }
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "session-id": "root-session",
+        "thread-id": "child-thread",
+        "x-openai-subagent": "unexpected",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][1]?.initiator).toBe("user")
+    expect(createResponses.mock.calls[0][1]?.subagentMarker).toBeNull()
+  })
+
+  test("accepts known Codex subagent header values", async () => {
+    for (const agentType of ["compact", "memory_consolidation", "review"]) {
+      createResponses.mockReset()
+      createResponses.mockImplementation((payload) =>
+        Promise.resolve(createResponsesResult(payload.model)),
+      )
+
+      const app = createApp()
+      const response = await app.request("/v1/responses", {
+        body: JSON.stringify({
+          input: [
+            {
+              content: [{ text: "hello", type: "input_text" }],
+              role: "user",
+            },
+          ],
+          model: "gpt-test",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "session-id": "root-session",
+          "thread-id": "child-thread",
+          "x-openai-subagent": agentType,
+        },
+        method: "POST",
+      })
+
+      expect(response.status).toBe(200)
+      expect(createResponses).toHaveBeenCalledTimes(1)
+      expect(createResponses.mock.calls[0][1]?.initiator).toBe("agent")
+      expect(createResponses.mock.calls[0][1]?.subagentMarker).toEqual({
+        agent_id: "child-thread",
+        agent_type: agentType,
+        session_id: "child-thread",
+      })
+    }
   })
 
   test("omits oversized input images before forwarding to Copilot Responses", async () => {


### PR DESCRIPTION
## Summary

- Detect Codex Responses subagent requests from `x-openai-subagent`.
- Map known Codex subagent values to the existing Copilot subagent attribution path.
- Preserve normal `/v1/responses` behavior when the header is absent or unknown.

## Context

OpenAI Codex now sends subagent identity on Responses requests with `x-openai-subagent`. Its current source maps built-in subagent sources to `review`, `compact`, `memory_consolidation`, and `collab_spawn`.

References:

- `X_OPENAI_SUBAGENT_HEADER`: https://github.com/openai/codex/blob/a717e4ef31f64feab49b6d857f1b5b1e027ff254/codex-rs/core/src/client.rs#L141
- Responses identity headers: https://github.com/openai/codex/blob/a717e4ef31f64feab49b6d857f1b5b1e027ff254/codex-rs/core/src/client.rs#L619-L648
- Built-in subagent value mapping: https://github.com/openai/codex/blob/a717e4ef31f64feab49b6d857f1b5b1e027ff254/codex-rs/core/src/client.rs#L1715-L1722

When a known Codex subagent value is present, this PR reuses the existing Copilot subagent attribution path (`x-initiator: agent`, `x-interaction-type: conversation-subagent`). Unknown or missing values keep the previous request/session behavior.

## Validation

Tests passed, and I also verified a real Codex CLI `spawn_agent` request against this branch.
