### PR TITLE
fix(messages): strip top-level cache_control and eager_input_streaming

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -745,6 +745,67 @@ const stripCacheControl = (payload: AnthropicMessagesPayload): void => {
   }
 }
 
+// Port top-level cache_control onto the last cacheable block as a lossless
+// polyfill, then drop the top-level field.
+const applyTopLevelCacheControl = (payload: AnthropicMessagesPayload): void => {
+  const topLevel = payload.cache_control
+  if (!topLevel || typeof topLevel !== "object") {
+    if (topLevel !== undefined) {
+      delete payload.cache_control
+    }
+    return
+  }
+
+  delete payload.cache_control
+
+  for (let m = payload.messages.length - 1; m >= 0; m--) {
+    const message = payload.messages[m]
+
+    if (typeof message.content === "string") {
+      message.content = [
+        {
+          type: "text",
+          text: message.content,
+          cache_control: { ...topLevel },
+        },
+      ]
+      return
+    }
+
+    if (!Array.isArray(message.content)) continue
+
+    for (let b = message.content.length - 1; b >= 0; b--) {
+      const block = message.content[b]
+      if (
+        block.type !== "text"
+        && block.type !== "image"
+        && block.type !== "tool_use"
+        && block.type !== "tool_result"
+      ) {
+        continue
+      }
+      if (!block.cache_control) {
+        block.cache_control = { ...topLevel }
+      }
+      return
+    }
+  }
+}
+
+// Strip per-tool eager_input_streaming.
+const stripToolEagerInputStreaming = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  if (!payload.tools || payload.tools.length === 0) return
+
+  for (const tool of payload.tools) {
+    const extended = tool as typeof tool & { eager_input_streaming?: unknown }
+    if ("eager_input_streaming" in extended) {
+      delete extended.eager_input_streaming
+    }
+  }
+}
+
 // Pre-request processing: filter thinking blocks for Claude models so only
 // valid thinking blocks are sent to the Copilot Messages API.
 const filterAssistantThinkingBlocks = (
@@ -770,6 +831,8 @@ export const prepareMessagesApiPayload = (
   selectedModel?: Model,
 ): void => {
   stripCacheControl(payload)
+  applyTopLevelCacheControl(payload)
+  stripToolEagerInputStreaming(payload)
   filterAssistantThinkingBlocks(payload)
 
   const hasThinking = Boolean(payload.thinking)

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1177,4 +1177,78 @@ describe("prepareMessagesApiPayload", () => {
     expect(payload.thinking).toBeUndefined()
     expect(payload.output_config).toBeUndefined()
   })
+
+  test("strips top-level cache_control sent by Zed (minimal-mode shape)", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-haiku-4.5",
+      max_tokens: 64000,
+      cache_control: { type: "ephemeral" },
+      system: [
+        {
+          type: "text",
+          text: "You are the Zed coding agent ...",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello world!" }],
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    expect(payload.cache_control).toBeUndefined()
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "Hello world!",
+        cache_control: { type: "ephemeral" },
+      },
+    ])
+    expect(
+      (payload.system as unknown as Array<Record<string, unknown>>)[0]
+        .cache_control,
+    ).toEqual({ type: "ephemeral", ttl: "1h" })
+  })
+
+  test("strips tool eager_input_streaming sent by Zed (write-mode shape)", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-haiku-4.5",
+      max_tokens: 64000,
+      cache_control: { type: "ephemeral" },
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "Hello World" }],
+        },
+      ],
+      tools: [
+        {
+          name: "edit_file",
+          input_schema: { type: "object" },
+          eager_input_streaming: true,
+        },
+        {
+          name: "write_file",
+          input_schema: { type: "object" },
+          eager_input_streaming: true,
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+      ] as unknown as AnthropicMessagesPayload["tools"],
+    }
+
+    prepareMessagesApiPayload(payload)
+
+    for (const tool of payload.tools ?? []) {
+      expect(tool).not.toHaveProperty("eager_input_streaming")
+    }
+    expect(payload.tools?.[1].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    })
+    expect(payload.cache_control).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Hello @caozhiyuan, this PR addresses the issues described in #269 

- Strip the per-tool `eager_input_streaming` field, which Copilot's Messages API rejects with `tools.N.custom.eager_input_streaming: Extra inputs are not permitted`.
- Port the top-level `cache_control` onto the last cacheable content block as a lossless polyfill, then drop the top-level field. Copilot rejects it with `cache_control: Extra inputs are not permitted`. 

Addressed this as proposed by @Menci's references and your input. Thank you both for that.

Applied to all models in `prepareMessagesApiPayload`, per the issue discussion.


- `bun test` → 276/276 pass (2 new tests covering both helpers)
- `bun run lint` clean
- Manually verified and working using Zed (Minimal / Ask / Write) with haiku 4.5, opus 4.5, sonnet 4.5, sonnet 4.6.

Let me know if more input or changes are needed.

Thank you for your time,

Kind regards.
