### PR TITLE
fix: add backoff to Copilot token refresh retries

### DIFF
--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -183,6 +183,8 @@ export const setupCodexToken = async (): Promise<void> => {
 const REFRESH_POLL_INTERVAL_MS = 15_000
 const EARLY_REFRESH_BUFFER_MS = 60_000
 const RETRY_REFRESH_DELAY_MS = 15_000
+const MAX_RETRY_REFRESH_DELAY_MS = 600_000
+const RETRY_REFRESH_JITTER_MS = 15_000
 const MIN_REFRESH_DELAY_MS = 1_000
 
 export const getRefreshDeadlineMs = (
@@ -204,6 +206,7 @@ const runCopilotRefreshLoop = async (
   signal: AbortSignal,
 ) => {
   let refreshAtMs = getRefreshDeadlineMs(refreshIn)
+  let retryDelayMs = RETRY_REFRESH_DELAY_MS
 
   while (!signal.aborted) {
     const nextDelayMs = getRefreshPollDelayMs(refreshAtMs)
@@ -218,15 +221,21 @@ const runCopilotRefreshLoop = async (
       const { token, refresh_in } = await getCopilotToken()
       state.copilotToken = token
       refreshAtMs = getRefreshDeadlineMs(refresh_in)
+      retryDelayMs = RETRY_REFRESH_DELAY_MS
       consola.debug("Copilot token refreshed")
       if (state.showToken) {
         consola.info("Refreshed Copilot token:", token)
       }
     } catch (error) {
       consola.error("Failed to refresh Copilot token:", error)
-      refreshAtMs = Date.now() + RETRY_REFRESH_DELAY_MS
+      const delayMs = Math.min(
+        retryDelayMs + Math.floor(Math.random() * RETRY_REFRESH_JITTER_MS),
+        MAX_RETRY_REFRESH_DELAY_MS,
+      )
+      refreshAtMs = Date.now() + delayMs
+      retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_REFRESH_DELAY_MS)
       consola.warn(
-        `Retrying Copilot token refresh in ${RETRY_REFRESH_DELAY_MS / 1000}s`,
+        `Retrying Copilot token refresh in ${Math.round(delayMs / 1000)}s`,
       )
     }
   }


### PR DESCRIPTION
When running copilot-api in batches, multiple instances can fail to refresh Copilot tokens at the same time and then retry every 15 seconds in lockstep. During transient GitHub/Copilot/network failures, this synchronized retry pattern can leave the batch stuck in collective refresh failures.

Add exponential backoff with jitter for Copilot token refresh retries, cap the retry delay at 10 minutes, and reset the delay after a successful refresh.

批量使用 copilot-api 时发现，多个实例可能同时刷新 Copilot token 失败，并按固定 15 秒节奏集体重试。在 GitHub/Copilot 临时异常、网络抖动或限流时，这种同步重试容易让批量实例陷入集体刷新卡死。

将 Copilot token 刷新失败重试改为带随机抖动的指数退避，最大延迟 10 分钟，并在刷新成功后重置退避延迟。