### PR TITLE
fix: strip additional request headers before forwarding to Codex

### DIFF
--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -41,7 +41,9 @@ interface CodexResponsesHeaderOptions {
 }
 
 const STRIPPED_CODEX_REQUEST_HEADERS = new Set([
+  "accept-encoding",
   "authorization",
+  "cdn-loop",
   "connection",
   "content-length",
   "host",
@@ -51,8 +53,11 @@ const STRIPPED_CODEX_REQUEST_HEADERS = new Set([
   "te",
   "trailer",
   "transfer-encoding",
+  "true-client-ip",
   "upgrade",
   "x-api-key",
+  "x-forwarded-for",
+  "x-forwarded-proto",
 ])
 
 const STRIPPED_CODEX_WEBSOCKET_HEADERS = new Set(["accept", "content-type"])
@@ -106,6 +111,9 @@ export function buildCodexResponsesHeaders(
       continue
     }
     if (headerNameLower.includes("trace")) {
+      continue
+    }
+    if (headerNameLower.startsWith("cf-")) {
       continue
     }
     headers.set(headerName, headerValue)


### PR DESCRIPTION
This fixes the second issue in #278 

Sorry it took me some time to get around to testing using Codex itself with copilot-api.  What I found is if I pointed my Codex at http://localhost:4141, then it would use the copilot-api proxy fine.  But, if I tried to point Codex at a public URL I have established through a cloudflared tunnel in my own Cloudflare account (that proxies to copilot-api), then Codex would fail with: we're currently experiencing high demand which may cause temporary errors.

When I added debug code to copilot-api to log the request headers, I could see my cloudflared tunnel was adding several headers that were not present when Codex used localhost.  After some trial and error, I found these extra headers to be sufficient to get Codex working through localhost and my tunnel.  It also fixes the `curl` I was trying in that issue.

Thanks for bearing with me in the initial troubleshooting.  And thanks for this proxy.  I found it through your comment on the original's "is this project dead?" and I'm glad I did!