### PR TITLE
Stabilize Claude Code billing header cch for better cache hit rate

### DIFF
--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -33,6 +33,7 @@ import {
   getCompactType,
   getLastMessageContentCacheControl,
   mergeToolResultForClaude,
+  normalizeClaudeCodeBillingHeaderInSystem,
   normalizeSystemMessages,
   sanitizeIdeTools,
   stripToolReferenceTurnBoundary,
@@ -78,6 +79,7 @@ export async function handleCompletion(c: Context) {
 
   debugJson(logger, "Anthropic request payload:", anthropicPayload)
 
+  normalizeClaudeCodeBillingHeaderInSystem(anthropicPayload)
   normalizeSystemMessages(anthropicPayload)
 
   await checkRateLimit(state)

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -38,6 +38,8 @@ const IDE_GET_DIAGNOSTICS_TOOL = "mcp__ide__getDiagnostics"
 const IDE_GET_DIAGNOSTICS_DESCRIPTION =
   "Get language diagnostics from VS Code. Returns errors, warnings, information, and hints for files in the workspace."
 const PDF_FILE_READ_PREFIX = "PDF file read:"
+const CLAUDE_CODE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
+const CLAUDE_CODE_CCH_SEGMENT_PATTERN = /(^|;\s*)cch=[^;]+;/u
 
 type AnthropicAttachmentBlock = AnthropicImageBlock | AnthropicDocumentBlock
 type AnthropicMessageContentBlock =
@@ -157,6 +159,38 @@ const prependSystemContentToUserMessage = (
       [createTextBlock(message.content)]
     : message.content),
   ]
+}
+
+const normalizeClaudeCodeBillingHeader = (text: string): string => {
+  if (!text.startsWith(CLAUDE_CODE_BILLING_HEADER_PREFIX)) {
+    return text
+  }
+
+  return text.replace(CLAUDE_CODE_CCH_SEGMENT_PATTERN, "$1cch=<stable>;")
+}
+
+export const normalizeClaudeCodeBillingHeaderInSystem = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  const system = payload.system
+  if (!system) {
+    return
+  }
+
+  if (typeof system === "string") {
+    payload.system = normalizeClaudeCodeBillingHeader(system)
+    return
+  }
+
+  if (system.length === 0) {
+    return
+  }
+
+  payload.system = system.map((block, index) =>
+    index === 0 ?
+      { ...block, text: normalizeClaudeCodeBillingHeader(block.text) }
+    : block,
+  )
 }
 
 export const normalizeSystemMessages = (

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -71,6 +71,8 @@ const COMPACTION_SIGNATURE_PREFIX = "cm1#"
 const COMPACTION_SIGNATURE_SEPARATOR = "@"
 
 export const THINKING_TEXT = "Thinking..."
+const CLAUDE_CODE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
+const CLAUDE_CODE_CCH_SEGMENT_PATTERN = /(^|;\s*)cch=[^;]+;/u
 
 const buildPromptCacheKey = (
   basePromptCacheKey: string | null,
@@ -663,12 +665,25 @@ const translateSystemPrompt = (
   const text = system
     .map((block, index) => {
       if (index === 0) {
-        return block.text + "\n\n" + extraPrompt + "\n\n"
+        return (
+          normalizeSystemPromptBlockText(block.text)
+          + "\n\n"
+          + extraPrompt
+          + "\n\n"
+        )
       }
       return block.text
     })
     .join(" ")
   return text.length > 0 ? text : null
+}
+
+const normalizeSystemPromptBlockText = (text: string): string => {
+  if (!text.startsWith(CLAUDE_CODE_BILLING_HEADER_PREFIX)) {
+    return text
+  }
+
+  return text.replace(CLAUDE_CODE_CCH_SEGMENT_PATTERN, "$1cch=<stable>;")
 }
 
 const convertAnthropicTools = (

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -71,8 +71,6 @@ const COMPACTION_SIGNATURE_PREFIX = "cm1#"
 const COMPACTION_SIGNATURE_SEPARATOR = "@"
 
 export const THINKING_TEXT = "Thinking..."
-const CLAUDE_CODE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
-const CLAUDE_CODE_CCH_SEGMENT_PATTERN = /(^|;\s*)cch=[^;]+;/u
 
 const buildPromptCacheKey = (
   basePromptCacheKey: string | null,
@@ -665,25 +663,12 @@ const translateSystemPrompt = (
   const text = system
     .map((block, index) => {
       if (index === 0) {
-        return (
-          normalizeSystemPromptBlockText(block.text)
-          + "\n\n"
-          + extraPrompt
-          + "\n\n"
-        )
+        return block.text + "\n\n" + extraPrompt + "\n\n"
       }
       return block.text
     })
     .join(" ")
   return text.length > 0 ? text : null
-}
-
-const normalizeSystemPromptBlockText = (text: string): string => {
-  if (!text.startsWith(CLAUDE_CODE_BILLING_HEADER_PREFIX)) {
-    return text
-  }
-
-  return text.replace(CLAUDE_CODE_CCH_SEGMENT_PATTERN, "$1cch=<stable>;")
 }
 
 const convertAnthropicTools = (

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -13,6 +13,9 @@ const actualConfigModule = await import("../src/lib/config")
 const actualModelsModule = await import("../src/lib/models")
 const actualRateLimitModule = await import("../src/lib/rate-limit")
 const actualUtilsModule = await import("../src/lib/utils")
+const { responsesUtilsDependencies } = await import(
+  "../src/routes/responses/utils"
+)
 
 const state = {
   ...actualStateModule.state,
@@ -22,6 +25,7 @@ const state = {
 }
 
 let messagesApiEnabled = true
+let responsesApiWebSocketEnabled = true
 let modelMappings: Record<string, string> = {}
 type SelectedModel = {
   id: string
@@ -74,6 +78,7 @@ await mock.module("~/lib/config", () => ({
   ...actualConfigModule,
   getSmallModel: () => "small-model",
   isMessagesApiEnabled: () => messagesApiEnabled,
+  isResponsesApiWebSocketEnabled: () => responsesApiWebSocketEnabled,
   resolveMappedModel: (model: string) => modelMappings[model] ?? model,
 }))
 await mock.module("~/lib/models", () => ({
@@ -88,6 +93,7 @@ const { handleCompletion, messagesFlowHandlers } = await import(
 )
 
 const defaultMessagesFlowHandlers = { ...messagesFlowHandlers }
+const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
 
 const createApp = () => {
   const app = new Hono()
@@ -108,8 +114,12 @@ beforeEach(() => {
   state.manualApprove = false
   state.verbose = false
   messagesApiEnabled = true
+  responsesApiWebSocketEnabled = true
   modelMappings = {}
   selectedModel = undefined
+
+  responsesUtilsDependencies.isResponsesApiWebSocketEnabled = () =>
+    responsesApiWebSocketEnabled
 
   messagesFlowHandlers.handleWithMessagesApi = handleWithMessagesApi
   messagesFlowHandlers.handleWithResponsesApi = handleWithResponsesApi
@@ -129,6 +139,7 @@ afterEach(() => {
     defaultMessagesFlowHandlers.handleWithResponsesApi
   messagesFlowHandlers.handleWithChatCompletions =
     defaultMessagesFlowHandlers.handleWithChatCompletions
+  Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
 })
 
 describe("messages handler orchestration", () => {
@@ -441,7 +452,51 @@ describe("messages handler orchestration", () => {
     expect(forwardedPayload.model).toBe("messages-model")
   })
 
-  test("delegates to the Responses API flow when the model supports /responses", async () => {
+  test("stabilizes Claude Code billing header before forwarding to the Messages API flow", async () => {
+    selectedModel = {
+      id: "messages-model",
+      supported_endpoints: ["/v1/messages"],
+    }
+
+    const app = createApp()
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("messages")
+
+    const [, forwardedPayload] = handleWithMessagesApi.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
+  })
+
+  test("stabilizes Claude Code billing header before forwarding to the Responses API flow", async () => {
     selectedModel = {
       id: "responses-model",
       supported_endpoints: ["/responses"],
@@ -453,7 +508,20 @@ describe("messages handler orchestration", () => {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(createPayload()),
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
     })
 
     expect(response.status).toBe(200)
@@ -461,9 +529,22 @@ describe("messages handler orchestration", () => {
     expect(handleWithMessagesApi).not.toHaveBeenCalled()
     expect(handleWithResponsesApi).toHaveBeenCalledTimes(1)
     expect(handleWithChatCompletions).not.toHaveBeenCalled()
+
+    const [, forwardedPayload] = handleWithResponsesApi.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
   })
 
   test("delegates to the Responses API flow when the model supports ws:/responses", async () => {
+    responsesApiWebSocketEnabled = true
     selectedModel = {
       id: "responses-ws-model",
       supported_endpoints: ["ws:/responses"],
@@ -516,7 +597,7 @@ describe("messages handler orchestration", () => {
     expect(handleWithChatCompletions).toHaveBeenCalledTimes(1)
   })
 
-  test("falls back to the Chat Completions flow when no endpoint matches", async () => {
+  test("stabilizes Claude Code billing header before falling back to the Chat Completions flow", async () => {
     selectedModel = {
       id: "chat-model",
       supported_endpoints: [],
@@ -528,7 +609,20 @@ describe("messages handler orchestration", () => {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(createPayload()),
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
     })
 
     expect(response.status).toBe(200)
@@ -536,6 +630,18 @@ describe("messages handler orchestration", () => {
     expect(handleWithMessagesApi).not.toHaveBeenCalled()
     expect(handleWithResponsesApi).not.toHaveBeenCalled()
     expect(handleWithChatCompletions).toHaveBeenCalledTimes(1)
+
+    const [, forwardedPayload] = handleWithChatCompletions.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
   })
 
   test("applies warmup model override and passes request metadata to the selected flow", async () => {

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 
 import type { AnthropicMessagesPayload } from "../src/routes/messages/anthropic-types"
+
+const actualConfigModule = await import("../src/lib/config")
+
+let mockedReasoningEffort:
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh" = "xhigh"
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getReasoningEffortForModel: () => mockedReasoningEffort,
+}))
 
 import {
   applyLastMessageCacheControl,
@@ -11,6 +26,14 @@ import {
   sanitizeIdeTools,
   stripToolReferenceTurnBoundary,
 } from "../src/routes/messages/preprocess"
+
+beforeEach(() => {
+  mockedReasoningEffort = "xhigh"
+})
+
+afterEach(() => {
+  mockedReasoningEffort = "xhigh"
+})
 
 describe("normalizeSystemMessages", () => {
   test("merges system string content into the previous message", () => {

--- a/tests/responses-translation.test.ts
+++ b/tests/responses-translation.test.ts
@@ -190,36 +190,6 @@ describe("translateAnthropicMessagesToResponsesPayload", () => {
     expect(result.prompt_cache_key).toBe("opencode-session:agent:agent-123")
   })
 
-  it("stabilizes claude code billing header cch for claude code system prompts", () => {
-    const payload = {
-      model: "gpt-5.4",
-      max_tokens: 1024,
-      system: [
-        {
-          type: "text",
-          text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
-        },
-        {
-          type: "text",
-          text: "You are Claude Code, Anthropic's official CLI for Claude.",
-        },
-      ],
-      messages: [
-        {
-          role: "user",
-          content: [{ type: "text", text: "hello codex" }],
-        },
-      ],
-    } as unknown as AnthropicMessagesPayload
-
-    const result = translateAnthropicMessagesToResponsesPayload(payload)
-
-    expect(result.instructions).toContain(
-      "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
-    )
-    expect(result.instructions).not.toContain("cch=6fb32;")
-  })
-
   it("keeps unrelated system prompt text unchanged", () => {
     const payload = {
       model: "gpt-5.4",

--- a/tests/responses-translation.test.ts
+++ b/tests/responses-translation.test.ts
@@ -190,6 +190,60 @@ describe("translateAnthropicMessagesToResponsesPayload", () => {
     expect(result.prompt_cache_key).toBe("opencode-session:agent:agent-123")
   })
 
+  it("stabilizes claude code billing header cch for claude code system prompts", () => {
+    const payload = {
+      model: "gpt-5.4",
+      max_tokens: 1024,
+      system: [
+        {
+          type: "text",
+          text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+        },
+        {
+          type: "text",
+          text: "You are Claude Code, Anthropic's official CLI for Claude.",
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello codex" }],
+        },
+      ],
+    } as unknown as AnthropicMessagesPayload
+
+    const result = translateAnthropicMessagesToResponsesPayload(payload)
+
+    expect(result.instructions).toContain(
+      "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+    )
+    expect(result.instructions).not.toContain("cch=6fb32;")
+  })
+
+  it("keeps unrelated system prompt text unchanged", () => {
+    const payload = {
+      model: "gpt-5.4",
+      max_tokens: 1024,
+      system: [
+        {
+          type: "text",
+          text: "ordinary system prompt",
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello gpt54" }],
+        },
+      ],
+    } as unknown as AnthropicMessagesPayload
+
+    const result = translateAnthropicMessagesToResponsesPayload(payload)
+
+    expect(result.instructions).toContain("ordinary system prompt")
+    expect(result.instructions).not.toContain("cch=<stable>;")
+  })
+
   it("ignores blank subagent agent_id", () => {
     const result = translateAnthropicMessagesToResponsesPayload(
       {


### PR DESCRIPTION
## Summary
- stabilize the volatile `cch` segment in the Claude Code billing header before translating system prompts
- keep unrelated system prompt text unchanged
- add regression tests so translated instructions stay stable and improve Claude Code cache hit rate