### PR TITLE
Add configurable model metadata overrides

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,8 @@ import fs from "node:fs"
 
 import { PATHS } from "./paths"
 
+export type ModelMetadataOverride = Record<string, unknown>
+
 export interface AppConfig {
   auth?: {
     apiKeys?: Array<string>
@@ -11,6 +13,7 @@ export interface AppConfig {
   }
   providers?: Record<string, ProviderConfig>
   modelMappings?: Record<string, string>
+  modelOverrides?: Record<string, ModelMetadataOverride>
   extraPrompts?: Record<string, string>
   smallModel?: string
   useResponsesApiContextManagement?: boolean
@@ -380,6 +383,60 @@ export function setModelMappings(
 
 export function resolveMappedModel(model: string): string {
   return getModelMappings()[model] ?? model
+}
+
+function isOverrideObject(value: unknown): value is ModelMetadataOverride {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function getModelOverrides(): Record<string, ModelMetadataOverride> {
+  const config = getConfig()
+  const modelOverrides = config.modelOverrides
+  if (!modelOverrides) {
+    return {}
+  }
+
+  const validOverrides: Record<string, ModelMetadataOverride> = {}
+  for (const [modelId, override] of Object.entries(modelOverrides)) {
+    if (!modelId || !isOverrideObject(override)) {
+      continue
+    }
+    validOverrides[modelId] = override
+  }
+
+  return validOverrides
+}
+
+function validateModelOverrides(
+  modelOverrides: Record<string, ModelMetadataOverride>,
+): Record<string, ModelMetadataOverride> {
+  const validatedOverrides: Record<string, ModelMetadataOverride> = {}
+  for (const [modelId, override] of Object.entries(modelOverrides)) {
+    if (!modelId) {
+      throw new Error("Each model override must use a non-empty model id.")
+    }
+    if (!isOverrideObject(override)) {
+      throw new Error(
+        `Model override for '${modelId}' must be an object of metadata fields.`,
+      )
+    }
+    validatedOverrides[modelId] = override
+  }
+
+  return validatedOverrides
+}
+
+export function setModelOverrides(
+  modelOverrides: Record<string, ModelMetadataOverride>,
+): Record<string, ModelMetadataOverride> {
+  const nextConfig = {
+    ...readEditableConfigFromDisk(),
+    modelOverrides: validateModelOverrides(modelOverrides),
+  }
+
+  writeConfigToDisk(nextConfig)
+  cachedConfig = reloadConfig()
+  return getModelOverrides()
 }
 
 export function getSmallModel(): string {

--- a/src/lib/deep-merge.ts
+++ b/src/lib/deep-merge.ts
@@ -1,0 +1,23 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Recursively merges `source` onto `target`, returning a new value without
+ * mutating either input.
+ *
+ * - Plain objects are merged key by key.
+ * - Arrays, primitives, `null`, and type mismatches replace the target value.
+ */
+export function deepMerge<T>(target: T, source: unknown): T {
+  if (!isPlainObject(target) || !isPlainObject(source)) {
+    return source as T
+  }
+
+  const result: Record<string, unknown> = { ...target }
+  for (const [key, sourceValue] of Object.entries(source)) {
+    result[key] = deepMerge(result[key], sourceValue)
+  }
+
+  return result as T
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,5 +1,7 @@
 import type { Model } from "~/services/copilot/get-models"
 
+import { getModelOverrides } from "~/lib/config"
+import { deepMerge } from "~/lib/deep-merge"
 import { state } from "~/lib/state"
 
 export interface NormalizedSdkModelId {
@@ -7,11 +9,28 @@ export interface NormalizedSdkModelId {
   version: string
 }
 
+/**
+ * Applies any configured metadata override for a model onto a clone of its
+ * metadata. The map key identifies the model, so an `id` field inside an
+ * override is ignored (the original id is always preserved).
+ */
+export const applyModelOverride = (model: Model): Model => {
+  const override = getModelOverrides()[model.id]
+  if (!override) {
+    return model
+  }
+
+  return { ...deepMerge(model, override), id: model.id }
+}
+
+export const applyModelOverrides = (models: Array<Model>): Array<Model> =>
+  models.map((model) => applyModelOverride(model))
+
 export const findEndpointModel = (sdkModelId: string): Model | undefined => {
   const models = state.models?.data ?? []
   const exactMatch = models.find((m) => m.id === sdkModelId)
   if (exactMatch) {
-    return exactMatch
+    return applyModelOverride(exactMatch)
   }
 
   const normalized = normalizeSdkModelId(sdkModelId)
@@ -22,7 +41,7 @@ export const findEndpointModel = (sdkModelId: string): Model | undefined => {
   const modelName = `claude-${normalized.family}-${normalized.version}`
   const model = models.find((m) => m.id === modelName)
   if (model) {
-    return model
+    return applyModelOverride(model)
   }
 
   return undefined

--- a/src/routes/admin/config/route.ts
+++ b/src/routes/admin/config/route.ts
@@ -2,13 +2,25 @@ import { Hono } from "hono"
 import { z } from "zod"
 
 import { forwardError } from "~/lib/error"
-import { getModelMappings, setModelMappings } from "~/lib/config"
+import {
+  getModelMappings,
+  getModelOverrides,
+  setModelMappings,
+  setModelOverrides,
+} from "~/lib/config"
 import { PATHS } from "~/lib/paths"
 
 export const configRoutes = new Hono()
 
 const modelMappingsRequestSchema = z.object({
   modelMappings: z.record(z.string(), z.string()),
+})
+
+const modelOverridesRequestSchema = z.object({
+  modelOverrides: z.record(
+    z.string().min(1),
+    z.record(z.string(), z.unknown()),
+  ),
 })
 
 configRoutes.get("/model-mappings", (c) => {
@@ -41,6 +53,44 @@ configRoutes.post("/model-mappings", async (c) => {
     return c.json({
       configPath: PATHS.CONFIG_PATH,
       modelMappings: updatedModelMappings,
+    })
+  } catch (error) {
+    return await forwardError(c, error)
+  }
+})
+
+configRoutes.get("/model-overrides", (c) => {
+  return c.json({
+    configPath: PATHS.CONFIG_PATH,
+    modelOverrides: getModelOverrides(),
+  })
+})
+
+configRoutes.post("/model-overrides", async (c) => {
+  try {
+    const parseResult = modelOverridesRequestSchema.safeParse(
+      await c.req.json(),
+    )
+    if (!parseResult.success) {
+      return c.json(
+        {
+          error: {
+            message:
+              parseResult.error.issues[0]?.message ?? "Invalid request body.",
+            type: "invalid_request_error",
+          },
+        },
+        400,
+      )
+    }
+
+    const updatedModelOverrides = setModelOverrides(
+      parseResult.data.modelOverrides,
+    )
+
+    return c.json({
+      configPath: PATHS.CONFIG_PATH,
+      modelOverrides: updatedModelOverrides,
     })
   } catch (error) {
     return await forwardError(c, error)

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -5,6 +5,7 @@ import { streamSSE, type SSEMessage } from "hono/streaming"
 import { awaitApproval } from "~/lib/approval"
 import { resolveMappedModel } from "~/lib/config"
 import { createHandlerLogger, debugJson, debugJsonTail } from "~/lib/logger"
+import { applyModelOverride } from "~/lib/models"
 import { checkRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
 import {
@@ -37,9 +38,10 @@ export async function handleCompletion(c: Context) {
   debugJsonTail(logger, "Request payload:", { value: payload, tailLength: 400 })
 
   // Find the selected model
-  const selectedModel = state.models?.data.find(
+  const foundModel = state.models?.data.find(
     (model) => model.id === payload.model,
   )
+  const selectedModel = foundModel ? applyModelOverride(foundModel) : undefined
 
   if (selectedModel?.id === "gpt-5.4") {
     return c.json(

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -1,6 +1,7 @@
 import type { ToolContentSupportType } from "~/lib/config"
 import type { Model } from "~/services/copilot/get-models"
 
+import { applyModelOverride } from "~/lib/models"
 import { state } from "~/lib/state"
 import {
   type ChatCompletionResponse,
@@ -71,7 +72,8 @@ export function translateToOpenAI(
   options: TranslateToOpenAIOptions = {},
 ): ChatCompletionsPayload {
   const modelId = payload.model
-  const model = state.models?.data.find((m) => m.id === modelId)
+  const foundModel = state.models?.data.find((m) => m.id === modelId)
+  const model = foundModel ? applyModelOverride(foundModel) : undefined
   const thinkingBudget = getThinkingBudget(payload, model)
   const capabilities = {
     supportPdf: options.supportPdf ?? false,

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 
 import { forwardError } from "~/lib/error"
+import { applyModelOverrides } from "~/lib/models"
 import { state } from "~/lib/state"
 import { cacheModels } from "~/lib/utils"
 
@@ -13,22 +14,24 @@ modelRoutes.get("/", async (c) => {
       await cacheModels()
     }
 
-    const models = state.models?.data.map((model) => {
-      // limits is typed as required but is missing for embedding models at runtime
-      const is1m =
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        model.capabilities.limits?.max_context_window_tokens === 1_000_000
-      return {
-        ...model,
-        id: is1m ? `${model.id}[1m]` : model.id,
-        object: "model",
-        type: "model",
-        created: 0, // No date available from source
-        created_at: new Date(0).toISOString(), // No date available from source
-        owned_by: model.vendor,
-        display_name: model.name,
-      }
-    })
+    const models = applyModelOverrides(state.models?.data ?? []).map(
+      (model) => {
+        // limits is typed as required but is missing for embedding models at runtime
+        const is1m =
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          model.capabilities.limits?.max_context_window_tokens === 1_000_000
+        return {
+          ...model,
+          id: is1m ? `${model.id}[1m]` : model.id,
+          object: "model",
+          type: "model",
+          created: 0, // No date available from source
+          created_at: new Date(0).toISOString(), // No date available from source
+          owned_by: model.vendor,
+          display_name: model.name,
+        }
+      },
+    )
 
     return c.json({
       object: "list",

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -26,6 +26,7 @@ import { type ModelConfig, type ResolvedProviderConfig } from "~/lib/config"
 import { logCodexRateLimitsEvent } from "~/lib/codex-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { createHandlerLogger, debugJson, debugLazy } from "~/lib/logger"
+import { applyModelOverride } from "~/lib/models"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { resolveBridgeToolSearchName } from "~/lib/tool-search"
 import {
@@ -193,10 +194,11 @@ const handleOpenAIResponsesProviderMessages = async (
   },
 ): Promise<Response> => {
   const { payload, provider, providerConfig } = options
-  const selectedModel =
+  const foundModel =
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
+  const selectedModel = foundModel ? applyModelOverride(foundModel) : undefined
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(payload)
 
   applyResponsesApiContextManagement(

--- a/src/routes/provider/models/route.ts
+++ b/src/routes/provider/models/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 
 import { forwardError } from "~/lib/error"
 import { createHandlerLogger } from "~/lib/logger"
+import { applyModelOverrides } from "~/lib/models"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { getModels as getCodexModels } from "~/services/codex/get-models"
 import {
@@ -34,7 +35,7 @@ providerModelRoutes.get("/", async (c) => {
       const models = getCodexModels()
       return c.json({
         object: "list",
-        data: models.data,
+        data: applyModelOverrides(models.data),
         has_more: false,
       })
     }

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -6,6 +6,7 @@ import { streamSSE } from "hono/streaming"
 import { logCodexRateLimitsEvent } from "~/lib/codex-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { createHandlerLogger, debugJson } from "~/lib/logger"
+import { applyModelOverride } from "~/lib/models"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { requestContext } from "~/lib/request-context"
 import {
@@ -57,10 +58,11 @@ export async function handleProviderResponsesForProvider(
     )
   }
 
-  const model =
+  const foundModel =
     providerConfig.name === "codex" ?
       getCodexModels().data.find((model) => model.id === payload.model)
     : undefined
+  const model = foundModel ? applyModelOverride(foundModel) : undefined
 
   const maxPromptTokens = model?.capabilities.limits.max_prompt_tokens ?? 0
   // Smaller than the client compaction threshold, use server-side compaction to maintain cache hit rate

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -8,6 +8,7 @@ import {
   resolveMappedModel,
 } from "~/lib/config"
 import { createHandlerLogger, debugJson, debugJsonTail } from "~/lib/logger"
+import { applyModelOverride } from "~/lib/models"
 import { parseProviderModelAlias } from "~/lib/provider-model"
 import { checkRateLimit as checkConfiguredRateLimit } from "~/lib/rate-limit"
 import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
@@ -94,9 +95,10 @@ export const handleResponses = async (c: Context) => {
 
   compactInputByLatestCompaction(payload)
 
-  const selectedModel = state.models?.data.find(
+  const foundModel = state.models?.data.find(
     (model) => model.id === payload.model,
   )
+  const selectedModel = foundModel ? applyModelOverride(foundModel) : undefined
   const responsesTransport = getResponsesTransportForModel(selectedModel)
 
   if (!responsesTransport) {

--- a/tests/admin-model-overrides-route.test.ts
+++ b/tests/admin-model-overrides-route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+import type { ModelMetadataOverride } from "../src/lib/config"
+
+const actualConfigModule = await import("../src/lib/config")
+const actualPathsModule = await import("../src/lib/paths")
+
+let modelOverrides: Record<string, ModelMetadataOverride> = {
+  "gpt-5.4": { capabilities: { limits: { max_output_tokens: 32_000 } } },
+}
+
+const getModelOverrides = mock(() => modelOverrides)
+const setModelOverrides = mock(
+  (next: Record<string, ModelMetadataOverride>) => {
+    modelOverrides = next
+    return modelOverrides
+  },
+)
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getModelOverrides,
+  setModelOverrides,
+}))
+
+const { configRoutes } = await import("../src/routes/admin/config/route")
+
+const createApp = () => {
+  const app = new Hono()
+  app.route("/admin/config", configRoutes)
+  return app
+}
+
+beforeEach(() => {
+  modelOverrides = {
+    "gpt-5.4": { capabilities: { limits: { max_output_tokens: 32_000 } } },
+  }
+  getModelOverrides.mockClear()
+  setModelOverrides.mockClear()
+})
+
+describe("config model overrides route", () => {
+  test("returns the current model overrides snapshot", async () => {
+    const app = createApp()
+    const response = await app.request("/admin/config/model-overrides")
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      configPath: actualPathsModule.PATHS.CONFIG_PATH,
+      modelOverrides: {
+        "gpt-5.4": { capabilities: { limits: { max_output_tokens: 32_000 } } },
+      },
+    })
+    expect(getModelOverrides).toHaveBeenCalledTimes(1)
+  })
+
+  test("updates model overrides through the config API", async () => {
+    const app = createApp()
+    const next = {
+      "gpt-5.4": { supported_endpoints: ["/responses"] },
+    }
+    const response = await app.request("/admin/config/model-overrides", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ modelOverrides: next }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(setModelOverrides).toHaveBeenCalledWith(next)
+    expect(await response.json()).toEqual({
+      configPath: actualPathsModule.PATHS.CONFIG_PATH,
+      modelOverrides: next,
+    })
+  })
+
+  test("rejects non-object override values", async () => {
+    const app = createApp()
+    const response = await app.request("/admin/config/model-overrides", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ modelOverrides: { "gpt-5.4": "nope" } }),
+    })
+
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: { type: string } }
+    expect(json.error.type).toBe("invalid_request_error")
+    expect(setModelOverrides).not.toHaveBeenCalled()
+  })
+
+  test("rejects empty model ids", async () => {
+    const app = createApp()
+    const response = await app.request("/admin/config/model-overrides", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ modelOverrides: { "": { name: "x" } } }),
+    })
+
+    expect(response.status).toBe(400)
+    const json = (await response.json()) as { error: { type: string } }
+    expect(json.error.type).toBe("invalid_request_error")
+    expect(setModelOverrides).not.toHaveBeenCalled()
+  })
+})

--- a/tests/deep-merge.test.ts
+++ b/tests/deep-merge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test"
+
+import { deepMerge } from "../src/lib/deep-merge"
+
+describe("deepMerge", () => {
+  test("merges nested objects recursively", () => {
+    const target = {
+      capabilities: {
+        limits: { max_output_tokens: 100, max_prompt_tokens: 200 },
+      },
+    }
+    const source = { capabilities: { limits: { max_output_tokens: 999 } } }
+
+    expect(deepMerge(target, source)).toEqual({
+      capabilities: {
+        limits: { max_output_tokens: 999, max_prompt_tokens: 200 },
+      },
+    })
+  })
+
+  test("replaces arrays instead of merging them", () => {
+    const target = { supported_endpoints: ["/v1/messages", "/responses"] }
+    const source = { supported_endpoints: ["/responses"] }
+
+    expect(deepMerge(target, source)).toEqual({
+      supported_endpoints: ["/responses"],
+    })
+  })
+
+  test("replaces primitives and null", () => {
+    expect(
+      deepMerge<Record<string, unknown>>({ a: 1, b: 2 }, { a: 5, b: null }),
+    ).toEqual({
+      a: 5,
+      b: null,
+    })
+  })
+
+  test("replaces when types mismatch", () => {
+    expect(
+      deepMerge<Record<string, unknown>>(
+        { a: { nested: true } },
+        { a: "scalar" },
+      ),
+    ).toEqual({
+      a: "scalar",
+    })
+  })
+
+  test("does not mutate the inputs", () => {
+    const target = { capabilities: { limits: { max_output_tokens: 100 } } }
+    const source = { capabilities: { limits: { max_output_tokens: 999 } } }
+
+    deepMerge(target, source)
+
+    expect(target.capabilities.limits.max_output_tokens).toBe(100)
+    expect(source.capabilities.limits.max_output_tokens).toBe(999)
+  })
+
+  test("adds new keys from source", () => {
+    expect(deepMerge<Record<string, unknown>>({ a: 1 }, { b: 2 })).toEqual({
+      a: 1,
+      b: 2,
+    })
+  })
+})

--- a/tests/model-overrides-config.test.ts
+++ b/tests/model-overrides-config.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+interface ConfigFileShape {
+  auth?: { apiKeys?: Array<string>; adminApiKey?: string }
+  modelOverrides?: Record<string, unknown>
+}
+
+const cwd = fileURLToPath(new URL("../", import.meta.url))
+const decoder = new TextDecoder()
+const tempDirs: Array<string> = []
+
+function createTempConfigDir(): string {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "copilot-api-model-overrides-"),
+  )
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+function writeConfigFile(tempDir: string, config: ConfigFileShape): string {
+  const configPath = path.join(tempDir, "config.json")
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8")
+  return configPath
+}
+
+function readConfigFile(configPath: string): ConfigFileShape {
+  return JSON.parse(fs.readFileSync(configPath, "utf8")) as ConfigFileShape
+}
+
+function runConfigScript(tempDir: string, script: string): string {
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, "--eval", script],
+    cwd,
+    env: {
+      ...process.env,
+      COPILOT_API_HOME: tempDir,
+      COPILOT_API_OAUTH_APP: "",
+      COPILOT_API_ENTERPRISE_URL: "",
+    },
+  })
+
+  const stdout = decoder.decode(result.stdout)
+  if (result.exitCode !== 0) {
+    const stderr = decoder.decode(result.stderr)
+    throw new Error(
+      `Config script failed with exit code ${result.exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    )
+  }
+  return stdout
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe("model overrides config", () => {
+  test("getModelOverrides drops entries with empty ids or non-object values", () => {
+    const tempDir = createTempConfigDir()
+    writeConfigFile(tempDir, {
+      modelOverrides: {
+        "gpt-5.4": { capabilities: { limits: { max_output_tokens: 32_000 } } },
+        "": { name: "ignored" },
+        "gpt-5.5": "not-an-object",
+      },
+    })
+
+    const stdout = runConfigScript(
+      tempDir,
+      'const { getModelOverrides } = await import("./src/lib/config"); console.log(JSON.stringify(getModelOverrides()));',
+    )
+
+    expect(JSON.parse(stdout.trim())).toEqual({
+      "gpt-5.4": { capabilities: { limits: { max_output_tokens: 32_000 } } },
+    })
+  })
+
+  test("setModelOverrides validates, persists, and reloads", () => {
+    const tempDir = createTempConfigDir()
+    const configPath = writeConfigFile(tempDir, {
+      auth: { apiKeys: ["regular-key"] },
+    })
+
+    const stdout = runConfigScript(
+      tempDir,
+      'const { setModelOverrides } = await import("./src/lib/config"); console.log(JSON.stringify(setModelOverrides({ "gpt-5.4": { supported_endpoints: ["/responses"] } })));',
+    )
+
+    expect(JSON.parse(stdout.trim())).toEqual({
+      "gpt-5.4": { supported_endpoints: ["/responses"] },
+    })
+
+    const config = readConfigFile(configPath)
+    expect(config.modelOverrides).toEqual({
+      "gpt-5.4": { supported_endpoints: ["/responses"] },
+    })
+    // unrelated config is preserved
+    expect(config.auth?.apiKeys).toEqual(["regular-key"])
+  })
+
+  test("setModelOverrides throws on empty model ids", () => {
+    const tempDir = createTempConfigDir()
+    writeConfigFile(tempDir, {})
+
+    const stdout = runConfigScript(
+      tempDir,
+      'const { setModelOverrides } = await import("./src/lib/config"); try { setModelOverrides({ "": { name: "x" } }); console.log("NO_THROW"); } catch (e) { console.log("THREW"); }',
+    )
+
+    expect(stdout.trim()).toBe("THREW")
+  })
+
+  test("setModelOverrides throws on non-object override values", () => {
+    const tempDir = createTempConfigDir()
+    writeConfigFile(tempDir, {})
+
+    const stdout = runConfigScript(
+      tempDir,
+      'const { setModelOverrides } = await import("./src/lib/config"); try { setModelOverrides({ "gpt-5.4": "nope" }); console.log("NO_THROW"); } catch (e) { console.log("THREW"); }',
+    )
+
+    expect(stdout.trim()).toBe("THREW")
+  })
+})

--- a/tests/model-overrides.test.ts
+++ b/tests/model-overrides.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+
+import type { ModelMetadataOverride } from "../src/lib/config"
+import type { Model } from "../src/services/copilot/get-models"
+
+const actualConfigModule = await import("../src/lib/config")
+
+let modelOverrides: Record<string, ModelMetadataOverride> = {}
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getModelOverrides: () => modelOverrides,
+}))
+
+const { state } = await import("../src/lib/state")
+const { applyModelOverride, applyModelOverrides } = await import(
+  "../src/lib/models"
+)
+
+const createModel = (overrides: Partial<Model> = {}): Model => ({
+  capabilities: {
+    family: "gpt",
+    limits: { max_output_tokens: 16_000, max_prompt_tokens: 128_000 },
+    object: "model_capabilities",
+    supports: {},
+    tokenizer: "o200k_base",
+    type: "chat",
+  },
+  id: "gpt-5.4",
+  model_picker_enabled: true,
+  name: "GPT-5.4",
+  object: "model",
+  preview: false,
+  vendor: "openai",
+  version: "v1",
+  supported_endpoints: ["/v1/messages", "/responses"],
+  ...overrides,
+})
+
+beforeEach(() => {
+  modelOverrides = {}
+  state.models = { object: "list", data: [createModel()] }
+})
+
+describe("applyModelOverride", () => {
+  test("returns the model unchanged when there is no override", () => {
+    const model = createModel()
+    expect(applyModelOverride(model)).toBe(model)
+  })
+
+  test("deep-merges nested override fields", () => {
+    modelOverrides = {
+      "gpt-5.4": {
+        capabilities: { limits: { max_output_tokens: 32_000 } },
+      },
+    }
+
+    const result = applyModelOverride(createModel())
+
+    expect(result.capabilities.limits.max_output_tokens).toBe(32_000)
+    // unrelated nested field is preserved
+    expect(result.capabilities.limits.max_prompt_tokens).toBe(128_000)
+  })
+
+  test("replaces array fields entirely", () => {
+    modelOverrides = {
+      "gpt-5.4": { supported_endpoints: ["/responses"] },
+    }
+
+    expect(applyModelOverride(createModel()).supported_endpoints).toEqual([
+      "/responses",
+    ])
+  })
+
+  test("ignores attempts to override the id", () => {
+    modelOverrides = {
+      "gpt-5.4": { id: "something-else" } as ModelMetadataOverride,
+    }
+
+    expect(applyModelOverride(createModel()).id).toBe("gpt-5.4")
+  })
+
+  test("does not mutate the original model", () => {
+    modelOverrides = {
+      "gpt-5.4": { capabilities: { limits: { max_output_tokens: 1 } } },
+    }
+    const model = createModel()
+
+    applyModelOverride(model)
+
+    expect(model.capabilities.limits.max_output_tokens).toBe(16_000)
+  })
+})
+
+describe("applyModelOverrides", () => {
+  test("applies overrides to each model in a list", () => {
+    modelOverrides = {
+      "gpt-5.4": { name: "Overridden" },
+    }
+
+    const [result] = applyModelOverrides([createModel()])
+    expect(result.name).toBe("Overridden")
+  })
+})

--- a/tests/models-route-overrides.test.ts
+++ b/tests/models-route-overrides.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+import type { ModelMetadataOverride } from "../src/lib/config"
+import type { Model } from "../src/services/copilot/get-models"
+
+const actualConfigModule = await import("../src/lib/config")
+
+let modelOverrides: Record<string, ModelMetadataOverride> = {}
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getModelOverrides: () => modelOverrides,
+}))
+
+const { state } = await import("../src/lib/state")
+const { modelRoutes } = await import("../src/routes/models/route")
+
+const createModel = (overrides: Partial<Model> = {}): Model => ({
+  capabilities: {
+    family: "gpt",
+    limits: {
+      max_context_window_tokens: 200_000,
+      max_output_tokens: 16_000,
+      max_prompt_tokens: 128_000,
+    },
+    object: "model_capabilities",
+    supports: {},
+    tokenizer: "o200k_base",
+    type: "chat",
+  },
+  id: "gpt-5.4",
+  model_picker_enabled: true,
+  name: "GPT-5.4",
+  object: "model",
+  preview: false,
+  vendor: "openai",
+  version: "v1",
+  supported_endpoints: ["/v1/messages", "/responses"],
+  ...overrides,
+})
+
+const createApp = () => {
+  const app = new Hono()
+  app.route("/models", modelRoutes)
+  return app
+}
+
+interface ModelsListResponse {
+  data: Array<Model & { display_name: string; owned_by: string }>
+}
+
+beforeEach(() => {
+  modelOverrides = {}
+  state.models = { object: "list", data: [createModel()] }
+})
+
+describe("models route with overrides", () => {
+  test("advertises overridden metadata", async () => {
+    modelOverrides = {
+      "gpt-5.4": {
+        capabilities: { limits: { max_output_tokens: 32_000 } },
+        supported_endpoints: ["/responses"],
+      },
+    }
+
+    const response = await createApp().request("/models")
+    expect(response.status).toBe(200)
+
+    const json = (await response.json()) as ModelsListResponse
+    const model = json.data[0]
+    expect(model.capabilities.limits.max_output_tokens).toBe(32_000)
+    expect(model.supported_endpoints).toEqual(["/responses"])
+  })
+
+  test("computes the [1m] suffix from the overridden context window", async () => {
+    modelOverrides = {
+      "gpt-5.4": {
+        capabilities: { limits: { max_context_window_tokens: 1_000_000 } },
+      },
+    }
+
+    const response = await createApp().request("/models")
+    const json = (await response.json()) as ModelsListResponse
+    expect(json.data[0].id).toBe("gpt-5.4[1m]")
+  })
+
+  test("leaves metadata untouched when there is no override", async () => {
+    const response = await createApp().request("/models")
+    const json = (await response.json()) as ModelsListResponse
+    expect(json.data[0].id).toBe("gpt-5.4")
+    expect(json.data[0].capabilities.limits.max_output_tokens).toBe(16_000)
+  })
+})


### PR DESCRIPTION
## Summary
- add config/admin API support for per-model metadata overrides
- deep-merge overrides into cloned model metadata while preserving model ids
- apply overrides in model listing and model resolution paths, including Codex provider models

## Tests
- bun run typecheck
- bun run lint:all
- bun test
