### PR TITLE
fix: force HTTP transport and strip temperature/top_p for GPT-5 models in Responses API

### DIFF
--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -40,6 +40,7 @@ export const getResponsesRequestOptions = (
 export const getResponsesTransportForModel = (
   selectedModel:
     | {
+        id?: string
         supported_endpoints?: Array<string>
       }
     | undefined,
@@ -48,8 +49,15 @@ export const getResponsesTransportForModel = (
   } = {},
 ): ResponsesTransport | null => {
   const supportedEndpoints = selectedModel?.supported_endpoints ?? []
+  const modelId = selectedModel?.id ?? ''
+
+  // GPT-5 models have a known WebSocket issue with GitHub Copilot's
+  // Responses API — the WebSocket opens but delivers zero tokens before
+  // closing. Force HTTP transport so streaming uses SSE over fetch instead.
+  // See: https://github.com/caozhiyuan/copilot-api/issues/246
   const useWebSocket =
     responsesUtilsDependencies.isResponsesApiWebSocketEnabled()
+    && !modelId.startsWith('gpt-5')
 
   if (
     options.compactType !== COMPACT_REQUEST

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -486,6 +486,12 @@ export const createResponses = async (
   // service_tier is not supported by github copilot
   payload.service_tier = undefined
 
+  // GPT-5 models reject temperature and top_p in the Responses API
+  if (payload.model?.startsWith('gpt-5')) {
+    delete payload.temperature
+    delete payload.top_p
+  }
+
   consola.log(`<-- model: ${payload.model}`)
 
   const effectiveTransport =


### PR DESCRIPTION
Fixes GPT-5 models (gpt-5-mini, gpt-5.4, etc.) returning empty streams or 400 errors when using the Responses API through copilot-api.

**Two changes:**

1. **** — Skip WebSocket transport for gpt-5* models. GitHub Copilot's WebSocket opens but delivers zero tokens before disconnecting. Forces HTTP transport (SSE over fetch), which works correctly.

2. **** — Strip `temperature` and `top_p` from the payload for gpt-5* models. GitHub's backend rejects these parameters for GPT-5 with `"Unsupported parameter: 'temperature' is not supported with this model."`

Fixes #246