### PR TITLE
Log requested model for messages

### DIFF
--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -81,6 +81,7 @@ export interface FlowBaseOptions {
   requestId: string
   sessionId?: string
   compactType?: CompactType
+  requestedModel: string
 }
 
 interface ResponsesFlowOptions extends FlowBaseOptions {
@@ -97,7 +98,14 @@ export const handleWithChatCompletions = async (
   anthropicPayload: AnthropicMessagesPayload,
   options: FlowBaseOptions,
 ) => {
-  const { logger, subagentMarker, requestId, sessionId, compactType } = options
+  const {
+    logger,
+    subagentMarker,
+    requestId,
+    sessionId,
+    compactType,
+    requestedModel,
+  } = options
   const openAIPayload = translateToOpenAI(anthropicPayload)
   prepareCopilotChatCompletionsPayload(openAIPayload)
   const recordUsage = createCopilotUsageRecorder({
@@ -115,6 +123,7 @@ export const handleWithChatCompletions = async (
       requestId,
       sessionId,
       compactType,
+      requestedModel,
     },
   )
 
@@ -310,6 +319,7 @@ export const handleWithMessagesApi = async (
     requestId,
     sessionId,
     compactType,
+    requestedModel,
   } = options
 
   prepareMessagesApiPayload(anthropicPayload, selectedModel)
@@ -330,6 +340,7 @@ export const handleWithMessagesApi = async (
       requestId,
       sessionId,
       compactType,
+      requestedModel,
     },
   )
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -141,6 +141,7 @@ export async function handleCompletion(c: Context) {
         sessionId,
         compactType,
         logger,
+        requestedModel,
       },
     )
   }
@@ -156,6 +157,7 @@ export async function handleCompletion(c: Context) {
         sessionId,
         compactType,
         logger,
+        requestedModel,
       },
     )
   }
@@ -169,6 +171,7 @@ export async function handleCompletion(c: Context) {
       sessionId,
       compactType,
       logger,
+      requestedModel,
     },
   )
 }

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -13,6 +13,7 @@ import {
 import { logCopilotRateLimits } from "~/lib/copilot-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import { logCopilotModel } from "~/services/copilot/model-log"
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
@@ -21,6 +22,7 @@ export const createChatCompletions = async (
     requestId: string
     sessionId?: string
     compactType?: CompactType
+    requestedModel?: string
   },
 ) => {
   if (!state.copilotToken) throw new Error("Copilot token not found")
@@ -56,7 +58,7 @@ export const createChatCompletions = async (
 
   prepareForCompact(headers, options.compactType)
 
-  consola.log(`<-- model: ${payload.model}`)
+  logCopilotModel(payload.model, options.requestedModel)
 
   const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
     method: "POST",

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -19,6 +19,7 @@ import { logCopilotRateLimits } from "~/lib/copilot-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
 import { parseUserIdMetadata } from "~/lib/utils"
+import { logCopilotModel } from "~/services/copilot/model-log"
 
 export type MessagesStream = ReturnType<typeof events>
 export type CreateMessagesReturn = AnthropicResponse | MessagesStream
@@ -70,6 +71,7 @@ export const createMessages = async (
     requestId: string
     sessionId?: string
     compactType?: CompactType
+    requestedModel?: string
   },
 ): Promise<CreateMessagesReturn> => {
   if (!state.copilotToken) throw new Error("Copilot token not found")
@@ -135,7 +137,7 @@ export const createMessages = async (
     headers["anthropic-beta"] = anthropicBeta
   }
 
-  consola.log(`<-- model: ${payload.model}`)
+  logCopilotModel(payload.model, options.requestedModel)
 
   const response = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
     method: "POST",

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -20,6 +20,7 @@ import {
 } from "~/lib/copilot-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import { logCopilotModel } from "~/services/copilot/model-log"
 import {
   createPooledWebSocketStream,
   createWebSocketUrl,
@@ -454,6 +455,7 @@ interface ResponsesRequestOptions {
   sessionId?: string
   compactType?: CompactType
   transport?: ResponsesTransport
+  requestedModel?: string
 }
 
 export const createResponses = async (
@@ -466,6 +468,7 @@ export const createResponses = async (
     sessionId,
     compactType,
     transport = "http",
+    requestedModel,
   }: ResponsesRequestOptions,
 ): Promise<CreateResponsesReturn> => {
   if (!state.copilotToken) throw new Error("Copilot token not found")
@@ -482,7 +485,7 @@ export const createResponses = async (
   // service_tier is not supported by github copilot
   payload.service_tier = undefined
 
-  consola.log(`<-- model: ${payload.model}`)
+  logCopilotModel(payload.model, requestedModel)
 
   const effectiveTransport =
     compactType === COMPACT_REQUEST ? "http" : transport

--- a/src/services/copilot/model-log.ts
+++ b/src/services/copilot/model-log.ts
@@ -1,0 +1,19 @@
+import consola from "consola"
+
+export const formatCopilotModelLog = (
+  model: string,
+  requestedModel?: string,
+): string => {
+  const logLine = `<-- model: ${model}`
+  if (!requestedModel) {
+    return logLine
+  }
+  return `${logLine} <-- requested model: ${requestedModel}`
+}
+
+export const logCopilotModel = (
+  model: string,
+  requestedModel?: string,
+): void => {
+  consola.log(formatCopilotModelLog(model, requestedModel))
+}

--- a/tests/messages-api-flows.test.ts
+++ b/tests/messages-api-flows.test.ts
@@ -6,6 +6,7 @@ import type {
   ChatCompletionResponse,
   ChatCompletionsPayload,
 } from "../src/services/copilot/create-chat-completions"
+import type { CreateMessagesReturn } from "../src/services/copilot/create-messages"
 import type {
   CreateResponsesReturn,
   ResponsesPayload,
@@ -14,11 +15,16 @@ import type {
 } from "../src/services/copilot/create-responses"
 
 import { COMPACT_REQUEST } from "../src/lib/compact"
+import { formatCopilotModelLog } from "../src/services/copilot/model-log"
 
 let capturedPayload: ChatCompletionsPayload | null = null
 let capturedResponsesPayload: ResponsesPayload | null = null
 let capturedResponsesOptions: {
+  requestedModel?: string
   transport?: ResponsesTransport
+} | null = null
+let capturedMessagesOptions: {
+  requestedModel?: string
 } | null = null
 let responsesApiWebSocketEnabled = true
 
@@ -48,6 +54,7 @@ const createResponses = mock(
   (
     payload: ResponsesPayload,
     options: {
+      requestedModel?: string
       transport?: ResponsesTransport
     },
   ): Promise<CreateResponsesReturn> => {
@@ -56,9 +63,34 @@ const createResponses = mock(
     return Promise.resolve(createResponsesResult(payload.model))
   },
 )
+const createMessages = mock(
+  (
+    payload: AnthropicMessagesPayload,
+    _anthropicBetaHeader: string | undefined,
+    options: {
+      requestedModel?: string
+    },
+  ): Promise<CreateMessagesReturn> => {
+    capturedMessagesOptions = options
+    return Promise.resolve({
+      id: "msg-test",
+      type: "message",
+      role: "assistant",
+      content: [],
+      model: payload.model,
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+      },
+    })
+  },
+)
 
 const {
   handleWithChatCompletions,
+  handleWithMessagesApi,
   handleWithResponsesApi,
   messagesApiFlowDependencies,
   prepareCopilotChatCompletionsPayload,
@@ -85,12 +117,15 @@ beforeEach(() => {
   capturedPayload = null
   capturedResponsesPayload = null
   capturedResponsesOptions = null
+  capturedMessagesOptions = null
   responsesApiWebSocketEnabled = true
   messagesApiFlowDependencies.createChatCompletions = createChatCompletions
+  messagesApiFlowDependencies.createMessages = createMessages
   messagesApiFlowDependencies.createResponses = createResponses
   responsesUtilsDependencies.isResponsesApiWebSocketEnabled = () =>
     responsesApiWebSocketEnabled
   createChatCompletions.mockClear()
+  createMessages.mockClear()
   createResponses.mockClear()
 })
 
@@ -129,6 +164,7 @@ test("messages Chat Completions flow adds Copilot cache control to system and la
   const response = await handleWithChatCompletions(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-test",
   })
 
   expect(response.status).toBe(200)
@@ -235,6 +271,30 @@ test("Copilot Chat Completions payload preparation marks two system and latest t
   ])
 })
 
+test("messages native flow passes requested model metadata to Copilot messages", async () => {
+  const payload: AnthropicMessagesPayload = {
+    max_tokens: 128,
+    messages: [{ role: "user", content: "hello" }],
+    model: "claude-opus-4.8",
+  }
+
+  const response = await handleWithMessagesApi(createContext(), payload, {
+    logger,
+    requestId: "request-1",
+    requestedModel: "claude-opus-4.7",
+  })
+
+  expect(response.status).toBe(200)
+  expect(createMessages).toHaveBeenCalledTimes(1)
+  expect(capturedMessagesOptions?.requestedModel).toBe("claude-opus-4.7")
+})
+
+test("Copilot model log includes requested model inline when provided", () => {
+  expect(formatCopilotModelLog("claude-opus-4.8", "claude-opus-4.7")).toBe(
+    "<-- model: claude-opus-4.8 <-- requested model: claude-opus-4.7",
+  )
+})
+
 test("messages Responses flow uses websocket transport by default for dual-endpoint models", async () => {
   const payload: AnthropicMessagesPayload = {
     max_tokens: 128,
@@ -245,6 +305,7 @@ test("messages Responses flow uses websocket transport by default for dual-endpo
   const response = await handleWithResponsesApi(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-test",
     selectedModel: createModel(["/responses", "ws:/responses"]),
   })
 
@@ -264,6 +325,7 @@ test("messages Responses flow keeps HTTP transport for dual-endpoint models when
   const response = await handleWithResponsesApi(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-test",
     selectedModel: createModel(["/responses", "ws:/responses"]),
   })
 
@@ -283,6 +345,7 @@ test("messages Responses flow keeps HTTP transport for compact requests", async 
     compactType: COMPACT_REQUEST,
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-test",
     selectedModel: createModel(["/responses", "ws:/responses"]),
   })
 
@@ -301,6 +364,7 @@ test("messages Responses flow keeps HTTP transport for /responses-only models", 
   const response = await handleWithResponsesApi(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-test",
     selectedModel: createModel(["/responses"]),
   })
 
@@ -331,6 +395,7 @@ test("messages Responses flow keeps streaming transport for deferred tool search
   const response = await handleWithResponsesApi(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-5.4",
     selectedModel: createModel(["/responses", "ws:/responses"]),
   })
 
@@ -344,7 +409,7 @@ test("messages Responses flow preserves the configured tool_search alias in non-
   createResponses.mockImplementationOnce(
     (
       payload: ResponsesPayload,
-      options: { transport?: ResponsesTransport },
+      options: { requestedModel?: string; transport?: ResponsesTransport },
     ) => {
       capturedResponsesPayload = payload
       capturedResponsesOptions = options
@@ -383,6 +448,7 @@ test("messages Responses flow preserves the configured tool_search alias in non-
   const response = await handleWithResponsesApi(createContext(), payload, {
     logger,
     requestId: "request-1",
+    requestedModel: "gpt-5.4",
     selectedModel: createModel(["/responses"]),
   })
 

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -30,6 +30,7 @@ type SelectedModel = {
 type FlowCallOptions = {
   compactType?: number
   requestId: string
+  requestedModel: string
   sessionId?: string
   subagentMarker?: unknown
   anthropicBetaHeader?: string
@@ -438,6 +439,9 @@ describe("messages handler orchestration", () => {
 
     const [, forwardedPayload] = handleWithMessagesApi.mock.calls[0]
     expect(forwardedPayload.model).toBe("messages-model")
+
+    const options = handleWithMessagesApi.mock.calls[0][2]
+    expect(options.requestedModel).toBe("claude-opus-4-7")
   })
 
   test("delegates to the Responses API flow when the model supports /responses", async () => {
@@ -584,6 +588,7 @@ describe("messages handler orchestration", () => {
 
     const options = handleWithMessagesApi.mock.calls[0][2]
     expect(options.requestId).toBe(expectedRequestId)
+    expect(options.requestedModel).toBe("original-model")
     expect(options.sessionId).toBe(expectedSessionId)
     expect(options.subagentMarker).toEqual({
       session_id: "sub-session",


### PR DESCRIPTION
## Summary
This PR improves `/v1/messages` observability by preserving the exact model value sent by the client before server-side model mapping, provider alias handling, warmup overrides, or endpoint model normalization. The original requested model is then included inline with the existing upstream Copilot model log.

This makes it easier to diagnose model-mapping behavior from the live server/desktop logs without enabling verbose payload logging or manually correlating handler debug files.

## Before
Only the final upstream model was visible in the live Copilot request log:

```text
<-- model: claude-opus-4.8
```

When a request was mapped from another model, the live log did not show which model the client originally requested.

## After
The same log line now includes both values:

```text
<-- model: claude-opus-4.8 <-- requested model: opus
```

If no rewrite occurs, both fields reflect the same model, which keeps the log format consistent while making mapping behavior explicit.

## Implementation Notes
- Captures the original `/v1/messages` `model` immediately after parsing the request body.
- Carries the requested model through the selected messages flow.
- Applies the inline log format across the Copilot service paths that `/v1/messages` can use: native Messages, Responses, and Chat Completions.
- Leaves direct `/v1/responses` and `/v1/chat/completions` behavior unchanged unless a caller provides requested-model metadata.

## Tests
- `bun test tests/messages-handler.test.ts tests/messages-api-flows.test.ts`
- `bun run lint`
- `bun run typecheck`