### PR TITLE
fix: strip top-level cache_control for unsupported models and scope from all blocks

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -730,18 +730,61 @@ const hasToolRef = (block: AnthropicToolResultBlock) => {
   )
 }
 
-// Strip cache_control from system content blocks as the
-// Copilot Messages API does not support them (rejects extra fields like scope).
-// commit by nicktogo
+// Models whose Copilot Messages API endpoints reject top-level cache_control.
+// Pattern: only Opus 4.6+ reliably accepts top-level cache_control.
+const TOP_LEVEL_CACHE_CONTROL_UNSUPPORTED_MODELS = [
+  "claude-sonnet-4.5",
+  "claude-sonnet-4.6",
+  "claude-opus-4.5",
+  "claude-haiku-4.5",
+]
+
+// Strip unsupported cache_control fields for Copilot Messages API compatibility.
+// - `scope` in block-level cache_control is always rejected and should be stripped everywhere.
+// - Top-level `cache_control` is rejected by some models and should be stripped.
 const stripCacheControl = (payload: AnthropicMessagesPayload): void => {
+  if (
+    payload.cache_control
+    && TOP_LEVEL_CACHE_CONTROL_UNSUPPORTED_MODELS.includes(payload.model)
+  ) {
+    delete payload.cache_control
+  }
   if (Array.isArray(payload.system)) {
     for (const block of payload.system) {
-      const cacheControl = block.cache_control
-      if (cacheControl && typeof cacheControl === "object") {
-        const { scope, ...rest } = cacheControl
-        block.cache_control = rest
+      stripCacheControlScope(block)
+    }
+  }
+
+  for (const message of payload.messages) {
+    if (!Array.isArray(message.content)) {
+      continue
+    }
+    for (const block of message.content) {
+      if ("cache_control" in block) {
+        stripCacheControlScope(block)
       }
     }
+  }
+
+  if (Array.isArray(payload.tools)) {
+    for (const tool of payload.tools) {
+      stripCacheControlScope(tool)
+    }
+  }
+}
+
+// Strip only the `scope` field from cache_control, preserving `type` and `ttl`.
+interface BlockWithCacheControl {
+  cache_control?: AnthropicCacheControl | null
+}
+const stripCacheControlScope = (block: BlockWithCacheControl): void => {
+  const cacheControl = block.cache_control
+  if (!cacheControl || typeof cacheControl !== "object") {
+    return
+  }
+  if ("scope" in cacheControl) {
+    const { scope, ...rest } = cacheControl
+    block.cache_control = rest
   }
 }
 

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1096,6 +1096,157 @@ describe("prepareMessagesApiPayload", () => {
     expect(payload.output_config).toEqual({ effort: "xhigh" })
   })
 
+  test("strips top-level cache_control for unsupported models, preserves ttl, strips scope", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-sonnet-4.6",
+      max_tokens: 128,
+      cache_control: { type: "ephemeral" },
+      system: [
+        {
+          type: "text",
+          text: "system prompt",
+          cache_control: {
+            type: "ephemeral",
+            ttl: "1h",
+            scope: "user",
+          },
+        } as AnthropicMessagesPayload["system"] extends Array<infer T> ? T
+        : never,
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "hello",
+              cache_control: { type: "ephemeral", ttl: "1h", scope: "user" },
+            } as never,
+          ],
+        },
+      ],
+      tools: [
+        {
+          name: "test_tool",
+          input_schema: {},
+          cache_control: { type: "ephemeral", ttl: "1h", scope: "user" },
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: false,
+        },
+      },
+    } as never)
+
+    // top-level stripped for unsupported model
+    expect(payload.cache_control).toBeUndefined()
+    // ttl preserved, scope stripped on all blocks
+    const systemBlock = (
+      payload.system as unknown as Array<Record<string, unknown>>
+    )[0]
+    expect(systemBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" })
+    const userContent = (
+      payload.messages[0].content as unknown as Array<Record<string, unknown>>
+    )[0]
+    expect(userContent.cache_control).toEqual({ type: "ephemeral", ttl: "1h" })
+    expect(payload.tools![0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    })
+  })
+
+  test("strips top-level cache_control for haiku-4.5", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-haiku-4.5",
+      max_tokens: 128,
+      cache_control: { type: "ephemeral" },
+      system: "system prompt",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: false,
+        },
+      },
+    } as never)
+
+    expect(payload.cache_control).toBeUndefined()
+  })
+
+  test("strips top-level cache_control for opus-4.5", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.5",
+      max_tokens: 128,
+      cache_control: { type: "ephemeral" },
+      system: "system prompt",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: false,
+        },
+      },
+    } as never)
+
+    expect(payload.cache_control).toBeUndefined()
+  })
+
+  test("preserves top-level cache_control for supported models", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.7",
+      max_tokens: 128,
+      cache_control: { type: "ephemeral" },
+      system: [
+        {
+          type: "text",
+          text: "system prompt",
+          cache_control: { type: "ephemeral", ttl: "1h", scope: "user" },
+        } as AnthropicMessagesPayload["system"] extends Array<infer T> ? T
+        : never,
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: true,
+        },
+      },
+    } as never)
+
+    // top-level preserved for supported model
+    expect(payload.cache_control).toEqual({ type: "ephemeral" })
+    // scope still stripped
+    const systemBlock = (
+      payload.system as unknown as Array<Record<string, unknown>>
+    )[0]
+    expect(systemBlock.cache_control).toEqual({ type: "ephemeral", ttl: "1h" })
+  })
+
   test("sets summarized display for Claude versions at least 4.7", () => {
     const models = [
       "claude-opus-4.7",


### PR DESCRIPTION
Hello @caozhiyuan,
I took some time to try and pinpoint the actual cache_control problems some more.

Here are two reproducible curl commands to see the issues at hand:

```bash
# 1. Top-level cache_control → 400 on sonnet-4.6 (unpatched)
curl -s -w "\n%{http_code}\n" -X POST http://localhost:4141/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-sonnet-4.6",
    "max_tokens": 32,
    "stream": false,
    "cache_control": {"type": "ephemeral"},
    "system": [{"type": "text", "text": "Reply with OK.", "cache_control": {"type": "ephemeral", "ttl": "1h"}}],
    "tools": [
      {
        "name": "get_weather",
        "description": "Get weather",
        "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
        "cache_control": {"type": "ephemeral", "ttl": "1h"}
      }
    ],
    "messages": [{"role": "user", "content": "Say OK"}]
  }'

# 2. scope on tool cache_control → 400 (unpatched, scope not stripped on tools)
curl -s -w "\n%{http_code}\n" -X POST http://localhost:4141/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-opus-4.7",
    "max_tokens": 32,
    "stream": false,
    "tools": [
      {
        "name": "get_weather",
        "description": "Get weather",
        "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}},
        "cache_control": {"type": "ephemeral", "ttl": "1h", "scope": "session"}
      }
    ],
    "messages": [{"role": "user", "content": "Say OK"}]
  }'
```

These both return `HTTP error: { message: 'cache_control: Extra inputs are not permitted' }`.

Regarding `top-level cache_control`: I have noticed only Opus 4.6+ can handle these request types reliably so now I would only strip this for unsupported models.

Regarding `scope on tool cache_control`: this isn't supported on any model via github copilot and should be stripped 

Both these curls work against this PR and provide compatibility for this matter using Zed with the tools' native Anthropic provider.

The other issue remaining is regarding `eager_input_streaming` but I will try to address that in another PR.

Sorry if I still missed something here: I'm open for discussion/suggestions.

Kind regards.