### PR TITLE
fix(messages): strip eager_input_streaming and cache_control to fix 400s

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -132,6 +132,7 @@ export interface AnthropicTool {
   description?: string
   input_schema: Record<string, unknown>
   defer_loading?: boolean
+  eager_input_streaming?: boolean
   cache_control?: AnthropicCacheControl | null
 }
 

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -733,14 +733,55 @@ const hasToolRef = (block: AnthropicToolResultBlock) => {
 // Strip cache_control from system content blocks as the
 // Copilot Messages API does not support them (rejects extra fields like scope).
 // commit by nicktogo
+// Strip eager_input_streaming from tool definitions.
+// Copilot's Messages API doesn't accept this field and returns 400.
+const stripToolEagerInputStreaming = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  if (!payload.tools?.length) return
+  payload.tools = payload.tools.map(
+    ({ eager_input_streaming: _, ...rest }) => rest,
+  )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stripCacheControlFromObject = (obj: Record<string, any>): void => {
+  delete obj["cache_control"]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stripCacheControlFromBlock = (block: Record<string, any>): void => {
+  stripCacheControlFromObject(block)
+  if (Array.isArray(block["content"])) {
+    for (const inner of block["content"]) {
+      if (inner && typeof inner === "object")
+        stripCacheControlFromObject(inner as Record<string, unknown>)
+    }
+  }
+}
+
+// Strip cache_control from the entire payload.
+// Copilot's Messages API rejects it outright and doesn't implement prompt caching.
 const stripCacheControl = (payload: AnthropicMessagesPayload): void => {
+  stripCacheControlFromObject(payload as unknown as Record<string, unknown>)
+
   if (Array.isArray(payload.system)) {
     for (const block of payload.system) {
-      const cacheControl = block.cache_control
-      if (cacheControl && typeof cacheControl === "object") {
-        const { scope, ...rest } = cacheControl
-        block.cache_control = rest
+      stripCacheControlFromObject(block as unknown as Record<string, unknown>)
+    }
+  }
+
+  for (const message of payload.messages) {
+    if (Array.isArray(message.content)) {
+      for (const block of message.content) {
+        stripCacheControlFromBlock(block as unknown as Record<string, unknown>)
       }
+    }
+  }
+
+  if (payload.tools) {
+    for (const tool of payload.tools) {
+      stripCacheControlFromObject(tool as unknown as Record<string, unknown>)
     }
   }
 }
@@ -770,6 +811,7 @@ export const prepareMessagesApiPayload = (
   selectedModel?: Model,
 ): void => {
   stripCacheControl(payload)
+  stripToolEagerInputStreaming(payload)
   filterAssistantThinkingBlocks(payload)
 
   const hasThinking = Boolean(payload.thinking)

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1010,7 +1010,7 @@ describe("sanitizeIdeTools", () => {
 })
 
 describe("prepareMessagesApiPayload", () => {
-  test("strips cache_control scope, filters thinking blocks, and enables adaptive thinking", () => {
+  test("strips cache_control entirely, filters thinking blocks, and enables adaptive thinking", () => {
     const payload: AnthropicMessagesPayload = {
       model: "gpt-5.4",
       max_tokens: 128,
@@ -1071,9 +1071,6 @@ describe("prepareMessagesApiPayload", () => {
     expect(systemBlock).toEqual({
       type: "text",
       text: "system prompt",
-      cache_control: {
-        type: "ephemeral",
-      },
     })
     expect(payload.messages[0]).toEqual({
       role: "assistant",
@@ -1176,5 +1173,80 @@ describe("prepareMessagesApiPayload", () => {
 
     expect(payload.thinking).toBeUndefined()
     expect(payload.output_config).toBeUndefined()
+  })
+})
+
+describe("stripToolEagerInputStreaming (via prepareMessagesApiPayload)", () => {
+  test("removes eager_input_streaming from all tool definitions", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        {
+          name: "edit_file",
+          description: "Edit a file",
+          input_schema: { type: "object", properties: {} },
+          eager_input_streaming: true,
+        },
+        {
+          name: "read_file",
+          description: "Read a file",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    expect(payload.tools).toHaveLength(2)
+    expect(payload.tools![0]).not.toHaveProperty("eager_input_streaming")
+    expect(payload.tools![1]).not.toHaveProperty("eager_input_streaming")
+    expect(payload.tools![0].name).toBe("edit_file")
+    expect(payload.tools![1].name).toBe("read_file")
+  })
+
+  test("does nothing when tools array is absent", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+    }
+
+    expect(() => prepareMessagesApiPayload(payload, undefined)).not.toThrow()
+    expect(payload.tools).toBeUndefined()
+  })
+
+  test("preserves all other tool fields except cache_control", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        {
+          name: "write_file",
+          description: "Write a file",
+          input_schema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+          defer_loading: true,
+          eager_input_streaming: true,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    expect(payload.tools![0]).toEqual({
+      name: "write_file",
+      description: "Write a file",
+      input_schema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+      },
+      defer_loading: true,
+    })
   })
 })


### PR DESCRIPTION
This PR fixes two separate 400s hitting Haiku 4.5, Sonnet 4.5, and Sonnet 4.6 when using `anthropic` provider w/Zed through the proxy:

- ```
  tools.N.custom.eager_input_streaming: Extra inputs are not permitted
  ```

Zed injects `eager_input_streaming: true` into every tool definition and Copilot's
backend doesn't accept it. Zed's own `copilot_chat` provider, opencode, kilocode, and a few other proxies all strip it.

- ```
  cache_control: Extra inputs are not permitted
  ```

The existing `stripCacheControl` only trimmed `scope` off system blocks. Haiku rejects
`cache_control` anywhere in the payload: tools, message content, `tool_result`
inner blocks, top-level.

---

### Changes: 

- **`stripToolEagerInputStreaming`** (new): strips `eager_input_streaming` from all tools
- **`stripCacheControl`** (expanded): now removes `cache_control` from the full payload tree
- Added `eager_input_streaming?: boolean` to `AnthropicTool` for type safety