### PR TITLE
fix(messages): respect Anthropic cache-control budget

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -247,6 +247,13 @@ export const applyLastMessageCacheControl = (
   anthropicPayload: AnthropicMessagesPayload,
   lastMessageCacheControl: AnthropicCacheControl | undefined,
 ): void => {
+  if (
+    !lastMessageCacheControl
+    && countCacheControlBlocks(anthropicPayload) >= 4
+  ) {
+    return
+  }
+
   const cacheControl = lastMessageCacheControl ?? {
     type: "ephemeral",
   }
@@ -262,6 +269,35 @@ export const applyLastMessageCacheControl = (
   }
 
   lastBlock.cache_control = { ...cacheControl }
+}
+
+const countCacheControlBlocks = (payload: AnthropicMessagesPayload): number => {
+  let count = 0
+
+  const visitBlock = (block: unknown): void => {
+    if (block && typeof block === "object" && "cache_control" in block) {
+      count++
+    }
+  }
+
+  if (Array.isArray(payload.tools)) {
+    for (const tool of payload.tools) {
+      visitBlock(tool)
+    }
+  }
+  if (Array.isArray(payload.system)) {
+    for (const block of payload.system) {
+      visitBlock(block)
+    }
+  }
+  for (const message of payload.messages) {
+    if (!Array.isArray(message.content)) continue
+    for (const block of message.content) {
+      visitBlock(block)
+    }
+  }
+
+  return count
 }
 
 const getCompactCandidateText = (message: AnthropicInputMessage): string => {

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -418,6 +418,138 @@ describe("mergeToolResultForClaude", () => {
     })
   })
 
+  test("does not add default last-message cache_control when the request already has four breakpoints", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.7",
+      max_tokens: 128,
+      tools: [
+        {
+          name: "web_search",
+          input_schema: {},
+          cache_control: {
+            type: "ephemeral",
+          },
+        },
+      ],
+      system: [
+        {
+          type: "text",
+          text: "system prompt",
+          cache_control: {
+            type: "ephemeral",
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "older cached answer",
+              cache_control: {
+                type: "ephemeral",
+              },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "newer cached answer",
+              cache_control: {
+                type: "ephemeral",
+              },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "latest user message",
+            },
+          ],
+        },
+      ],
+    }
+
+    const lastMessageCacheControl = getLastMessageContentCacheControl(
+      payload.messages.at(-1),
+    )
+    applyLastMessageCacheControl(payload, lastMessageCacheControl)
+
+    expect(payload.messages.at(-1)).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "latest user message",
+        },
+      ],
+    })
+  })
+
+  test("adds default last-message cache_control when the request has budget left", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.7",
+      max_tokens: 128,
+      system: [
+        {
+          type: "text",
+          text: "system prompt",
+          cache_control: {
+            type: "ephemeral",
+          },
+        },
+      ],
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "cached answer",
+              cache_control: {
+                type: "ephemeral",
+              },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "latest user message",
+            },
+          ],
+        },
+      ],
+    }
+
+    const lastMessageCacheControl = getLastMessageContentCacheControl(
+      payload.messages.at(-1),
+    )
+    applyLastMessageCacheControl(payload, lastMessageCacheControl)
+
+    expect(payload.messages.at(-1)).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "latest user message",
+          cache_control: {
+            type: "ephemeral",
+          },
+        },
+      ],
+    })
+  })
+
   test("strips cache_control from blocks absorbed into tool_result content", () => {
     const payload: AnthropicMessagesPayload = {
       model: "claude-opus-4.6",


### PR DESCRIPTION
GitHub Copilot's Messages endpoint accepts Anthropic-style cache_control markers, but Anthropic enforces a hard request-wide limit of four cache breakpoints across tools, system, and message content blocks. The existing Messages preprocessing always restored or defaulted a cache_control marker onto the final message block after the tool-result merge pipeline. That preserved cache hints when the merge rewrote the tail block, but it also added a new ephemeral marker when the client did not mark the final message.

This caused valid upstream client requests that already contained four cache_control blocks to be forwarded as five-block requests. A MITM capture of copilot-api's outbound POST /v1/messages showed an incoming four-marker request being sent to api.business.githubcopilot.com with an extra messages[last].content[0].cache_control marker; GitHub Copilot/Anthropic then correctly rejected it with: 'A maximum of 4 blocks with cache_control may be provided. Found 5.' The same payload with three incoming markers was forwarded with four markers and succeeded.

Fix this by treating the automatic final-message marker as budgeted. If the final message did not originally carry cache_control and the request already contains four cache_control blocks, skip adding the default marker. Existing behavior is preserved when there is remaining budget, and explicit cache_control on the original tail is still restored after preprocessing.

Add regression coverage for both sides of the boundary: a four-breakpoint request must not receive a default final-message marker, while a request with remaining budget still gets the automatic final-message cache_control.