### PR TITLE
fix: convert Claude model IDs to hyphenated format in /v1/models response

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -2,6 +2,19 @@ import type { Model } from "~/services/copilot/get-models"
 
 import { state } from "~/lib/state"
 
+/**
+ * Converts a Copilot upstream model ID to a client-friendly ID that Claude Code
+ * and Claude Desktop recognize (dots in version replaced with hyphens).
+ * e.g. "claude-sonnet-4.6" -> "claude-sonnet-4-6"
+ * Non-Claude models are returned unchanged.
+ */
+export const toClientModelId = (modelId: string): string => {
+  const normalized = normalizeSdkModelId(modelId)
+  if (!normalized) return modelId
+  const versionHyphenated = normalized.version.replace(/\./g, "-")
+  return `claude-${normalized.family}-${versionHyphenated}`
+}
+
 export interface NormalizedSdkModelId {
   family: string
   version: string

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono"
 
 import { forwardError } from "~/lib/error"
+import { toClientModelId } from "~/lib/models"
 import { state } from "~/lib/state"
 import { cacheModels } from "~/lib/utils"
 
@@ -18,9 +19,10 @@ modelRoutes.get("/", async (c) => {
       const is1m =
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         model.capabilities.limits?.max_context_window_tokens === 1_000_000
+      const clientId = toClientModelId(model.id)
       return {
         ...model,
-        id: is1m ? `${model.id}[1m]` : model.id,
+        id: is1m ? `${clientId}[1m]` : clientId,
         object: "model",
         type: "model",
         created: 0, // No date available from source


### PR DESCRIPTION
## Problem

The upstream Copilot API returns Claude model IDs with dot-versioning (e.g. `claude-sonnet-4.6`), but Claude Code and Claude Desktop expect hyphenated versions (e.g. `claude-sonnet-4-6`). This causes these clients to not recognize returned models.

## Solution

- Added `toClientModelId()` helper in `src/lib/models.ts` that converts upstream dot-versioned model IDs to hyphenated client IDs
- Used `toClientModelId()` in the `/v1/models` route when building the response

The reverse direction (client request → upstream lookup) already works correctly: `findEndpointModel('claude-sonnet-4-6')` hits Pattern 2 in `normalizeSdkModelId` which reconstructs `claude-sonnet-4.6` to match the upstream model.
