### PR TITLE
fix(messages): strip eager_input_streaming and cache_control scope

### DIFF
--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -132,6 +132,7 @@ export interface AnthropicTool {
   description?: string
   input_schema: Record<string, unknown>
   defer_loading?: boolean
+  eager_input_streaming?: boolean
   cache_control?: AnthropicCacheControl | null
 }
 

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -733,14 +733,54 @@ const hasToolRef = (block: AnthropicToolResultBlock) => {
 // Strip cache_control from system content blocks as the
 // Copilot Messages API does not support them (rejects extra fields like scope).
 // commit by nicktogo
-const stripCacheControl = (payload: AnthropicMessagesPayload): void => {
+// Strip eager_input_streaming from tool definitions.
+// Copilot's Messages API doesn't accept this field and returns 400.
+const stripToolEagerInputStreaming = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  if (!payload.tools?.length) return
+  payload.tools = payload.tools.map(
+    ({ eager_input_streaming: _, ...rest }) => rest,
+  )
+}
+
+// Strip the scope sub-field from cache_control wherever it appears.
+// Copilot's backend accepts cache_control on all models but rejects scope,
+// which is a newer Anthropic-only beta field (prompt-caching-scope-2026-01-05).
+const stripCacheControlScope = (payload: AnthropicMessagesPayload): void => {
+  const strip = (obj: Record<string, unknown>): void => {
+    if (obj["cache_control"] && typeof obj["cache_control"] === "object") {
+      delete (obj["cache_control"] as Record<string, unknown>)["scope"]
+    }
+  }
+
+  const stripBlock = (block: Record<string, unknown>): void => {
+    strip(block)
+    if (Array.isArray(block["content"])) {
+      for (const inner of block["content"]) {
+        if (inner && typeof inner === "object")
+          strip(inner as Record<string, unknown>)
+      }
+    }
+  }
+
   if (Array.isArray(payload.system)) {
     for (const block of payload.system) {
-      const cacheControl = block.cache_control
-      if (cacheControl && typeof cacheControl === "object") {
-        const { scope, ...rest } = cacheControl
-        block.cache_control = rest
+      strip(block as unknown as Record<string, unknown>)
+    }
+  }
+
+  for (const message of payload.messages) {
+    if (Array.isArray(message.content)) {
+      for (const block of message.content) {
+        stripBlock(block as unknown as Record<string, unknown>)
       }
+    }
+  }
+
+  if (payload.tools) {
+    for (const tool of payload.tools) {
+      strip(tool as unknown as Record<string, unknown>)
     }
   }
 }
@@ -769,7 +809,8 @@ export const prepareMessagesApiPayload = (
   payload: AnthropicMessagesPayload,
   selectedModel?: Model,
 ): void => {
-  stripCacheControl(payload)
+  stripCacheControlScope(payload)
+  stripToolEagerInputStreaming(payload)
   filterAssistantThinkingBlocks(payload)
 
   const hasThinking = Boolean(payload.thinking)

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1010,7 +1010,7 @@ describe("sanitizeIdeTools", () => {
 })
 
 describe("prepareMessagesApiPayload", () => {
-  test("strips cache_control scope, filters thinking blocks, and enables adaptive thinking", () => {
+  test("strips scope from cache_control, filters thinking blocks, and enables adaptive thinking", () => {
     const payload: AnthropicMessagesPayload = {
       model: "gpt-5.4",
       max_tokens: 128,
@@ -1071,9 +1071,7 @@ describe("prepareMessagesApiPayload", () => {
     expect(systemBlock).toEqual({
       type: "text",
       text: "system prompt",
-      cache_control: {
-        type: "ephemeral",
-      },
+      cache_control: { type: "ephemeral" },
     })
     expect(payload.messages[0]).toEqual({
       role: "assistant",
@@ -1176,5 +1174,154 @@ describe("prepareMessagesApiPayload", () => {
 
     expect(payload.thinking).toBeUndefined()
     expect(payload.output_config).toBeUndefined()
+  })
+})
+
+describe("stripCacheControlScope (via prepareMessagesApiPayload)", () => {
+  test("strips scope from cache_control on system blocks for all models", () => {
+    for (const model of [
+      "claude-haiku-4.5",
+      "claude-sonnet-4-6",
+      "claude-opus-4-6",
+    ]) {
+      const payload: AnthropicMessagesPayload = {
+        model,
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+        system: [
+          {
+            type: "text",
+            text: "sys",
+            cache_control: { type: "ephemeral", scope: "user" },
+          } as AnthropicMessagesPayload["system"] extends Array<infer T> ? T
+          : never,
+        ],
+      }
+
+      prepareMessagesApiPayload(payload, undefined)
+
+      const block = (
+        payload.system as unknown as Array<Record<string, unknown>>
+      )[0]
+      expect(block["cache_control"]).toEqual({ type: "ephemeral" })
+    }
+  })
+
+  test("strips scope from cache_control on tools", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        {
+          name: "t",
+          description: "t",
+          input_schema: {},
+          cache_control: { type: "ephemeral", scope: "user" },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    expect(payload.tools![0].cache_control).toEqual({ type: "ephemeral" })
+  })
+
+  test("preserves cache_control without scope", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-haiku-4.5",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      system: [
+        {
+          type: "text",
+          text: "sys",
+          cache_control: { type: "ephemeral" },
+        } as AnthropicMessagesPayload["system"] extends Array<infer T> ? T
+        : never,
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    const block = (
+      payload.system as unknown as Array<Record<string, unknown>>
+    )[0]
+    expect(block["cache_control"]).toEqual({ type: "ephemeral" })
+  })
+})
+describe("stripToolEagerInputStreaming (via prepareMessagesApiPayload)", () => {
+  test("removes eager_input_streaming from all tool definitions", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        {
+          name: "edit_file",
+          description: "Edit a file",
+          input_schema: { type: "object", properties: {} },
+          eager_input_streaming: true,
+        },
+        {
+          name: "read_file",
+          description: "Read a file",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    expect(payload.tools).toHaveLength(2)
+    expect(payload.tools![0]).not.toHaveProperty("eager_input_streaming")
+    expect(payload.tools![1]).not.toHaveProperty("eager_input_streaming")
+    expect(payload.tools![0].name).toBe("edit_file")
+    expect(payload.tools![1].name).toBe("read_file")
+  })
+
+  test("does nothing when tools array is absent", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+    }
+
+    expect(() => prepareMessagesApiPayload(payload, undefined)).not.toThrow()
+    expect(payload.tools).toBeUndefined()
+  })
+
+  test("preserves all other tool fields", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [
+        {
+          name: "write_file",
+          description: "Write a file",
+          input_schema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+          },
+          defer_loading: true,
+          eager_input_streaming: true,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, undefined)
+
+    expect(payload.tools![0]).toEqual({
+      name: "write_file",
+      description: "Write a file",
+      input_schema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+      },
+      defer_loading: true,
+      cache_control: { type: "ephemeral" },
+    })
   })
 })


### PR DESCRIPTION
This PR fixes two separate 400s hitting Haiku 4.5, Sonnet 4.5, and Sonnet 4.6 when using `anthropic` provider w/Zed through the proxy:

- ```
  tools.N.custom.eager_input_streaming: Extra inputs are not permitted
  ```

Zed injects `eager_input_streaming: true` into every tool definition and Copilot's
backend doesn't accept it. Zed's own `copilot_chat` provider, opencode, kilocode, and a few other proxies all strip it.

- ```
  cache_control: Extra inputs are not permitted
  ```

instead of stripping the entire cache_control block like my other PR, this just extends the existing scope-strip to tools and message content blocks, not only system blocks.

## Fix

- **`stripToolEagerInputStreaming`** (new) — strips `eager_input_streaming` from all tools
- **`stripCacheControlScope`** (expanded from `stripCacheControl`) — strips `scope` from
  `cache_control` across system blocks, tools, and message content
- Added `eager_input_streaming?: boolean` to `AnthropicTool` for type safety


thank you in advance for your time and for reviewing this.