### PR TITLE
feat: add Copilot token usage costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The following command line options are available for the `start` command:
   - `baseUrl` should be provider API base URL without the final endpoint. For Anthropic providers, omit `/v1/messages`; for OpenAI-compatible providers, omit `/v1/chat/completions`; for OpenAI Responses providers, omit `/v1/responses`.
   - `apiKey` is used as the upstream credential value and is required for regular providers.
   - `authType` (optional): Controls how `apiKey` is sent upstream. Supports `x-api-key` and `authorization` for regular providers. Anthropic providers default to `x-api-key`; OpenAI-compatible and OpenAI Responses providers default to `authorization`. When set to `authorization`, the proxy sends `Authorization: Bearer <apiKey>`. `oauth2` is reserved for the built-in `codex` provider and is written automatically by `auth login --provider codex`.
-  - `adjustInputTokens` (optional): When `true`, the proxy will adjust the `input_tokens` in the usage response by subtracting `cache_read_input_tokens` and `cache_creation_input_tokens`. 
+  - `adjustInputTokens` (optional): When `true`, the proxy will adjust the `input_tokens` in the usage response by subtracting `cache_read_input_tokens`.
   - `models` (optional): Per-model configuration map. Each key is a model ID (matching the model name in requests), and the value is:
     - `temperature` (optional): Default temperature value used when the request does not specify one.
     - `topP` (optional): Default top_p value used when the request does not specify one.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -258,7 +258,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
   - `baseUrl`：provider API 的基础 URL，不要带结尾的 endpoint。Anthropic provider 不要带 `/v1/messages`；OpenAI 兼容 provider 不要带 `/v1/chat/completions`；OpenAI Responses provider 不要带 `/v1/responses`。
   - `apiKey`：作为上游凭据值使用；普通 provider 必须配置。
   - `authType`：可选，控制 `apiKey` 如何发送到上游。普通 provider 支持 `x-api-key` 和 `authorization`。Anthropic provider 默认 `x-api-key`；OpenAI 兼容和 OpenAI Responses provider 默认 `authorization`。当设置为 `authorization` 时，代理会发送 `Authorization: Bearer <apiKey>`。`oauth2` 仅保留给内置 `codex` provider，并由 `auth login --provider codex` 自动写入。
-  - `adjustInputTokens`：可选，当为 `true` 时，代理会在 usage 响应里用 `input_tokens` 减去 `cache_read_input_tokens` 和 `cache_creation_input_tokens`。
+  - `adjustInputTokens`：可选，当为 `true` 时，代理会在 usage 响应里用 `input_tokens` 减去 `cache_read_input_tokens`。
   - `models`：可选，按模型 ID 配置的映射。每个键为请求中的模型名，值支持：
     - `temperature`：可选，当请求未指定时使用的默认温度。
     - `topP`：可选，当请求未指定时使用的默认 `top_p`。

--- a/desktop/src/pages/DashboardPage.tsx
+++ b/desktop/src/pages/DashboardPage.tsx
@@ -58,7 +58,6 @@ const TOKEN_USAGE_EVENTS_PAGE_SIZE = 10
 const ALL_METRICS_VALUE = '__all__'
 const ALL_MODELS_VALUE = '__all__'
 const EMPTY_TOKEN_USAGE_TOTALS: TokenUsageTotals = {
-  cache_creation_input_tokens: 0,
   cache_read_input_tokens: 0,
   input_tokens: 0,
   output_tokens: 0,
@@ -741,7 +740,6 @@ function TokenUsagePanel({
         <TokenUsageMetric label={t('dashboard.tokenUsageInput')} value={totals.input_tokens} loading={loading} tone="blue" />
         <TokenUsageMetric label={t('dashboard.tokenUsageOutput')} value={totals.output_tokens} loading={loading} tone="green" />
         <TokenUsageMetric label={t('dashboard.tokenUsageCacheRead')} value={totals.cache_read_input_tokens} loading={loading} tone="cyan" />
-        <TokenUsageMetric label={t('dashboard.tokenUsageCacheWrite')} value={totals.cache_creation_input_tokens} loading={loading} tone="amber" />
         <TokenUsageMetric label={t('dashboard.tokenUsageRequests')} value={totals.request_count} loading={loading} tone="violet" />
       </div>
 
@@ -781,7 +779,6 @@ function TokenUsagePanel({
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageInput')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageOutput')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageCacheRead')}</th>
-                    <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageCacheWrite')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageTotal')}</th>
                   </tr>
                 </thead>
@@ -846,7 +843,6 @@ function TokenUsagePanel({
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageInput')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageOutput')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageCacheRead')}</th>
-                    <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageCacheWrite')}</th>
                     <th className="px-2.5 py-1.5 text-right font-semibold">{t('dashboard.tokenUsageTotal')}</th>
                   </tr>
                 </thead>
@@ -892,7 +888,6 @@ function TokenUsageMetric({ label, loading, tone, value }: {
 }
 
 type TokenUsageTrendMetricKey =
-  | 'cache_creation_input_tokens'
   | 'cache_read_input_tokens'
   | 'input_tokens'
   | 'output_tokens'
@@ -933,8 +928,7 @@ function TokenUsageTrendChart({
     { color: '#0f172a', key: 'total_tokens', label: t('dashboard.tokenUsageTotal') },
     { color: '#2563eb', key: 'input_tokens', label: t('dashboard.tokenUsageInput') },
     { color: '#16a34a', key: 'output_tokens', label: t('dashboard.tokenUsageOutput') },
-    { color: '#0891b2', key: 'cache_read_input_tokens', label: t('dashboard.tokenUsageCacheRead') },
-    { color: '#d97706', key: 'cache_creation_input_tokens', label: t('dashboard.tokenUsageCacheWrite') }
+    { color: '#0891b2', key: 'cache_read_input_tokens', label: t('dashboard.tokenUsageCacheRead') }
   ]
   const visibleMetrics = selectedMetric === ALL_METRICS_VALUE
     ? metrics
@@ -1144,7 +1138,6 @@ function TokenUsageModelRow({ model }: { model: TokenUsageModelSummary }) {
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(model.input_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(model.output_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(model.cache_read_input_tokens)}</td>
-      <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(model.cache_creation_input_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right font-semibold text-[#0f172a]">{formatTokenCount(calcTokenTotal(model))}</td>
     </tr>
   )
@@ -1172,7 +1165,6 @@ function TokenUsageEventRow({ event }: { event: TokenUsageEventRecord }) {
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(event.input_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(event.output_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(event.cache_read_input_tokens)}</td>
-      <td className="px-2.5 py-1.5 text-right text-slate-500">{formatTokenCount(event.cache_creation_input_tokens)}</td>
       <td className="px-2.5 py-1.5 text-right font-semibold text-[#0f172a]">
         {formatTokenCount(event.total_tokens)}
       </td>

--- a/desktop/src/types/ipc.ts
+++ b/desktop/src/types/ipc.ts
@@ -38,7 +38,6 @@ export interface TokenUsageTotals {
   input_tokens: number
   output_tokens: number
   cache_read_input_tokens: number
-  cache_creation_input_tokens: number
   total_tokens: number
 }
 
@@ -93,7 +92,6 @@ export interface TokenUsageEventRecord {
   input_tokens: number
   output_tokens: number
   cache_read_input_tokens: number
-  cache_creation_input_tokens: number
   total_tokens: number
 }
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -281,7 +281,6 @@
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
           input_tokens: 0,
-          nano_cost_cache_creation: null,
           nano_cost_cache_read: null,
           nano_cost_cache_write: null,
           nano_cost_input: null,
@@ -512,22 +511,12 @@
           return `$${(Number(value) / 100000000000).toFixed(6)}`;
         }
 
-        function getCacheWriteNanoCost(totals) {
-          const cacheWrite = Number.isFinite(totals?.nano_cost_cache_write)
-            ? totals.nano_cost_cache_write
-            : 0;
-          const cacheCreation = Number.isFinite(totals?.nano_cost_cache_creation)
-            ? totals.nano_cost_cache_creation
-            : 0;
-          return cacheWrite + cacheCreation;
-        }
-
         function getTokenUsageCostLines(totals) {
           return [
             `Input Cost: ${formatUsdFromNano(totals?.nano_cost_input)}`,
             `Output Cost: ${formatUsdFromNano(totals?.nano_cost_output)}`,
             `Cache Read Cost: ${formatUsdFromNano(totals?.nano_cost_cache_read)}`,
-            `Cache Write Cost: ${formatUsdFromNano(getCacheWriteNanoCost(totals))}`,
+            `Cache Write Cost: ${formatUsdFromNano(totals?.nano_cost_cache_write)}`,
           ];
         }
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -278,7 +278,6 @@
         const API_KEY_STORAGE_KEY = "copilot-api.usage-viewer.x-api-key";
         const VALID_PERIODS = new Set(["day", "week", "month"]);
         const EMPTY_TOKEN_USAGE_TOTALS = {
-          cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
           input_tokens: 0,
           nano_cost_cache_read: null,
@@ -873,11 +872,6 @@
               key: "cache_read_input_tokens",
               label: "Cache Read",
             },
-            {
-              color: "var(--color-yellow-accent)",
-              key: "cache_creation_input_tokens",
-              label: "Cache Write",
-            },
           ];
         }
 
@@ -1226,9 +1220,6 @@
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     model.cache_read_input_tokens
                   )}</td>
-                  <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
-                    model.cache_creation_input_tokens
-                  )}</td>
                 </tr>
               `;
             })
@@ -1246,7 +1237,6 @@
                     <th class="px-4 py-2 text-right font-semibold">Input</th>
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1305,9 +1295,6 @@
                   )}</td>
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     event.cache_read_input_tokens
-                  )}</td>
-                  <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
-                    event.cache_creation_input_tokens
                   )}</td>
                 </tr>
               `;

--- a/pages/index.html
+++ b/pages/index.html
@@ -512,14 +512,22 @@
           return `$${(Number(value) / 100000000000).toFixed(6)}`;
         }
 
+        function getCacheWriteNanoCost(totals) {
+          const cacheWrite = Number.isFinite(totals?.nano_cost_cache_write)
+            ? totals.nano_cost_cache_write
+            : 0;
+          const cacheCreation = Number.isFinite(totals?.nano_cost_cache_creation)
+            ? totals.nano_cost_cache_creation
+            : 0;
+          return cacheWrite + cacheCreation;
+        }
+
         function getTokenUsageCostLines(totals) {
           return [
-            `Total Cost: ${formatUsdFromNano(totals?.total_nano_aiu)}`,
             `Input Cost: ${formatUsdFromNano(totals?.nano_cost_input)}`,
             `Output Cost: ${formatUsdFromNano(totals?.nano_cost_output)}`,
             `Cache Read Cost: ${formatUsdFromNano(totals?.nano_cost_cache_read)}`,
-            `Cache Write Cost: ${formatUsdFromNano(totals?.nano_cost_cache_write)}`,
-            `Cache Creation Cost: ${formatUsdFromNano(totals?.nano_cost_cache_creation)}`,
+            `Cache Write Cost: ${formatUsdFromNano(getCacheWriteNanoCost(totals))}`,
           ];
         }
 
@@ -792,68 +800,13 @@
                   : ""
               }
 
-              <div class="grid grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-3 ${
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 ${
                 state.isTokenUsageLoading ? "opacity-60" : ""
               }">
                 ${renderTokenUsageUsdMetric(
                   "Total Cost",
                   totals.total_nano_aiu,
                   "var(--color-yellow-accent)"
-                )}
-                ${renderTokenUsageUsdMetric(
-                  "Input Cost",
-                  totals.nano_cost_input,
-                  "var(--color-blue-accent)"
-                )}
-                ${renderTokenUsageUsdMetric(
-                  "Output Cost",
-                  totals.nano_cost_output,
-                  "var(--color-green-accent)"
-                )}
-                ${renderTokenUsageUsdMetric(
-                  "Cache Read Cost",
-                  totals.nano_cost_cache_read,
-                  "var(--color-aqua-accent)"
-                )}
-                ${renderTokenUsageUsdMetric(
-                  "Cache Write Cost",
-                  totals.nano_cost_cache_write,
-                  "var(--color-yellow-accent)"
-                )}
-                ${renderTokenUsageUsdMetric(
-                  "Cache Creation Cost",
-                  totals.nano_cost_cache_creation,
-                  "var(--color-orange-accent)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Total",
-                  totals.total_tokens,
-                  "var(--color-fg-lightest)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Input",
-                  totals.input_tokens,
-                  "var(--color-blue-accent)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Output",
-                  totals.output_tokens,
-                  "var(--color-green-accent)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Cache Read",
-                  totals.cache_read_input_tokens,
-                  "var(--color-aqua-accent)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Cache Write",
-                  totals.cache_creation_input_tokens,
-                  "var(--color-yellow-accent)"
-                )}
-                ${renderTokenUsageMetric(
-                  "Requests",
-                  totals.request_count,
-                  "var(--color-purple-accent)"
                 )}
               </div>
 
@@ -1196,9 +1149,6 @@
                 <span class="font-semibold" style="color: var(--color-fg-lightest);">${escapeHtml(
                   formatChartDate(activeDay.date)
                 )}</span>
-                ${getTokenUsageCostLines(activeTotals)
-                  .map((line) => `<span>${escapeHtml(line)}</span>`)
-                  .join("")}
                 ${visibleMetrics
                   .map(
                     (metric) =>
@@ -1263,11 +1213,18 @@
 
           const rows = summary.byModel
             .map((model) => {
+              const costBreakdown = getTokenUsageCostLines(model).join("\n");
               return `
                 <tr class="border-b last:border-b-0" style="border-color: var(--color-bg-light-1);">
                   <td class="px-4 py-2 max-w-[280px] truncate" style="color: var(--color-fg-lightest);" title="${escapeHtml(
                     model.model
                   )}">${escapeHtml(model.model)}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);" title="${escapeHtml(costBreakdown)}">${formatUsdFromNano(
+                    model.total_nano_aiu
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
+                    model.total_tokens
+                  )}</td>
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     model.request_count
                   )}</td>
@@ -1283,27 +1240,6 @@
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     model.cache_creation_input_tokens
                   )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-blue-accent);">${formatUsdFromNano(
-                    model.nano_cost_input
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-green-accent);">${formatUsdFromNano(
-                    model.nano_cost_output
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-aqua-accent);">${formatUsdFromNano(
-                    model.nano_cost_cache_read
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
-                    model.nano_cost_cache_write
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-orange-accent);">${formatUsdFromNano(
-                    model.nano_cost_cache_creation
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
-                    model.total_nano_aiu
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
-                    model.total_tokens
-                  )}</td>
                 </tr>
               `;
             })
@@ -1311,21 +1247,17 @@
 
           return `
             <div class="overflow-auto ${state.isTokenUsageLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[1320px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[880px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Model</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total</th>
                     <th class="px-4 py-2 text-right font-semibold">Requests</th>
                     <th class="px-4 py-2 text-right font-semibold">Input</th>
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Input Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Output Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Read Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Write Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Creation Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1348,6 +1280,7 @@
               const userId = formatCellText(event.user_id);
               const sessionId = formatCellText(event.session_id);
               const traceId = formatCellText(event.trace_id);
+              const costBreakdown = getTokenUsageCostLines(event).join("\n");
 
               return `
                 <tr class="border-b last:border-b-0" style="border-color: var(--color-bg-light-1);">
@@ -1369,6 +1302,12 @@
                   <td class="px-4 py-2 max-w-[200px] truncate font-mono" style="color: var(--color-fg-dark);" title="${escapeHtml(
                     traceId
                   )}">${escapeHtml(traceId)}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);" title="${escapeHtml(costBreakdown)}">${formatUsdFromNano(
+                    event.total_nano_aiu
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
+                    event.total_tokens
+                  )}</td>
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     event.input_tokens
                   )}</td>
@@ -1381,27 +1320,6 @@
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     event.cache_creation_input_tokens
                   )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-blue-accent);">${formatUsdFromNano(
-                    event.nano_cost_input
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-green-accent);">${formatUsdFromNano(
-                    event.nano_cost_output
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-aqua-accent);">${formatUsdFromNano(
-                    event.nano_cost_cache_read
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
-                    event.nano_cost_cache_write
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-orange-accent);">${formatUsdFromNano(
-                    event.nano_cost_cache_creation
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
-                    event.total_nano_aiu
-                  )}</td>
-                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
-                    event.total_tokens
-                  )}</td>
                 </tr>
               `;
             })
@@ -1409,7 +1327,7 @@
 
           return `
             <div class="overflow-auto ${state.isEventsLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[1720px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[1280px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Time</th>
@@ -1418,16 +1336,12 @@
                     <th class="px-4 py-2 font-semibold">Model</th>
                     <th class="px-4 py-2 font-semibold">Session</th>
                     <th class="px-4 py-2 font-semibold">Trace</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total</th>
                     <th class="px-4 py-2 text-right font-semibold">Input</th>
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Input Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Output Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Read Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Write Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Cache Creation Cost</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/pages/index.html
+++ b/pages/index.html
@@ -281,8 +281,14 @@
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
           input_tokens: 0,
+          nano_cost_cache_creation: null,
+          nano_cost_cache_read: null,
+          nano_cost_cache_write: null,
+          nano_cost_input: null,
+          nano_cost_output: null,
           output_tokens: 0,
           request_count: 0,
+          total_nano_aiu: null,
           total_tokens: 0,
         };
 
@@ -497,6 +503,24 @@
 
         function formatNumber(value) {
           return Number.isFinite(value) ? Number(value).toLocaleString() : "0";
+        }
+
+        function formatUsdFromNano(value) {
+          if (!Number.isFinite(value)) {
+            return "—";
+          }
+          return `$${(Number(value) / 100000000000).toFixed(6)}`;
+        }
+
+        function getTokenUsageCostLines(totals) {
+          return [
+            `Total Cost: ${formatUsdFromNano(totals?.total_nano_aiu)}`,
+            `Input Cost: ${formatUsdFromNano(totals?.nano_cost_input)}`,
+            `Output Cost: ${formatUsdFromNano(totals?.nano_cost_output)}`,
+            `Cache Read Cost: ${formatUsdFromNano(totals?.nano_cost_cache_read)}`,
+            `Cache Write Cost: ${formatUsdFromNano(totals?.nano_cost_cache_write)}`,
+            `Cache Creation Cost: ${formatUsdFromNano(totals?.nano_cost_cache_creation)}`,
+          ];
         }
 
         function formatDateTime(value) {
@@ -768,9 +792,39 @@
                   : ""
               }
 
-              <div class="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3 ${
+              <div class="grid grid-cols-2 lg:grid-cols-4 xl:grid-cols-6 gap-3 ${
                 state.isTokenUsageLoading ? "opacity-60" : ""
               }">
+                ${renderTokenUsageUsdMetric(
+                  "Total Cost",
+                  totals.total_nano_aiu,
+                  "var(--color-yellow-accent)"
+                )}
+                ${renderTokenUsageUsdMetric(
+                  "Input Cost",
+                  totals.nano_cost_input,
+                  "var(--color-blue-accent)"
+                )}
+                ${renderTokenUsageUsdMetric(
+                  "Output Cost",
+                  totals.nano_cost_output,
+                  "var(--color-green-accent)"
+                )}
+                ${renderTokenUsageUsdMetric(
+                  "Cache Read Cost",
+                  totals.nano_cost_cache_read,
+                  "var(--color-aqua-accent)"
+                )}
+                ${renderTokenUsageUsdMetric(
+                  "Cache Write Cost",
+                  totals.nano_cost_cache_write,
+                  "var(--color-yellow-accent)"
+                )}
+                ${renderTokenUsageUsdMetric(
+                  "Cache Creation Cost",
+                  totals.nano_cost_cache_creation,
+                  "var(--color-orange-accent)"
+                )}
                 ${renderTokenUsageMetric(
                   "Total",
                   totals.total_tokens,
@@ -1090,6 +1144,7 @@
               const totals = getDailyTrendTotals(day, selectedModel);
               const title = [
                 formatChartDate(day.date),
+                ...getTokenUsageCostLines(totals),
                 ...visibleMetrics.map(
                   (metric) =>
                     `${metric.label}: ${formatNumber(
@@ -1141,6 +1196,9 @@
                 <span class="font-semibold" style="color: var(--color-fg-lightest);">${escapeHtml(
                   formatChartDate(activeDay.date)
                 )}</span>
+                ${getTokenUsageCostLines(activeTotals)
+                  .map((line) => `<span>${escapeHtml(line)}</span>`)
+                  .join("")}
                 ${visibleMetrics
                   .map(
                     (metric) =>
@@ -1183,6 +1241,19 @@
           `;
         }
 
+        function renderTokenUsageUsdMetric(label, value, accentColor) {
+          return `
+            <div class="p-4 border" style="background-color: var(--color-bg); border-color: var(--color-bg-light-2);">
+              <div class="text-lg font-bold" style="color: ${accentColor};">${formatUsdFromNano(
+                value
+              )}</div>
+              <div class="mt-1 text-xs uppercase tracking-wide" style="color: var(--color-gray-accent);">${escapeHtml(
+                label
+              )}</div>
+            </div>
+          `;
+        }
+
         function renderTokenUsageModelBreakdown(summary) {
           if (!summary || summary.byModel.length === 0) {
             return renderEmptyState(
@@ -1212,6 +1283,24 @@
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     model.cache_creation_input_tokens
                   )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-blue-accent);">${formatUsdFromNano(
+                    model.nano_cost_input
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-green-accent);">${formatUsdFromNano(
+                    model.nano_cost_output
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-aqua-accent);">${formatUsdFromNano(
+                    model.nano_cost_cache_read
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
+                    model.nano_cost_cache_write
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-orange-accent);">${formatUsdFromNano(
+                    model.nano_cost_cache_creation
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
+                    model.total_nano_aiu
+                  )}</td>
                   <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
                     model.total_tokens
                   )}</td>
@@ -1222,7 +1311,7 @@
 
           return `
             <div class="overflow-auto ${state.isTokenUsageLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[760px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[1320px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Model</th>
@@ -1231,7 +1320,12 @@
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total</th>
+                    <th class="px-4 py-2 text-right font-semibold">Input Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Output Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Read Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Write Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Creation Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1287,6 +1381,24 @@
                   <td class="px-4 py-2 text-right" style="color: var(--color-fg-dark);">${formatNumber(
                     event.cache_creation_input_tokens
                   )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-blue-accent);">${formatUsdFromNano(
+                    event.nano_cost_input
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-green-accent);">${formatUsdFromNano(
+                    event.nano_cost_output
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-aqua-accent);">${formatUsdFromNano(
+                    event.nano_cost_cache_read
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
+                    event.nano_cost_cache_write
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-orange-accent);">${formatUsdFromNano(
+                    event.nano_cost_cache_creation
+                  )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatUsdFromNano(
+                    event.total_nano_aiu
+                  )}</td>
                   <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
                     event.total_tokens
                   )}</td>
@@ -1297,7 +1409,7 @@
 
           return `
             <div class="overflow-auto ${state.isEventsLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[1180px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[1720px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Time</th>
@@ -1310,7 +1422,12 @@
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total</th>
+                    <th class="px-4 py-2 text-right font-semibold">Input Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Output Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Read Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Write Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Cache Creation Cost</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -106,7 +106,6 @@ function resolveUserId(input: TokenUsageEventInput): string {
 function resolveTokenDetails(
   details: Array<TokenUsageTokenDetail> | null | undefined,
 ): {
-  nano_cost_cache_creation: number | null
   nano_cost_cache_read: number | null
   nano_cost_cache_write: number | null
   nano_cost_input: number | null
@@ -114,7 +113,6 @@ function resolveTokenDetails(
 } {
   if (!Array.isArray(details)) {
     return {
-      nano_cost_cache_creation: null,
       nano_cost_cache_read: null,
       nano_cost_cache_write: null,
       nano_cost_input: null,
@@ -123,7 +121,6 @@ function resolveTokenDetails(
   }
 
   const result = {
-    nano_cost_cache_creation: 0,
     nano_cost_cache_read: 0,
     nano_cost_cache_write: 0,
     nano_cost_input: 0,
@@ -152,10 +149,6 @@ function resolveTokenDetails(
       }
       case "cache_write": {
         result.nano_cost_cache_write += cost
-        break
-      }
-      case "cache_creation": {
-        result.nano_cost_cache_creation += cost
         break
       }
       case "output": {

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -171,9 +171,6 @@ function toPersistedEvent(
   const now = new Date()
   const cost = resolveTokenDetails(input.copilotUsage?.token_details)
   return {
-    cache_creation_input_tokens: normalizeToken(
-      input.cache_creation_input_tokens,
-    ),
     cache_read_input_tokens: normalizeToken(input.cache_read_input_tokens),
     created_at_ms: now.getTime(),
     created_at_utc: now.toISOString(),
@@ -249,7 +246,6 @@ export function normalizeOpenAIUsage(
         prompt_tokens?: number
         total_tokens?: number
         prompt_tokens_details?: {
-          cache_creation_input_tokens?: number
           cached_tokens?: number
         }
       }
@@ -259,17 +255,10 @@ export function normalizeOpenAIUsage(
   const cachedTokens = normalizeToken(
     usage?.prompt_tokens_details?.cached_tokens,
   )
-  const cacheCreationTokens = normalizeToken(
-    usage?.prompt_tokens_details?.cache_creation_input_tokens,
-  )
   const promptTokens = normalizeToken(usage?.prompt_tokens)
   return {
-    cache_creation_input_tokens: cacheCreationTokens,
     cache_read_input_tokens: cachedTokens,
-    input_tokens: Math.max(
-      0,
-      promptTokens - cachedTokens - cacheCreationTokens,
-    ),
+    input_tokens: Math.max(0, promptTokens - cachedTokens),
     output_tokens: normalizeToken(usage?.completion_tokens),
     total_tokens: normalizeOptionalToken(usage?.total_tokens),
   }
@@ -303,7 +292,6 @@ export function normalizeResponsesUsage(
 export function normalizeAnthropicUsage(
   usage:
     | {
-        cache_creation_input_tokens?: number
         cache_read_input_tokens?: number
         input_tokens?: number
         output_tokens?: number
@@ -313,9 +301,6 @@ export function normalizeAnthropicUsage(
     | undefined,
 ): UsageTokens {
   return {
-    cache_creation_input_tokens: normalizeOptionalToken(
-      usage?.cache_creation_input_tokens,
-    ),
     cache_read_input_tokens: normalizeOptionalToken(
       usage?.cache_read_input_tokens,
     ),
@@ -330,8 +315,6 @@ export function mergeAnthropicUsage(
   next: UsageTokens,
 ): UsageTokens {
   return {
-    cache_creation_input_tokens:
-      next.cache_creation_input_tokens ?? current.cache_creation_input_tokens,
     cache_read_input_tokens:
       next.cache_read_input_tokens ?? current.cache_read_input_tokens,
     input_tokens: next.input_tokens ?? current.input_tokens,

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -362,3 +362,26 @@ export function copilotUsageToTokens(
     total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }
+
+export function nonEmptyCopilotUsageTokens(
+  usage: CopilotUsage | null | undefined,
+): CopilotUsageTokens | null {
+  const tokens = copilotUsageToTokens(usage)
+  return (
+      tokens.token_details !== undefined || tokens.total_nano_aiu !== undefined
+    ) ?
+      tokens
+    : null
+}
+
+export function copilotUsageFromResponsesEvent(event: {
+  copilot_usage?: CopilotUsage | null
+  response?: { copilot_usage?: CopilotUsage | null }
+}): CopilotUsageTokens | null {
+  const topLevelUsage = nonEmptyCopilotUsageTokens(event.copilot_usage)
+  if (topLevelUsage) {
+    return topLevelUsage
+  }
+
+  return nonEmptyCopilotUsageTokens(event.response?.copilot_usage)
+}

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -8,9 +8,11 @@ import {
   normalizeOptionalToken,
   normalizeToken,
   resolveTotalTokens,
+  type CopilotUsageTokens,
   type PersistedTokenUsageEvent,
   type TokenUsageEndpoint,
   type TokenUsageSource,
+  type TokenUsageTokenDetail,
   type UsageTokens,
 } from "./store"
 
@@ -22,6 +24,7 @@ export {
 } from "./store"
 
 export type {
+  CopilotUsageTokens,
   TokenUsageDailyBucket,
   TokenUsageDailySummary,
   TokenUsageEndpoint,
@@ -30,12 +33,14 @@ export type {
   TokenUsageModelSummary,
   TokenUsagePeriod,
   TokenUsageSource,
+  TokenUsageTokenDetail,
   TokenUsageSummary,
   TokenUsageTotals,
   UsageTokens,
 } from "./store"
 
 export interface TokenUsageEventInput extends UsageTokens {
+  copilotUsage?: CopilotUsageTokens | null
   endpoint: TokenUsageEndpoint
   fallbackSessionId?: string | null
   model: string
@@ -96,6 +101,71 @@ function resolveUserId(input: TokenUsageEventInput): string {
   return state.userName?.trim() || ""
 }
 
+function resolveTokenDetails(
+  details: Array<TokenUsageTokenDetail> | null | undefined,
+): {
+  nano_cost_cache_creation: number | null
+  nano_cost_cache_read: number | null
+  nano_cost_cache_write: number | null
+  nano_cost_input: number | null
+  nano_cost_output: number | null
+} {
+  if (!Array.isArray(details)) {
+    return {
+      nano_cost_cache_creation: null,
+      nano_cost_cache_read: null,
+      nano_cost_cache_write: null,
+      nano_cost_input: null,
+      nano_cost_output: null,
+    }
+  }
+
+  const result = {
+    nano_cost_cache_creation: 0,
+    nano_cost_cache_read: 0,
+    nano_cost_cache_write: 0,
+    nano_cost_input: 0,
+    nano_cost_output: 0,
+  }
+
+  for (const detail of details) {
+    if (!detail || typeof detail.token_count !== "number") {
+      continue
+    }
+
+    const cost =
+      Math.round(
+        (detail.token_count / Math.max(1, detail.batch_size || 1))
+          * (detail.cost_per_batch || 0),
+      ) || 0
+
+    switch (detail.token_type) {
+      case "input": {
+        result.nano_cost_input += cost
+        break
+      }
+      case "cache_read": {
+        result.nano_cost_cache_read += cost
+        break
+      }
+      case "cache_write": {
+        result.nano_cost_cache_write += cost
+        break
+      }
+      case "cache_creation": {
+        result.nano_cost_cache_creation += cost
+        break
+      }
+      case "output": {
+        result.nano_cost_output += cost
+        break
+      }
+    }
+  }
+
+  return result
+}
+
 function toPersistedEvent(
   input: TokenUsageEventInput,
 ): PersistedTokenUsageEvent | null {
@@ -104,6 +174,7 @@ function toPersistedEvent(
   }
 
   const now = new Date()
+  const cost = resolveTokenDetails(input.copilotUsage?.token_details)
   return {
     cache_creation_input_tokens: normalizeToken(
       input.cache_creation_input_tokens,
@@ -114,6 +185,7 @@ function toPersistedEvent(
     endpoint: input.endpoint,
     input_tokens: normalizeToken(input.input_tokens),
     model: input.model.trim() || "unknown",
+    ...cost,
     output_tokens: normalizeToken(input.output_tokens),
     provider_name: input.providerName?.trim() || null,
     session_id: resolveTokenUsageSessionId(
@@ -121,6 +193,13 @@ function toPersistedEvent(
       input.fallbackSessionId,
     ),
     source: input.source,
+    total_nano_aiu:
+      (
+        input.copilotUsage?.total_nano_aiu === undefined
+        || input.copilotUsage.total_nano_aiu === null
+      ) ?
+        null
+      : normalizeToken(input.copilotUsage.total_nano_aiu),
     total_tokens: resolveTotalTokens(input),
     trace_id: resolveTraceId(input.traceId),
     user_id: resolveUserId(input),
@@ -140,18 +219,19 @@ export function recordTokenUsageEvent(input: TokenUsageEventInput): void {
 
 export function createTokenUsageRecorder(
   options: TokenUsageRecorderOptions,
-): (usage: UsageTokens) => void {
-  return (usage) => {
+): (usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void {
+  return (usage, copilotUsage) => {
     recordTokenUsageEvent({
       ...usage,
       ...options,
+      copilotUsage,
     })
   }
 }
 
 export function createCopilotTokenUsageRecorder(
   options: CopilotTokenUsageRecorderOptions,
-): (usage: UsageTokens) => void {
+): (usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void {
   return createTokenUsageRecorder({
     ...options,
     source: "copilot",
@@ -160,7 +240,7 @@ export function createCopilotTokenUsageRecorder(
 
 export function createProviderTokenUsageRecorder(
   options: ProviderTokenUsageRecorderOptions,
-): (usage: UsageTokens) => void {
+): (usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void {
   return createTokenUsageRecorder({
     ...options,
     source: "provider",

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalToken,
   normalizeToken,
   resolveTotalTokens,
+  type CopilotUsage,
   type CopilotUsageTokens,
   type PersistedTokenUsageEvent,
   type TokenUsageEndpoint,
@@ -24,6 +25,7 @@ export {
 } from "./store"
 
 export type {
+  CopilotUsage,
   CopilotUsageTokens,
   TokenUsageDailyBucket,
   TokenUsageDailySummary,
@@ -342,5 +344,21 @@ export function mergeAnthropicUsage(
     input_tokens: next.input_tokens ?? current.input_tokens,
     output_tokens: next.output_tokens ?? current.output_tokens,
     total_tokens: next.total_tokens ?? current.total_tokens,
+  }
+}
+
+/**
+ * Convert API response CopilotUsage field to CopilotUsageTokens for recorder.
+ * Returns empty object when input is absent.
+ */
+export function copilotUsageToTokens(
+  copilotUsage: CopilotUsage | null | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -39,7 +39,6 @@ export interface CopilotUsageTokens {
 export type CopilotUsage = CopilotUsageTokens
 
 export interface UsageTokens {
-  cache_creation_input_tokens?: number | null
   cache_read_input_tokens?: number | null
   input_tokens?: number | null
   output_tokens?: number | null
@@ -47,7 +46,6 @@ export interface UsageTokens {
 }
 
 export interface PersistedTokenUsageEvent {
-  cache_creation_input_tokens: number
   cache_read_input_tokens: number
   created_at_ms: number
   created_at_utc: string
@@ -69,7 +67,6 @@ export interface PersistedTokenUsageEvent {
 }
 
 export interface TokenUsageTotals {
-  cache_creation_input_tokens: number
   cache_read_input_tokens: number
   input_tokens: number
   nano_cost_cache_read: number | null
@@ -87,7 +84,6 @@ export interface TokenUsageModelSummary extends TokenUsageTotals {
 }
 
 export interface TokenUsageEventRecord {
-  cache_creation_input_tokens: number
   cache_read_input_tokens: number
   created_at_ms: number
   created_at_utc: string
@@ -199,7 +195,6 @@ function initializeTokenUsageDb(db: SqliteDatabase): void {
       input_tokens INTEGER NOT NULL DEFAULT 0,
       output_tokens INTEGER NOT NULL DEFAULT 0,
       cache_read_input_tokens INTEGER NOT NULL DEFAULT 0,
-      cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
       total_tokens INTEGER NOT NULL DEFAULT 0,
       total_nano_aiu INTEGER,
       nano_cost_input INTEGER,
@@ -271,7 +266,6 @@ export function hasAnyToken(tokens: UsageTokens): boolean {
     normalizeToken(tokens.input_tokens) > 0
     || normalizeToken(tokens.output_tokens) > 0
     || normalizeToken(tokens.cache_read_input_tokens) > 0
-    || normalizeToken(tokens.cache_creation_input_tokens) > 0
     || normalizeToken(tokens.total_tokens) > 0
   )
 }
@@ -285,7 +279,6 @@ export function resolveTotalTokens(input: UsageTokens): number {
     normalizeToken(input.input_tokens)
     + normalizeToken(input.output_tokens)
     + normalizeToken(input.cache_read_input_tokens)
-    + normalizeToken(input.cache_creation_input_tokens)
   )
 }
 
@@ -308,14 +301,13 @@ async function writeTokenUsageEvent(
         input_tokens,
         output_tokens,
         cache_read_input_tokens,
-        cache_creation_input_tokens,
         total_tokens,
         total_nano_aiu,
         nano_cost_input,
         nano_cost_cache_read,
         nano_cost_cache_write,
         nano_cost_output
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
   ).run(
     event.created_at_ms,
@@ -330,7 +322,6 @@ async function writeTokenUsageEvent(
     event.input_tokens,
     event.output_tokens,
     event.cache_read_input_tokens,
-    event.cache_creation_input_tokens,
     event.total_tokens,
     event.total_nano_aiu,
     event.nano_cost_input,
@@ -442,7 +433,6 @@ function createDailyIntervals(range: { endMs: number; startMs: number }) {
 
 function createEmptyTotals(): TokenUsageTotals {
   return {
-    cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     input_tokens: 0,
     nano_cost_cache_read: null,
@@ -457,7 +447,6 @@ function createEmptyTotals(): TokenUsageTotals {
 }
 
 function addTotals(target: TokenUsageTotals, next: TokenUsageTotals): void {
-  target.cache_creation_input_tokens += next.cache_creation_input_tokens
   target.cache_read_input_tokens += next.cache_read_input_tokens
   target.input_tokens += next.input_tokens
   target.nano_cost_cache_read = addNullableNumbers(
@@ -593,10 +582,6 @@ function totalsFromRow(
   row: Record<string, unknown> | undefined,
 ): TokenUsageTotals {
   return {
-    cache_creation_input_tokens: numberFromRow(
-      row,
-      "cache_creation_input_tokens",
-    ),
     cache_read_input_tokens: numberFromRow(row, "cache_read_input_tokens"),
     input_tokens: numberFromRow(row, "input_tokens"),
     nano_cost_cache_read: nullableNumberFromRow(row, "nano_cost_cache_read"),
@@ -636,10 +621,6 @@ function usageEventFromRow(
   row: Record<string, unknown>,
 ): TokenUsageEventRecord {
   return {
-    cache_creation_input_tokens: numberFromRow(
-      row,
-      "cache_creation_input_tokens",
-    ),
     cache_read_input_tokens: numberFromRow(row, "cache_read_input_tokens"),
     created_at_ms: numberFromRow(row, "created_at_ms"),
     created_at_utc: stringFromRow(row, "created_at_utc"),
@@ -674,7 +655,6 @@ function getTotalsRow(
       COALESCE(SUM(input_tokens), 0) AS input_tokens,
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
-      COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
       COALESCE(SUM(total_tokens), 0) AS total_tokens,
       SUM(total_nano_aiu) AS total_nano_aiu,
       SUM(nano_cost_input) AS nano_cost_input,
@@ -701,7 +681,6 @@ function getModelRows(
       COALESCE(SUM(input_tokens), 0) AS input_tokens,
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
-      COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
       COALESCE(SUM(total_tokens), 0) AS total_tokens,
       SUM(total_nano_aiu) AS total_nano_aiu,
       SUM(nano_cost_input) AS nano_cost_input,
@@ -825,7 +804,6 @@ export async function getTokenUsageEventsPage(input: {
       input_tokens,
       output_tokens,
       cache_read_input_tokens,
-      cache_creation_input_tokens,
       total_tokens,
       total_nano_aiu,
       nano_cost_input,

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -32,6 +32,12 @@ export interface CopilotUsageTokens {
   total_nano_aiu?: number | null
 }
 
+/**
+ * Alias for service-layer API response field shape.
+ * Same shape as CopilotUsageTokens; service layers re-export this name.
+ */
+export type CopilotUsage = CopilotUsageTokens
+
 export interface UsageTokens {
   cache_creation_input_tokens?: number | null
   cache_read_input_tokens?: number | null

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -20,6 +20,18 @@ export type TokenUsageEndpoint =
 
 export type TokenUsagePeriod = "day" | "week" | "month"
 
+export interface TokenUsageTokenDetail {
+  batch_size: number
+  cost_per_batch: number
+  token_count: number
+  token_type: string
+}
+
+export interface CopilotUsageTokens {
+  token_details?: Array<TokenUsageTokenDetail> | null
+  total_nano_aiu?: number | null
+}
+
 export interface UsageTokens {
   cache_creation_input_tokens?: number | null
   cache_read_input_tokens?: number | null
@@ -36,10 +48,16 @@ export interface PersistedTokenUsageEvent {
   endpoint: TokenUsageEndpoint
   input_tokens: number
   model: string
+  nano_cost_cache_creation: number | null
+  nano_cost_cache_read: number | null
+  nano_cost_cache_write: number | null
+  nano_cost_input: number | null
+  nano_cost_output: number | null
   output_tokens: number
   provider_name: string | null
   session_id: string
   source: TokenUsageSource
+  total_nano_aiu: number | null
   total_tokens: number
   trace_id: string
   user_id: string
@@ -49,8 +67,14 @@ export interface TokenUsageTotals {
   cache_creation_input_tokens: number
   cache_read_input_tokens: number
   input_tokens: number
+  nano_cost_cache_creation: number | null
+  nano_cost_cache_read: number | null
+  nano_cost_cache_write: number | null
+  nano_cost_input: number | null
+  nano_cost_output: number | null
   output_tokens: number
   request_count: number
+  total_nano_aiu: number | null
   total_tokens: number
 }
 
@@ -67,10 +91,16 @@ export interface TokenUsageEventRecord {
   id: number
   input_tokens: number
   model: string
+  nano_cost_cache_creation: number | null
+  nano_cost_cache_read: number | null
+  nano_cost_cache_write: number | null
+  nano_cost_input: number | null
+  nano_cost_output: number | null
   output_tokens: number
   provider_name: string | null
   session_id: string
   source: TokenUsageSource
+  total_nano_aiu: number | null
   total_tokens: number
   trace_id: string
   user_id: string
@@ -167,11 +197,23 @@ function initializeTokenUsageDb(db: SqliteDatabase): void {
       output_tokens INTEGER NOT NULL DEFAULT 0,
       cache_read_input_tokens INTEGER NOT NULL DEFAULT 0,
       cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
-      total_tokens INTEGER NOT NULL DEFAULT 0
+      total_tokens INTEGER NOT NULL DEFAULT 0,
+      total_nano_aiu INTEGER,
+      nano_cost_input INTEGER,
+      nano_cost_cache_read INTEGER,
+      nano_cost_cache_write INTEGER,
+      nano_cost_cache_creation INTEGER,
+      nano_cost_output INTEGER
     )
   `)
   ensureColumn(db, "user_id", "TEXT NOT NULL DEFAULT ''")
   ensureColumn(db, "total_tokens", "INTEGER NOT NULL DEFAULT 0")
+  ensureColumn(db, "total_nano_aiu", "INTEGER")
+  ensureColumn(db, "nano_cost_input", "INTEGER")
+  ensureColumn(db, "nano_cost_cache_read", "INTEGER")
+  ensureColumn(db, "nano_cost_cache_write", "INTEGER")
+  ensureColumn(db, "nano_cost_cache_creation", "INTEGER")
+  ensureColumn(db, "nano_cost_output", "INTEGER")
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_token_usage_events_created_at_ms
     ON token_usage_events(created_at_ms)
@@ -266,8 +308,14 @@ async function writeTokenUsageEvent(
         output_tokens,
         cache_read_input_tokens,
         cache_creation_input_tokens,
-        total_tokens
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        total_tokens,
+        total_nano_aiu,
+        nano_cost_input,
+        nano_cost_cache_read,
+        nano_cost_cache_write,
+        nano_cost_cache_creation,
+        nano_cost_output
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
   ).run(
     event.created_at_ms,
@@ -284,6 +332,12 @@ async function writeTokenUsageEvent(
     event.cache_read_input_tokens,
     event.cache_creation_input_tokens,
     event.total_tokens,
+    event.total_nano_aiu,
+    event.nano_cost_input,
+    event.nano_cost_cache_read,
+    event.nano_cost_cache_write,
+    event.nano_cost_cache_creation,
+    event.nano_cost_output,
   )
 }
 
@@ -392,8 +446,14 @@ function createEmptyTotals(): TokenUsageTotals {
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     input_tokens: 0,
+    nano_cost_cache_creation: null,
+    nano_cost_cache_read: null,
+    nano_cost_cache_write: null,
+    nano_cost_input: null,
+    nano_cost_output: null,
     output_tokens: 0,
     request_count: 0,
+    total_nano_aiu: null,
     total_tokens: 0,
   }
 }
@@ -402,8 +462,32 @@ function addTotals(target: TokenUsageTotals, next: TokenUsageTotals): void {
   target.cache_creation_input_tokens += next.cache_creation_input_tokens
   target.cache_read_input_tokens += next.cache_read_input_tokens
   target.input_tokens += next.input_tokens
+  target.nano_cost_cache_creation = addNullableNumbers(
+    target.nano_cost_cache_creation,
+    next.nano_cost_cache_creation,
+  )
+  target.nano_cost_cache_read = addNullableNumbers(
+    target.nano_cost_cache_read,
+    next.nano_cost_cache_read,
+  )
+  target.nano_cost_cache_write = addNullableNumbers(
+    target.nano_cost_cache_write,
+    next.nano_cost_cache_write,
+  )
+  target.nano_cost_input = addNullableNumbers(
+    target.nano_cost_input,
+    next.nano_cost_input,
+  )
+  target.nano_cost_output = addNullableNumbers(
+    target.nano_cost_output,
+    next.nano_cost_output,
+  )
   target.output_tokens += next.output_tokens
   target.request_count += next.request_count
+  target.total_nano_aiu = addNullableNumbers(
+    target.total_nano_aiu,
+    next.total_nano_aiu,
+  )
   target.total_tokens += next.total_tokens
 }
 
@@ -490,6 +574,27 @@ function numberFromRow(
   return typeof value === "number" && Number.isFinite(value) ? value : 0
 }
 
+function nullableNumberFromRow(
+  row: Record<string, unknown> | undefined,
+  key: string,
+): number | null {
+  const value = row?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function addNullableNumbers(
+  current: number | null,
+  next: number | null,
+): number | null {
+  if (current === null) {
+    return next
+  }
+  if (next === null) {
+    return current
+  }
+  return current + next
+}
+
 function totalsFromRow(
   row: Record<string, unknown> | undefined,
 ): TokenUsageTotals {
@@ -500,8 +605,17 @@ function totalsFromRow(
     ),
     cache_read_input_tokens: numberFromRow(row, "cache_read_input_tokens"),
     input_tokens: numberFromRow(row, "input_tokens"),
+    nano_cost_cache_creation: nullableNumberFromRow(
+      row,
+      "nano_cost_cache_creation",
+    ),
+    nano_cost_cache_read: nullableNumberFromRow(row, "nano_cost_cache_read"),
+    nano_cost_cache_write: nullableNumberFromRow(row, "nano_cost_cache_write"),
+    nano_cost_input: nullableNumberFromRow(row, "nano_cost_input"),
+    nano_cost_output: nullableNumberFromRow(row, "nano_cost_output"),
     output_tokens: numberFromRow(row, "output_tokens"),
     request_count: numberFromRow(row, "request_count"),
+    total_nano_aiu: nullableNumberFromRow(row, "total_nano_aiu"),
     total_tokens: numberFromRow(row, "total_tokens"),
   }
 }
@@ -543,10 +657,19 @@ function usageEventFromRow(
     id: numberFromRow(row, "id"),
     input_tokens: numberFromRow(row, "input_tokens"),
     model: stringFromRow(row, "model") || "unknown",
+    nano_cost_cache_creation: nullableNumberFromRow(
+      row,
+      "nano_cost_cache_creation",
+    ),
+    nano_cost_cache_read: nullableNumberFromRow(row, "nano_cost_cache_read"),
+    nano_cost_cache_write: nullableNumberFromRow(row, "nano_cost_cache_write"),
+    nano_cost_input: nullableNumberFromRow(row, "nano_cost_input"),
+    nano_cost_output: nullableNumberFromRow(row, "nano_cost_output"),
     output_tokens: numberFromRow(row, "output_tokens"),
     provider_name: nullableStringFromRow(row, "provider_name"),
     session_id: stringFromRow(row, "session_id"),
     source: stringFromRow(row, "source") as TokenUsageSource,
+    total_nano_aiu: nullableNumberFromRow(row, "total_nano_aiu"),
     total_tokens: numberFromRow(row, "total_tokens"),
     trace_id: stringFromRow(row, "trace_id"),
     user_id: stringFromRow(row, "user_id"),
@@ -566,7 +689,13 @@ function getTotalsRow(
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
       COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
-      COALESCE(SUM(total_tokens), 0) AS total_tokens
+      COALESCE(SUM(total_tokens), 0) AS total_tokens,
+      SUM(total_nano_aiu) AS total_nano_aiu,
+      SUM(nano_cost_input) AS nano_cost_input,
+      SUM(nano_cost_cache_read) AS nano_cost_cache_read,
+      SUM(nano_cost_cache_write) AS nano_cost_cache_write,
+      SUM(nano_cost_cache_creation) AS nano_cost_cache_creation,
+      SUM(nano_cost_output) AS nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
   `,
@@ -588,7 +717,13 @@ function getModelRows(
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
       COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
-      COALESCE(SUM(total_tokens), 0) AS total_tokens
+      COALESCE(SUM(total_tokens), 0) AS total_tokens,
+      SUM(total_nano_aiu) AS total_nano_aiu,
+      SUM(nano_cost_input) AS nano_cost_input,
+      SUM(nano_cost_cache_read) AS nano_cost_cache_read,
+      SUM(nano_cost_cache_write) AS nano_cost_cache_write,
+      SUM(nano_cost_cache_creation) AS nano_cost_cache_creation,
+      SUM(nano_cost_output) AS nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
     GROUP BY model
@@ -707,7 +842,13 @@ export async function getTokenUsageEventsPage(input: {
       output_tokens,
       cache_read_input_tokens,
       cache_creation_input_tokens,
-      total_tokens
+      total_tokens,
+      total_nano_aiu,
+      nano_cost_input,
+      nano_cost_cache_read,
+      nano_cost_cache_write,
+      nano_cost_cache_creation,
+      nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
     ORDER BY created_at_ms DESC, id DESC

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -54,7 +54,6 @@ export interface PersistedTokenUsageEvent {
   endpoint: TokenUsageEndpoint
   input_tokens: number
   model: string
-  nano_cost_cache_creation: number | null
   nano_cost_cache_read: number | null
   nano_cost_cache_write: number | null
   nano_cost_input: number | null
@@ -73,7 +72,6 @@ export interface TokenUsageTotals {
   cache_creation_input_tokens: number
   cache_read_input_tokens: number
   input_tokens: number
-  nano_cost_cache_creation: number | null
   nano_cost_cache_read: number | null
   nano_cost_cache_write: number | null
   nano_cost_input: number | null
@@ -97,7 +95,6 @@ export interface TokenUsageEventRecord {
   id: number
   input_tokens: number
   model: string
-  nano_cost_cache_creation: number | null
   nano_cost_cache_read: number | null
   nano_cost_cache_write: number | null
   nano_cost_input: number | null
@@ -208,7 +205,6 @@ function initializeTokenUsageDb(db: SqliteDatabase): void {
       nano_cost_input INTEGER,
       nano_cost_cache_read INTEGER,
       nano_cost_cache_write INTEGER,
-      nano_cost_cache_creation INTEGER,
       nano_cost_output INTEGER
     )
   `)
@@ -218,7 +214,6 @@ function initializeTokenUsageDb(db: SqliteDatabase): void {
   ensureColumn(db, "nano_cost_input", "INTEGER")
   ensureColumn(db, "nano_cost_cache_read", "INTEGER")
   ensureColumn(db, "nano_cost_cache_write", "INTEGER")
-  ensureColumn(db, "nano_cost_cache_creation", "INTEGER")
   ensureColumn(db, "nano_cost_output", "INTEGER")
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_token_usage_events_created_at_ms
@@ -319,9 +314,8 @@ async function writeTokenUsageEvent(
         nano_cost_input,
         nano_cost_cache_read,
         nano_cost_cache_write,
-        nano_cost_cache_creation,
         nano_cost_output
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
   ).run(
     event.created_at_ms,
@@ -342,7 +336,6 @@ async function writeTokenUsageEvent(
     event.nano_cost_input,
     event.nano_cost_cache_read,
     event.nano_cost_cache_write,
-    event.nano_cost_cache_creation,
     event.nano_cost_output,
   )
 }
@@ -452,7 +445,6 @@ function createEmptyTotals(): TokenUsageTotals {
     cache_creation_input_tokens: 0,
     cache_read_input_tokens: 0,
     input_tokens: 0,
-    nano_cost_cache_creation: null,
     nano_cost_cache_read: null,
     nano_cost_cache_write: null,
     nano_cost_input: null,
@@ -468,10 +460,6 @@ function addTotals(target: TokenUsageTotals, next: TokenUsageTotals): void {
   target.cache_creation_input_tokens += next.cache_creation_input_tokens
   target.cache_read_input_tokens += next.cache_read_input_tokens
   target.input_tokens += next.input_tokens
-  target.nano_cost_cache_creation = addNullableNumbers(
-    target.nano_cost_cache_creation,
-    next.nano_cost_cache_creation,
-  )
   target.nano_cost_cache_read = addNullableNumbers(
     target.nano_cost_cache_read,
     next.nano_cost_cache_read,
@@ -611,10 +599,6 @@ function totalsFromRow(
     ),
     cache_read_input_tokens: numberFromRow(row, "cache_read_input_tokens"),
     input_tokens: numberFromRow(row, "input_tokens"),
-    nano_cost_cache_creation: nullableNumberFromRow(
-      row,
-      "nano_cost_cache_creation",
-    ),
     nano_cost_cache_read: nullableNumberFromRow(row, "nano_cost_cache_read"),
     nano_cost_cache_write: nullableNumberFromRow(row, "nano_cost_cache_write"),
     nano_cost_input: nullableNumberFromRow(row, "nano_cost_input"),
@@ -663,10 +647,6 @@ function usageEventFromRow(
     id: numberFromRow(row, "id"),
     input_tokens: numberFromRow(row, "input_tokens"),
     model: stringFromRow(row, "model") || "unknown",
-    nano_cost_cache_creation: nullableNumberFromRow(
-      row,
-      "nano_cost_cache_creation",
-    ),
     nano_cost_cache_read: nullableNumberFromRow(row, "nano_cost_cache_read"),
     nano_cost_cache_write: nullableNumberFromRow(row, "nano_cost_cache_write"),
     nano_cost_input: nullableNumberFromRow(row, "nano_cost_input"),
@@ -700,7 +680,6 @@ function getTotalsRow(
       SUM(nano_cost_input) AS nano_cost_input,
       SUM(nano_cost_cache_read) AS nano_cost_cache_read,
       SUM(nano_cost_cache_write) AS nano_cost_cache_write,
-      SUM(nano_cost_cache_creation) AS nano_cost_cache_creation,
       SUM(nano_cost_output) AS nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
@@ -728,7 +707,6 @@ function getModelRows(
       SUM(nano_cost_input) AS nano_cost_input,
       SUM(nano_cost_cache_read) AS nano_cost_cache_read,
       SUM(nano_cost_cache_write) AS nano_cost_cache_write,
-      SUM(nano_cost_cache_creation) AS nano_cost_cache_creation,
       SUM(nano_cost_output) AS nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
@@ -853,7 +831,6 @@ export async function getTokenUsageEventsPage(input: {
       nano_cost_input,
       nano_cost_cache_read,
       nano_cost_cache_write,
-      nano_cost_cache_creation,
       nano_cost_output
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -12,6 +12,7 @@ import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
+  type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
 import { generateRequestIdFromPayload, getUUID, isNullish } from "~/lib/utils"
@@ -21,6 +22,7 @@ import {
   type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
+  type CopilotUsage,
 } from "~/services/copilot/create-chat-completions"
 
 const logger = createHandlerLogger("chat-completions-handler")
@@ -94,13 +96,17 @@ export async function handleCompletion(c: Context) {
 
   if (isNonStreaming(response)) {
     debugJson(logger, "Non-streaming response:", response)
-    recordUsage(normalizeOpenAIUsage(response.usage))
+    recordUsage(
+      normalizeOpenAIUsage(response.usage),
+      copilotUsageFromResponse(response.copilot_usage),
+    )
     return c.json(response)
   }
 
   logger.debug("Streaming response")
   return streamSSE(c, async (stream) => {
     let usage: UsageTokens = {}
+    let copilotUsage: CopilotUsageTokens = {}
 
     for await (const chunk of response) {
       debugJson(logger, "Streaming chunk:", chunk)
@@ -108,10 +114,13 @@ export async function handleCompletion(c: Context) {
       if (parsedChunk?.usage) {
         usage = normalizeOpenAIUsage(parsedChunk.usage)
       }
+      if (parsedChunk?.copilot_usage) {
+        copilotUsage = copilotUsageFromResponse(parsedChunk.copilot_usage)
+      }
       await stream.writeSSE(chunk as SSEMessage)
     }
 
-    recordUsage(usage)
+    recordUsage(usage, copilotUsage)
   })
 }
 
@@ -131,5 +140,18 @@ const parseChatCompletionChunk = (
     return JSON.parse(data) as ChatCompletionChunk
   } catch {
     return null
+  }
+}
+
+function copilotUsageFromResponse(
+  copilotUsage: CopilotUsage | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -12,6 +12,7 @@ import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
+  copilotUsageToTokens,
   type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -22,7 +23,6 @@ import {
   type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
-  type CopilotUsage,
 } from "~/services/copilot/create-chat-completions"
 
 const logger = createHandlerLogger("chat-completions-handler")
@@ -98,7 +98,7 @@ export async function handleCompletion(c: Context) {
     debugJson(logger, "Non-streaming response:", response)
     recordUsage(
       normalizeOpenAIUsage(response.usage),
-      copilotUsageFromResponse(response.copilot_usage),
+      copilotUsageToTokens(response.copilot_usage),
     )
     return c.json(response)
   }
@@ -115,7 +115,7 @@ export async function handleCompletion(c: Context) {
         usage = normalizeOpenAIUsage(parsedChunk.usage)
       }
       if (parsedChunk?.copilot_usage) {
-        copilotUsage = copilotUsageFromResponse(parsedChunk.copilot_usage)
+        copilotUsage = copilotUsageToTokens(parsedChunk.copilot_usage)
       }
       await stream.writeSSE(chunk as SSEMessage)
     }
@@ -140,18 +140,5 @@ const parseChatCompletionChunk = (
     return JSON.parse(data) as ChatCompletionChunk
   } catch {
     return null
-  }
-}
-
-function copilotUsageFromResponse(
-  copilotUsage: CopilotUsage | undefined,
-): CopilotUsageTokens {
-  if (!copilotUsage) {
-    return {}
-  }
-
-  return {
-    token_details: copilotUsage.token_details,
-    total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -1,5 +1,7 @@
 // Anthropic API Types
 
+import type { CopilotUsage } from "~/lib/token-usage"
+
 export interface AnthropicMessagesPayload {
   model: string
   messages: Array<AnthropicInputMessage>
@@ -202,15 +204,7 @@ export interface AnthropicResponse {
     cache_read_input_tokens?: number
     service_tier?: "standard" | "priority" | "batch"
   }
-  copilot_usage?: {
-    token_details?: Array<{
-      batch_size: number
-      cost_per_batch: number
-      token_count: number
-      token_type: string
-    }>
-    total_nano_aiu?: number
-  }
+  copilot_usage?: CopilotUsage | null
 }
 
 export type AnthropicResponseContentBlock =
@@ -268,15 +262,7 @@ export interface AnthropicMessageDeltaEvent {
     cache_creation_input_tokens?: number
     cache_read_input_tokens?: number
   }
-  copilot_usage?: {
-    token_details?: Array<{
-      batch_size: number
-      cost_per_batch: number
-      token_count: number
-      token_type: string
-    }>
-    total_nano_aiu?: number
-  }
+  copilot_usage?: CopilotUsage | null
 }
 
 export interface AnthropicMessageStopEvent {

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -200,7 +200,6 @@ export interface AnthropicResponse {
   usage: {
     input_tokens: number
     output_tokens: number
-    cache_creation_input_tokens?: number
     cache_read_input_tokens?: number
     service_tier?: "standard" | "priority" | "batch"
   }
@@ -259,7 +258,6 @@ export interface AnthropicMessageDeltaEvent {
   usage?: {
     input_tokens?: number
     output_tokens: number
-    cache_creation_input_tokens?: number
     cache_read_input_tokens?: number
   }
   copilot_usage?: CopilotUsage | null

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -202,6 +202,15 @@ export interface AnthropicResponse {
     cache_read_input_tokens?: number
     service_tier?: "standard" | "priority" | "batch"
   }
+  copilot_usage?: {
+    token_details?: Array<{
+      batch_size: number
+      cost_per_batch: number
+      token_count: number
+      token_type: string
+    }>
+    total_nano_aiu?: number
+  }
 }
 
 export type AnthropicResponseContentBlock =
@@ -258,6 +267,15 @@ export interface AnthropicMessageDeltaEvent {
     output_tokens: number
     cache_creation_input_tokens?: number
     cache_read_input_tokens?: number
+  }
+  copilot_usage?: {
+    token_details?: Array<{
+      batch_size: number
+      cost_per_batch: number
+      token_count: number
+      token_type: string
+    }>
+    total_nano_aiu?: number
   }
 }
 

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -16,6 +16,7 @@ import {
   normalizeOpenAIUsage,
   normalizeResponsesUsage,
   copilotUsageToTokens,
+  type CopilotUsage,
   type CopilotUsageTokens,
   type TokenUsageEndpoint,
   type UsageTokens,
@@ -257,9 +258,8 @@ export const handleWithResponsesApi = async (
           || responseEvent.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(responseEvent.response.usage)
-          copilotUsage = copilotUsageToTokens(
-            responseEvent.response.copilot_usage,
-          )
+          copilotUsage =
+            copilotUsageFromResponsesEvent(responseEvent) ?? copilotUsage
         }
 
         const events = translateResponsesStreamEvent(responseEvent, streamState)
@@ -474,6 +474,32 @@ const createCopilotUsageRecorder = (options: {
 const getMetadataSessionId = (
   payload: AnthropicMessagesPayload,
 ): string | null => parseUserIdMetadata(payload.metadata?.user_id).sessionId
+
+const copilotUsageFromResponsesEvent = (
+  event: ResponseStreamEvent,
+): CopilotUsageTokens | null => {
+  const topLevelUsage = nonEmptyCopilotUsageTokens(
+    (event as { copilot_usage?: CopilotUsage | null }).copilot_usage,
+  )
+  if (topLevelUsage) {
+    return topLevelUsage
+  }
+
+  const response = (
+    event as {
+      response?: { copilot_usage?: CopilotUsage | null }
+    }
+  ).response
+
+  return nonEmptyCopilotUsageTokens(response?.copilot_usage)
+}
+
+const nonEmptyCopilotUsageTokens = (
+  usage: CopilotUsage | null | undefined,
+): CopilotUsageTokens | null => {
+  const tokens = copilotUsageToTokens(usage)
+  return Object.keys(tokens).length > 0 ? tokens : null
+}
 
 const parseAnthropicStreamEvent = (
   data: string,

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -15,6 +15,7 @@ import {
   normalizeAnthropicUsage,
   normalizeOpenAIUsage,
   normalizeResponsesUsage,
+  copilotUsageToTokens,
   type CopilotUsageTokens,
   type TokenUsageEndpoint,
   type UsageTokens,
@@ -40,13 +41,11 @@ import {
   type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
-  type CopilotUsage,
   type Message,
 } from "~/services/copilot/create-chat-completions"
 import { createMessages as createCopilotMessages } from "~/services/copilot/create-messages"
 import {
   createResponses as createCopilotResponses,
-  type CopilotUsage as ResponsesCopilotUsage,
   type ResponsesResult,
   type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
@@ -125,7 +124,7 @@ export const handleWithChatCompletions = async (
     debugJson(logger, "Non-streaming response from Copilot:", response)
     recordUsage(
       normalizeOpenAIUsage(response.usage),
-      copilotUsageFromResponse(response.copilot_usage),
+      copilotUsageToTokens(response.copilot_usage),
     )
     const anthropicResponse = translateToAnthropic(response)
     debugJson(logger, "Translated Anthropic response:", anthropicResponse)
@@ -159,7 +158,7 @@ export const handleWithChatCompletions = async (
         usage = normalizeOpenAIUsage(chunk.usage)
       }
       if (chunk.copilot_usage) {
-        copilotUsage = copilotUsageFromResponse(chunk.copilot_usage)
+        copilotUsage = copilotUsageToTokens(chunk.copilot_usage)
       }
       const events = translateChunkToAnthropicEvents(chunk, streamState)
 
@@ -258,7 +257,7 @@ export const handleWithResponsesApi = async (
           || responseEvent.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(responseEvent.response.usage)
-          copilotUsage = responsesCopilotUsageFromResponse(
+          copilotUsage = copilotUsageToTokens(
             responseEvent.response.copilot_usage,
           )
         }
@@ -306,7 +305,7 @@ export const handleWithResponsesApi = async (
   })
   recordUsage(
     normalizeResponsesUsage(result.usage),
-    responsesCopilotUsageFromResponse(result.copilot_usage),
+    copilotUsageToTokens(result.copilot_usage),
   )
   debugJson(logger, "Translated Anthropic response:", anthropicResponse)
   return c.json(anthropicResponse)
@@ -370,15 +369,13 @@ export const handleWithMessagesApi = async (
             usage,
             normalizeAnthropicUsage(parsedEvent.message.usage),
           )
-          copilotUsage = copilotUsageFromResponse(
-            parsedEvent.message.copilot_usage,
-          )
+          copilotUsage = copilotUsageToTokens(parsedEvent.message.copilot_usage)
         } else if (parsedEvent?.type === "message_delta") {
           usage = mergeAnthropicUsage(
             usage,
             normalizeAnthropicUsage(parsedEvent.usage),
           )
-          copilotUsage = copilotUsageFromResponse(parsedEvent.copilot_usage)
+          copilotUsage = copilotUsageToTokens(parsedEvent.copilot_usage)
         }
         await stream.writeSSE({
           event: eventName,
@@ -396,7 +393,7 @@ export const handleWithMessagesApi = async (
   })
   recordUsage(
     normalizeAnthropicUsage(response.usage),
-    copilotUsageFromResponse(response.copilot_usage),
+    copilotUsageToTokens(response.copilot_usage),
   )
   return c.json(response)
 }
@@ -473,32 +470,6 @@ const createCopilotUsageRecorder = (options: {
     model: options.model,
     sessionId: getMetadataSessionId(options.payload),
   })
-
-function copilotUsageFromResponse(
-  copilotUsage: CopilotUsage | undefined,
-): CopilotUsageTokens {
-  if (!copilotUsage) {
-    return {}
-  }
-
-  return {
-    token_details: copilotUsage.token_details,
-    total_nano_aiu: copilotUsage.total_nano_aiu,
-  }
-}
-
-function responsesCopilotUsageFromResponse(
-  copilotUsage: ResponsesCopilotUsage | null | undefined,
-): CopilotUsageTokens {
-  if (!copilotUsage) {
-    return {}
-  }
-
-  return {
-    token_details: copilotUsage.token_details,
-    total_nano_aiu: copilotUsage.total_nano_aiu,
-  }
-}
 
 const getMetadataSessionId = (
   payload: AnthropicMessagesPayload,

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -10,13 +10,13 @@ import type { Model } from "~/services/copilot/get-models"
 import { debugJson, debugJsonTail, debugLazy } from "~/lib/logger"
 import { resolveBridgeToolSearchName } from "~/lib/tool-search"
 import {
+  copilotUsageFromResponsesEvent,
   createCopilotTokenUsageRecorder,
   mergeAnthropicUsage,
   normalizeAnthropicUsage,
   normalizeOpenAIUsage,
   normalizeResponsesUsage,
   copilotUsageToTokens,
-  type CopilotUsage,
   type CopilotUsageTokens,
   type TokenUsageEndpoint,
   type UsageTokens,
@@ -474,32 +474,6 @@ const createCopilotUsageRecorder = (options: {
 const getMetadataSessionId = (
   payload: AnthropicMessagesPayload,
 ): string | null => parseUserIdMetadata(payload.metadata?.user_id).sessionId
-
-const copilotUsageFromResponsesEvent = (
-  event: ResponseStreamEvent,
-): CopilotUsageTokens | null => {
-  const topLevelUsage = nonEmptyCopilotUsageTokens(
-    (event as { copilot_usage?: CopilotUsage | null }).copilot_usage,
-  )
-  if (topLevelUsage) {
-    return topLevelUsage
-  }
-
-  const response = (
-    event as {
-      response?: { copilot_usage?: CopilotUsage | null }
-    }
-  ).response
-
-  return nonEmptyCopilotUsageTokens(response?.copilot_usage)
-}
-
-const nonEmptyCopilotUsageTokens = (
-  usage: CopilotUsage | null | undefined,
-): CopilotUsageTokens | null => {
-  const tokens = copilotUsageToTokens(usage)
-  return Object.keys(tokens).length > 0 ? tokens : null
-}
 
 const parseAnthropicStreamEvent = (
   data: string,

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -15,6 +15,7 @@ import {
   normalizeAnthropicUsage,
   normalizeOpenAIUsage,
   normalizeResponsesUsage,
+  type CopilotUsageTokens,
   type TokenUsageEndpoint,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -39,11 +40,13 @@ import {
   type ChatCompletionChunk,
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
+  type CopilotUsage,
   type Message,
 } from "~/services/copilot/create-chat-completions"
 import { createMessages as createCopilotMessages } from "~/services/copilot/create-messages"
 import {
   createResponses as createCopilotResponses,
+  type CopilotUsage as ResponsesCopilotUsage,
   type ResponsesResult,
   type ResponseStreamEvent,
 } from "~/services/copilot/create-responses"
@@ -120,7 +123,10 @@ export const handleWithChatCompletions = async (
 
   if (isNonStreaming(response)) {
     debugJson(logger, "Non-streaming response from Copilot:", response)
-    recordUsage(normalizeOpenAIUsage(response.usage))
+    recordUsage(
+      normalizeOpenAIUsage(response.usage),
+      copilotUsageFromResponse(response.copilot_usage),
+    )
     const anthropicResponse = translateToAnthropic(response)
     debugJson(logger, "Translated Anthropic response:", anthropicResponse)
     return c.json(anthropicResponse)
@@ -129,6 +135,7 @@ export const handleWithChatCompletions = async (
   logger.debug("Streaming response from Copilot")
   return streamSSE(c, async (stream) => {
     let usage: UsageTokens = {}
+    let copilotUsage: CopilotUsageTokens = {}
     const streamState: AnthropicStreamState = {
       messageStartSent: false,
       contentBlockIndex: 0,
@@ -151,6 +158,9 @@ export const handleWithChatCompletions = async (
       if (chunk.usage) {
         usage = normalizeOpenAIUsage(chunk.usage)
       }
+      if (chunk.copilot_usage) {
+        copilotUsage = copilotUsageFromResponse(chunk.copilot_usage)
+      }
       const events = translateChunkToAnthropicEvents(chunk, streamState)
 
       for (const event of events) {
@@ -172,7 +182,7 @@ export const handleWithChatCompletions = async (
       })
     }
 
-    recordUsage(usage)
+    recordUsage(usage, copilotUsage)
   })
 }
 
@@ -225,6 +235,7 @@ export const handleWithResponsesApi = async (
         toolSearchName: resolveBridgeToolSearchName(anthropicPayload.tools),
       })
       let usage: UsageTokens = {}
+      let copilotUsage: CopilotUsageTokens = {}
 
       for await (const chunk of response) {
         const eventName = chunk.event
@@ -247,6 +258,9 @@ export const handleWithResponsesApi = async (
           || responseEvent.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(responseEvent.response.usage)
+          copilotUsage = responsesCopilotUsageFromResponse(
+            responseEvent.response.copilot_usage,
+          )
         }
 
         const events = translateResponsesStreamEvent(responseEvent, streamState)
@@ -278,7 +292,7 @@ export const handleWithResponsesApi = async (
         })
       }
 
-      recordUsage(usage)
+      recordUsage(usage, copilotUsage)
     })
   }
 
@@ -286,13 +300,14 @@ export const handleWithResponsesApi = async (
     value: response,
     tailLength: 400,
   })
-  const anthropicResponse = translateResponsesResultToAnthropic(
-    response as ResponsesResult,
-    {
-      toolSearchName: resolveBridgeToolSearchName(anthropicPayload.tools),
-    },
+  const result = response as ResponsesResult
+  const anthropicResponse = translateResponsesResultToAnthropic(result, {
+    toolSearchName: resolveBridgeToolSearchName(anthropicPayload.tools),
+  })
+  recordUsage(
+    normalizeResponsesUsage(result.usage),
+    responsesCopilotUsageFromResponse(result.copilot_usage),
   )
-  recordUsage(normalizeResponsesUsage((response as ResponsesResult).usage))
   debugJson(logger, "Translated Anthropic response:", anthropicResponse)
   return c.json(anthropicResponse)
 }
@@ -337,6 +352,7 @@ export const handleWithMessagesApi = async (
     logger.debug("Streaming response from Copilot (Messages API)")
     return streamSSE(c, async (stream) => {
       let usage: UsageTokens = {}
+      let copilotUsage: CopilotUsageTokens = {}
 
       for await (const event of response) {
         const eventName = event.event
@@ -354,11 +370,15 @@ export const handleWithMessagesApi = async (
             usage,
             normalizeAnthropicUsage(parsedEvent.message.usage),
           )
+          copilotUsage = copilotUsageFromResponse(
+            parsedEvent.message.copilot_usage,
+          )
         } else if (parsedEvent?.type === "message_delta") {
           usage = mergeAnthropicUsage(
             usage,
             normalizeAnthropicUsage(parsedEvent.usage),
           )
+          copilotUsage = copilotUsageFromResponse(parsedEvent.copilot_usage)
         }
         await stream.writeSSE({
           event: eventName,
@@ -366,7 +386,7 @@ export const handleWithMessagesApi = async (
         })
       }
 
-      recordUsage(usage)
+      recordUsage(usage, copilotUsage)
     })
   }
 
@@ -374,7 +394,10 @@ export const handleWithMessagesApi = async (
     value: response,
     tailLength: 400,
   })
-  recordUsage(normalizeAnthropicUsage(response.usage))
+  recordUsage(
+    normalizeAnthropicUsage(response.usage),
+    copilotUsageFromResponse(response.copilot_usage),
+  )
   return c.json(response)
 }
 
@@ -443,13 +466,39 @@ const createCopilotUsageRecorder = (options: {
   fallbackSessionId?: string
   model: string
   payload: AnthropicMessagesPayload
-}): ((usage: UsageTokens) => void) =>
+}): ((usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void) =>
   createCopilotTokenUsageRecorder({
     endpoint: options.endpoint,
     fallbackSessionId: options.fallbackSessionId,
     model: options.model,
     sessionId: getMetadataSessionId(options.payload),
   })
+
+function copilotUsageFromResponse(
+  copilotUsage: CopilotUsage | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
+  }
+}
+
+function responsesCopilotUsageFromResponse(
+  copilotUsage: ResponsesCopilotUsage | null | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
+  }
+}
 
 const getMetadataSessionId = (
   payload: AnthropicMessagesPayload,

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -556,18 +556,11 @@ function mapOpenAIChatCompletionUsage(
   const promptDetails = response.usage?.prompt_tokens_details
   const promptTokens = response.usage?.prompt_tokens ?? 0
   const cachedTokens = promptDetails?.cached_tokens ?? 0
-  const cacheCreationTokens = promptDetails?.cache_creation_input_tokens ?? 0
   const usage: AnthropicResponse["usage"] = {
-    input_tokens: Math.max(
-      0,
-      promptTokens - cachedTokens - cacheCreationTokens,
-    ),
+    input_tokens: Math.max(0, promptTokens - cachedTokens),
     output_tokens: response.usage?.completion_tokens ?? 0,
   }
 
-  if (promptDetails?.cache_creation_input_tokens !== undefined) {
-    usage.cache_creation_input_tokens = cacheCreationTokens
-  }
   if (promptDetails?.cached_tokens !== undefined) {
     usage.cache_read_input_tokens = cachedTokens
   }

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -118,16 +118,11 @@ function handleFinish(
 function getAnthropicUsageFromOpenAIChunk(
   chunk: ChatCompletionChunk,
 ): NonNullable<AnthropicMessageDeltaEvent["usage"]> {
-  const { cachedTokens, cacheCreationTokens, inputTokens } =
-    getOpenAIChunkUsageTokens(chunk)
+  const { cachedTokens, inputTokens } = getOpenAIChunkUsageTokens(chunk)
 
   return {
     input_tokens: inputTokens,
     output_tokens: chunk.usage?.completion_tokens ?? 0,
-    ...(chunk.usage?.prompt_tokens_details?.cache_creation_input_tokens
-      !== undefined && {
-      cache_creation_input_tokens: cacheCreationTokens,
-    }),
     ...(chunk.usage?.prompt_tokens_details?.cached_tokens !== undefined && {
       cache_read_input_tokens: cachedTokens,
     }),
@@ -135,19 +130,15 @@ function getAnthropicUsageFromOpenAIChunk(
 }
 
 function getOpenAIChunkUsageTokens(chunk: ChatCompletionChunk): {
-  cacheCreationTokens: number
   cachedTokens: number
   inputTokens: number
 } {
   const promptTokens = chunk.usage?.prompt_tokens ?? 0
   const cachedTokens = chunk.usage?.prompt_tokens_details?.cached_tokens ?? 0
-  const cacheCreationTokens =
-    chunk.usage?.prompt_tokens_details?.cache_creation_input_tokens ?? 0
 
   return {
-    cacheCreationTokens,
     cachedTokens,
-    inputTokens: Math.max(0, promptTokens - cachedTokens - cacheCreationTokens),
+    inputTokens: Math.max(0, promptTokens - cachedTokens),
   }
 }
 
@@ -339,8 +330,7 @@ function handleMessageStart(
   chunk: ChatCompletionChunk,
 ) {
   if (!state.messageStartSent) {
-    const { cachedTokens, cacheCreationTokens, inputTokens } =
-      getOpenAIChunkUsageTokens(chunk)
+    const { cachedTokens, inputTokens } = getOpenAIChunkUsageTokens(chunk)
 
     events.push({
       type: "message_start",
@@ -355,10 +345,6 @@ function handleMessageStart(
         usage: {
           input_tokens: inputTokens,
           output_tokens: 0, // Will be updated in message_delta when finished
-          ...(chunk.usage?.prompt_tokens_details?.cache_creation_input_tokens
-            !== undefined && {
-            cache_creation_input_tokens: cacheCreationTokens,
-          }),
           ...(chunk.usage?.prompt_tokens_details?.cached_tokens
             !== undefined && {
             cache_read_input_tokens: cachedTokens,

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -19,6 +19,7 @@ import {
 import {
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
+  type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
 import {
@@ -29,6 +30,7 @@ import {
 } from "~/lib/utils"
 import {
   createResponses as createCopilotResponses,
+  type CopilotUsage,
   type ResponseStreamEvent,
   type ResponsesPayload,
   type ResponsesResult,
@@ -64,7 +66,7 @@ export const webSearchFlowDependencies = {
     payload: AnthropicMessagesPayload,
     sessionId?: string,
     webSearchModel?: string,
-  ): ((usage: UsageTokens) => void) =>
+  ): ((usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void) =>
     createCopilotTokenUsageRecorder({
       endpoint: "responses",
       fallbackSessionId: sessionId,
@@ -580,7 +582,7 @@ const createUsageRecorder = (
   payload: AnthropicMessagesPayload,
   sessionId?: string,
   webSearchModel?: string,
-): ((usage: UsageTokens) => void) =>
+): ((usage: UsageTokens, copilotUsage?: CopilotUsageTokens | null) => void) =>
   webSearchFlowDependencies.createUsageRecorder(
     payload,
     sessionId,
@@ -717,7 +719,10 @@ export const handleWebSearchViaResponses = async (
     options.sessionId,
     webSearchModel,
   )
-  recordUsage(normalizeResponsesUsage(result.usage))
+  recordUsage(
+    normalizeResponsesUsage(result.usage),
+    copilotUsageFromResponse(result.copilot_usage),
+  )
 
   if (!wantsStream) {
     return c.json(response)
@@ -731,6 +736,19 @@ export const handleWebSearchViaResponses = async (
       })
     }
   })
+}
+
+function copilotUsageFromResponse(
+  copilotUsage: CopilotUsage | null | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
+  }
 }
 
 // --- Synthetic SSE replay -------------------------------------------------

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -19,6 +19,7 @@ import {
 import {
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
+  copilotUsageToTokens,
   type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -30,7 +31,6 @@ import {
 } from "~/lib/utils"
 import {
   createResponses as createCopilotResponses,
-  type CopilotUsage,
   type ResponseStreamEvent,
   type ResponsesPayload,
   type ResponsesResult,
@@ -721,7 +721,7 @@ export const handleWebSearchViaResponses = async (
   )
   recordUsage(
     normalizeResponsesUsage(result.usage),
-    copilotUsageFromResponse(result.copilot_usage),
+    copilotUsageToTokens(result.copilot_usage),
   )
 
   if (!wantsStream) {
@@ -736,19 +736,6 @@ export const handleWebSearchViaResponses = async (
       })
     }
   })
-}
-
-function copilotUsageFromResponse(
-  copilotUsage: CopilotUsage | null | undefined,
-): CopilotUsageTokens {
-  if (!copilotUsage) {
-    return {}
-  }
-
-  return {
-    token_details: copilotUsage.token_details,
-    total_nano_aiu: copilotUsage.total_nano_aiu,
-  }
 }
 
 // --- Synthetic SSE replay -------------------------------------------------

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -1053,7 +1053,6 @@ const adjustInputTokens = (
   usage?: {
     input_tokens?: number
     cache_read_input_tokens?: number
-    cache_creation_input_tokens?: number
   },
 ): void => {
   if (!providerConfig.adjustInputTokens || !usage) {
@@ -1061,9 +1060,7 @@ const adjustInputTokens = (
   }
   const adjustedInput = Math.max(
     0,
-    (usage.input_tokens ?? 0)
-      - (usage.cache_read_input_tokens ?? 0)
-      - (usage.cache_creation_input_tokens ?? 0),
+    (usage.input_tokens ?? 0) - (usage.cache_read_input_tokens ?? 0),
   )
   usage.input_tokens = adjustedInput
   debugJson(logger, "provider.messages.adjusted_usage:", usage)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono"
 
 import { streamSSE } from "hono/streaming"
 
+import consola from "consola"
 import { awaitApproval } from "~/lib/approval"
 import {
   isResponsesApiWebSearchEnabled as isConfiguredResponsesApiWebSearchEnabled,
@@ -10,17 +11,19 @@ import {
 import { createHandlerLogger, debugJson, debugJsonTail } from "~/lib/logger"
 import { parseProviderModelAlias } from "~/lib/provider-model"
 import { checkRateLimit as checkConfiguredRateLimit } from "~/lib/rate-limit"
-import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
 import { state } from "~/lib/state"
+import type { SubagentMarker } from "~/lib/subagent"
 import {
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
+  type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
 import { generateRequestIdFromPayload, getUUID } from "~/lib/utils"
-import type { SubagentMarker } from "~/lib/subagent"
+import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
 import {
   createResponses as createCopilotResponses,
+  type CopilotUsage,
   type ResponsesPayload,
   type ResponsesResult,
   type ResponseStreamEvent,
@@ -30,11 +33,10 @@ import { createStreamIdTracker, fixStreamIds } from "./stream-id-sync"
 import {
   applyResponsesApiContextManagement,
   compactInputByLatestCompaction,
-  getResponsesTransportForModel,
   getResponsesRequestOptions,
+  getResponsesTransportForModel,
   sanitizeOversizedInputImages,
 } from "./utils"
-import consola from "consola"
 
 const logger = createHandlerLogger("responses-handler")
 
@@ -151,6 +153,7 @@ export const handleResponses = async (c: Context) => {
     return streamSSE(c, async (stream) => {
       const idTracker = createStreamIdTracker()
       let usage: UsageTokens = {}
+      let copilotUsage: CopilotUsageTokens = {}
 
       for await (const chunk of response) {
         debugJson(logger, "Responses stream chunk:", chunk)
@@ -161,6 +164,9 @@ export const handleResponses = async (c: Context) => {
           || parsedEvent?.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(parsedEvent.response.usage)
+          copilotUsage = copilotUsageFromResponse(
+            parsedEvent.response.copilot_usage,
+          )
         }
 
         const processedData = fixStreamIds(
@@ -176,7 +182,7 @@ export const handleResponses = async (c: Context) => {
         })
       }
 
-      recordUsage(usage)
+      recordUsage(usage, copilotUsage)
     })
   }
 
@@ -184,8 +190,12 @@ export const handleResponses = async (c: Context) => {
     value: response,
     tailLength: 400,
   })
-  recordUsage(normalizeResponsesUsage((response as ResponsesResult).usage))
-  return c.json(response as ResponsesResult)
+  const result = response as ResponsesResult
+  recordUsage(
+    normalizeResponsesUsage(result.usage),
+    copilotUsageFromResponse(result.copilot_usage),
+  )
+  return c.json(result)
 }
 
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
@@ -207,6 +217,19 @@ const parseResponsesStreamEvent = (
     return JSON.parse(data) as ResponseStreamEvent
   } catch {
     return null
+  }
+}
+
+function copilotUsageFromResponse(
+  copilotUsage: CopilotUsage | null | undefined,
+): CopilotUsageTokens {
+  if (!copilotUsage) {
+    return {}
+  }
+
+  return {
+    token_details: copilotUsage.token_details,
+    total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }
 

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -17,6 +17,7 @@ import {
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
   copilotUsageToTokens,
+  type CopilotUsage,
   type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -164,9 +165,8 @@ export const handleResponses = async (c: Context) => {
           || parsedEvent?.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(parsedEvent.response.usage)
-          copilotUsage = copilotUsageToTokens(
-            parsedEvent.response.copilot_usage,
-          )
+          copilotUsage =
+            copilotUsageFromResponsesEvent(parsedEvent) ?? copilotUsage
         }
 
         const processedData = fixStreamIds(
@@ -218,6 +218,32 @@ const parseResponsesStreamEvent = (
   } catch {
     return null
   }
+}
+
+const copilotUsageFromResponsesEvent = (
+  event: ResponseStreamEvent,
+): CopilotUsageTokens | null => {
+  const topLevelUsage = nonEmptyCopilotUsageTokens(
+    (event as { copilot_usage?: CopilotUsage | null }).copilot_usage,
+  )
+  if (topLevelUsage) {
+    return topLevelUsage
+  }
+
+  const response = (
+    event as {
+      response?: { copilot_usage?: CopilotUsage | null }
+    }
+  ).response
+
+  return nonEmptyCopilotUsageTokens(response?.copilot_usage)
+}
+
+const nonEmptyCopilotUsageTokens = (
+  usage: CopilotUsage | null | undefined,
+): CopilotUsageTokens | null => {
+  const tokens = copilotUsageToTokens(usage)
+  return Object.keys(tokens).length > 0 ? tokens : null
 }
 
 const removeWebSearchTool = (payload: ResponsesPayload): void => {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -14,10 +14,10 @@ import { checkRateLimit as checkConfiguredRateLimit } from "~/lib/rate-limit"
 import { state } from "~/lib/state"
 import type { SubagentMarker } from "~/lib/subagent"
 import {
+  copilotUsageFromResponsesEvent,
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
   copilotUsageToTokens,
-  type CopilotUsage,
   type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -218,32 +218,6 @@ const parseResponsesStreamEvent = (
   } catch {
     return null
   }
-}
-
-const copilotUsageFromResponsesEvent = (
-  event: ResponseStreamEvent,
-): CopilotUsageTokens | null => {
-  const topLevelUsage = nonEmptyCopilotUsageTokens(
-    (event as { copilot_usage?: CopilotUsage | null }).copilot_usage,
-  )
-  if (topLevelUsage) {
-    return topLevelUsage
-  }
-
-  const response = (
-    event as {
-      response?: { copilot_usage?: CopilotUsage | null }
-    }
-  ).response
-
-  return nonEmptyCopilotUsageTokens(response?.copilot_usage)
-}
-
-const nonEmptyCopilotUsageTokens = (
-  usage: CopilotUsage | null | undefined,
-): CopilotUsageTokens | null => {
-  const tokens = copilotUsageToTokens(usage)
-  return Object.keys(tokens).length > 0 ? tokens : null
 }
 
 const removeWebSearchTool = (payload: ResponsesPayload): void => {

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -16,6 +16,7 @@ import type { SubagentMarker } from "~/lib/subagent"
 import {
   createCopilotTokenUsageRecorder,
   normalizeResponsesUsage,
+  copilotUsageToTokens,
   type CopilotUsageTokens,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -23,7 +24,6 @@ import { generateRequestIdFromPayload, getUUID } from "~/lib/utils"
 import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
 import {
   createResponses as createCopilotResponses,
-  type CopilotUsage,
   type ResponsesPayload,
   type ResponsesResult,
   type ResponseStreamEvent,
@@ -164,7 +164,7 @@ export const handleResponses = async (c: Context) => {
           || parsedEvent?.type === "response.incomplete"
         ) {
           usage = normalizeResponsesUsage(parsedEvent.response.usage)
-          copilotUsage = copilotUsageFromResponse(
+          copilotUsage = copilotUsageToTokens(
             parsedEvent.response.copilot_usage,
           )
         }
@@ -193,7 +193,7 @@ export const handleResponses = async (c: Context) => {
   const result = response as ResponsesResult
   recordUsage(
     normalizeResponsesUsage(result.usage),
-    copilotUsageFromResponse(result.copilot_usage),
+    copilotUsageToTokens(result.copilot_usage),
   )
   return c.json(result)
 }
@@ -217,19 +217,6 @@ const parseResponsesStreamEvent = (
     return JSON.parse(data) as ResponseStreamEvent
   } catch {
     return null
-  }
-}
-
-function copilotUsageFromResponse(
-  copilotUsage: CopilotUsage | null | undefined,
-): CopilotUsageTokens {
-  if (!copilotUsage) {
-    return {}
-  }
-
-  return {
-    token_details: copilotUsage.token_details,
-    total_nano_aiu: copilotUsage.total_nano_aiu,
   }
 }
 

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -80,6 +80,18 @@ export const createChatCompletions = async (
 
 // Streaming types
 
+export interface CopilotUsageTokenDetail {
+  batch_size: number
+  cost_per_batch: number
+  token_count: number
+  token_type: string
+}
+
+export interface CopilotUsage {
+  token_details?: Array<CopilotUsageTokenDetail>
+  total_nano_aiu?: number
+}
+
 export interface ChatCompletionChunk {
   id: string
   object: "chat.completion.chunk"
@@ -100,6 +112,7 @@ export interface ChatCompletionChunk {
       rejected_prediction_tokens: number
     }
   }
+  copilot_usage?: CopilotUsage
 }
 
 export interface Delta {
@@ -144,6 +157,7 @@ export interface ChatCompletionResponse {
       cached_tokens?: number
     }
   }
+  copilot_usage?: CopilotUsage
 }
 
 interface ResponseMessage {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -13,6 +13,9 @@ import {
 import { logCopilotRateLimits } from "~/lib/copilot-rate-limit"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
+import type { CopilotUsage } from "~/lib/token-usage"
+
+export type { CopilotUsage }
 
 export const createChatCompletions = async (
   payload: ChatCompletionsPayload,
@@ -79,18 +82,6 @@ export const createChatCompletions = async (
 }
 
 // Streaming types
-
-export interface CopilotUsageTokenDetail {
-  batch_size: number
-  cost_per_batch: number
-  token_count: number
-  token_type: string
-}
-
-export interface CopilotUsage {
-  token_details?: Array<CopilotUsageTokenDetail>
-  total_nano_aiu?: number
-}
 
 export interface ChatCompletionChunk {
   id: string

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -95,7 +95,6 @@ export interface ChatCompletionChunk {
     completion_tokens: number
     total_tokens: number
     prompt_tokens_details?: {
-      cache_creation_input_tokens?: number
       cached_tokens?: number
     }
     completion_tokens_details?: {
@@ -144,7 +143,6 @@ export interface ChatCompletionResponse {
     completion_tokens: number
     total_tokens: number
     prompt_tokens_details?: {
-      cache_creation_input_tokens?: number
       cached_tokens?: number
     }
   }

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -201,6 +201,18 @@ export interface ResponseInputFile {
   filename?: string | null
 }
 
+export interface CopilotUsageTokenDetail {
+  batch_size: number
+  cost_per_batch: number
+  token_count: number
+  token_type: string
+}
+
+export interface CopilotUsage {
+  token_details?: Array<CopilotUsageTokenDetail>
+  total_nano_aiu?: number
+}
+
 export interface ResponsesResult {
   id: string
   object: "response"
@@ -210,6 +222,7 @@ export interface ResponsesResult {
   output_text: string
   status: string
   usage?: ResponseUsage | null
+  copilot_usage?: CopilotUsage | null
   error: ResponseError | null
   incomplete_details: IncompleteDetails | null
   instructions: string | null

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -343,6 +343,7 @@ export type ResponseStreamEvent =
   | ResponseTextDoneEvent
 
 export interface ResponseCompletedEvent {
+  copilot_usage?: CopilotUsage | null
   copilot_quota_snapshots?: Record<string, CopilotQuotaSnapshot>
   response: ResponsesResult
   sequence_number: number
@@ -350,6 +351,7 @@ export interface ResponseCompletedEvent {
 }
 
 export interface ResponseIncompleteEvent {
+  copilot_usage?: CopilotUsage | null
   response: ResponsesResult
   sequence_number: number
   type: "response.incomplete"
@@ -394,6 +396,7 @@ export interface ResponseFunctionCallArgumentsDoneEvent {
 }
 
 export interface ResponseFailedEvent {
+  copilot_usage?: CopilotUsage | null
   response: ResponsesResult
   sequence_number: number
   type: "response.failed"

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -24,6 +24,9 @@ import {
   createPooledWebSocketStream,
   createWebSocketUrl,
 } from "~/services/responses-websocket"
+import type { CopilotUsage } from "~/lib/token-usage"
+
+export type { CopilotUsage }
 
 export interface ResponsesPayload {
   model: string
@@ -199,18 +202,6 @@ export interface ResponseInputFile {
   file_data?: string | null
   file_id?: string | null
   filename?: string | null
-}
-
-export interface CopilotUsageTokenDetail {
-  batch_size: number
-  cost_per_batch: number
-  token_count: number
-  token_type: string
-}
-
-export interface CopilotUsage {
-  token_details?: Array<CopilotUsageTokenDetail>
-  total_nano_aiu?: number
 }
 
 export interface ResponsesResult {

--- a/tests/anthropic-response.test.ts
+++ b/tests/anthropic-response.test.ts
@@ -193,7 +193,7 @@ describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
     expect(anthropicResponse.stop_reason).toBe("max_tokens")
   })
 
-  test("should translate OpenAI cache creation usage details", () => {
+  test("should translate OpenAI cached usage details", () => {
     const openAIResponse: ChatCompletionResponse = {
       id: "chatcmpl-cache",
       object: "chat.completion",
@@ -215,7 +215,6 @@ describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
         completion_tokens: 10,
         total_tokens: 110,
         prompt_tokens_details: {
-          cache_creation_input_tokens: 20,
           cached_tokens: 12,
         },
       },
@@ -224,9 +223,8 @@ describe("OpenAI to Anthropic Non-Streaming Response Translation", () => {
     const anthropicResponse = translateToAnthropic(openAIResponse)
 
     expect(anthropicResponse.usage).toEqual({
-      cache_creation_input_tokens: 20,
       cache_read_input_tokens: 12,
-      input_tokens: 68,
+      input_tokens: 88,
       output_tokens: 10,
     })
   })
@@ -599,7 +597,6 @@ describe("OpenAI usage-only stream translation", () => {
           completion_tokens: 20,
           total_tokens: 120,
           prompt_tokens_details: {
-            cache_creation_input_tokens: 3,
             cached_tokens: 12,
           },
         },
@@ -629,9 +626,8 @@ describe("OpenAI usage-only stream translation", () => {
         stop_sequence: null,
       },
       usage: {
-        input_tokens: 85,
+        input_tokens: 88,
         output_tokens: 20,
-        cache_creation_input_tokens: 3,
         cache_read_input_tokens: 12,
       },
     })

--- a/tests/messages-api-flows.test.ts
+++ b/tests/messages-api-flows.test.ts
@@ -456,6 +456,92 @@ test("messages Responses flow records top-level copilot_usage from terminal stre
   expect(page.items[0]?.total_nano_aiu).toBe(502_500)
 })
 
+test("messages Responses flow falls back to nested copilot_usage when top-level payload is empty", async () => {
+  createResponses.mockImplementationOnce(
+    (
+      payload: ResponsesPayload,
+      options: { transport?: ResponsesTransport },
+    ) => {
+      capturedResponsesPayload = payload
+      capturedResponsesOptions = options
+      return Promise.resolve(
+        streamChunks([
+          {
+            event: "response.incomplete",
+            data: JSON.stringify({
+              type: "response.incomplete",
+              copilot_usage: {},
+              response: {
+                ...createResponsesResult(payload.model),
+                copilot_usage: {
+                  token_details: [
+                    {
+                      batch_size: 1_000_000,
+                      cost_per_batch: 12_500_000_000,
+                      token_count: 3,
+                      token_type: "input",
+                    },
+                  ],
+                  total_nano_aiu: 37_500,
+                },
+                status: "incomplete",
+                usage: {
+                  input_tokens: 3,
+                  output_tokens: 0,
+                  total_tokens: 3,
+                },
+              },
+            }),
+          },
+        ]),
+      )
+    },
+  )
+
+  const payload: AnthropicMessagesPayload = {
+    max_tokens: 128,
+    stream: true,
+    messages: [{ role: "user", content: "hello" }],
+    model: "gpt-test",
+  }
+
+  const app = new Hono()
+  app.post("/messages-responses", (c) =>
+    handleWithResponsesApi(c, payload, {
+      logger,
+      requestId: "request-2",
+      selectedModel: createModel(["/responses"]),
+      sessionId: "nested-session",
+    }),
+  )
+  app.route("/token-usage", tokenUsageRoute)
+
+  const response = await app.request("/messages-responses", {
+    method: "POST",
+  })
+
+  expect(response.status).toBe(200)
+  await response.text()
+
+  const eventsResponse = await app.request(
+    "/token-usage/events?period=day&page=1&page_size=10",
+  )
+  expect(eventsResponse.status).toBe(200)
+
+  const page = (await eventsResponse.json()) as {
+    items: Array<{
+      nano_cost_input: number | null
+      session_id: string
+      total_nano_aiu: number | null
+    }>
+  }
+
+  expect(page.items).toHaveLength(1)
+  expect(page.items[0]?.session_id).toBe("nested-session")
+  expect(page.items[0]?.nano_cost_input).toBe(37_500)
+  expect(page.items[0]?.total_nano_aiu).toBe(37_500)
+})
+
 test("messages Responses flow preserves the configured tool_search alias in non-streaming responses", async () => {
   createResponses.mockImplementationOnce(
     (

--- a/tests/messages-api-flows.test.ts
+++ b/tests/messages-api-flows.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
 
 import type { AnthropicMessagesPayload } from "../src/routes/messages/anthropic-types"
 import type { Model } from "../src/services/copilot/get-models"
@@ -63,12 +64,15 @@ const {
   messagesApiFlowDependencies,
   prepareCopilotChatCompletionsPayload,
 } = await import("../src/routes/messages/api-flows")
+const { closeUsageStore } = await import("../src/lib/token-usage")
 const { responsesUtilsDependencies } = await import(
   "../src/routes/responses/utils"
 )
+const { tokenUsageRoute } = await import("../src/routes/token-usage/route")
 
 const defaultMessagesApiFlowDependencies = { ...messagesApiFlowDependencies }
 const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
+const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
 
 const logger = {
   debug: () => {},
@@ -81,7 +85,16 @@ const createContext = () =>
     json: (body: unknown) => Response.json(body),
   }) as Parameters<typeof handleWithChatCompletions>[0]
 
-beforeEach(() => {
+async function* streamChunks(items: Array<Record<string, unknown>>) {
+  await Promise.resolve()
+  for (const item of items) {
+    yield item
+  }
+}
+
+beforeEach(async () => {
+  process.env[DB_PATH_ENV] = ":memory:"
+  await closeUsageStore()
   capturedPayload = null
   capturedResponsesPayload = null
   capturedResponsesOptions = null
@@ -94,7 +107,9 @@ beforeEach(() => {
   createResponses.mockClear()
 })
 
-afterEach(() => {
+afterEach(async () => {
+  await closeUsageStore()
+  Reflect.deleteProperty(process.env, DB_PATH_ENV)
   Object.assign(messagesApiFlowDependencies, defaultMessagesApiFlowDependencies)
   Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
 })
@@ -338,6 +353,107 @@ test("messages Responses flow keeps streaming transport for deferred tool search
   expect(createResponses).toHaveBeenCalledTimes(1)
   expect(capturedResponsesPayload?.stream).toBe(true)
   expect(capturedResponsesOptions?.transport).toBe("websocket")
+})
+
+test("messages Responses flow records top-level copilot_usage from terminal stream events", async () => {
+  createResponses.mockImplementationOnce(
+    (
+      payload: ResponsesPayload,
+      options: { transport?: ResponsesTransport },
+    ) => {
+      capturedResponsesPayload = payload
+      capturedResponsesOptions = options
+      return Promise.resolve(
+        streamChunks([
+          {
+            event: "response.completed",
+            data: JSON.stringify({
+              type: "response.completed",
+              copilot_usage: {
+                token_details: [
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 25_000_000_000,
+                    token_count: 4,
+                    token_type: "input",
+                  },
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 2_500_000_000,
+                    token_count: 1,
+                    token_type: "cache_read",
+                  },
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 200_000_000_000,
+                    token_count: 2,
+                    token_type: "output",
+                  },
+                ],
+                total_nano_aiu: 502_500,
+              },
+              response: {
+                ...createResponsesResult(payload.model),
+                usage: {
+                  input_tokens: 5,
+                  input_tokens_details: { cached_tokens: 1 },
+                  output_tokens: 2,
+                  total_tokens: 7,
+                },
+              },
+            }),
+          },
+        ]),
+      )
+    },
+  )
+
+  const payload: AnthropicMessagesPayload = {
+    max_tokens: 128,
+    stream: true,
+    messages: [{ role: "user", content: "hello" }],
+    model: "gpt-test",
+  }
+
+  const app = new Hono()
+  app.post("/messages-responses", (c) =>
+    handleWithResponsesApi(c, payload, {
+      logger,
+      requestId: "request-1",
+      selectedModel: createModel(["/responses"]),
+      sessionId: "stream-session",
+    }),
+  )
+  app.route("/token-usage", tokenUsageRoute)
+
+  const response = await app.request("/messages-responses", {
+    method: "POST",
+  })
+
+  expect(response.status).toBe(200)
+  await response.text()
+
+  const eventsResponse = await app.request(
+    "/token-usage/events?period=day&page=1&page_size=10",
+  )
+  expect(eventsResponse.status).toBe(200)
+
+  const page = (await eventsResponse.json()) as {
+    items: Array<{
+      nano_cost_cache_read: number | null
+      nano_cost_input: number | null
+      nano_cost_output: number | null
+      session_id: string
+      total_nano_aiu: number | null
+    }>
+  }
+
+  expect(page.items).toHaveLength(1)
+  expect(page.items[0]?.session_id).toBe("stream-session")
+  expect(page.items[0]?.nano_cost_cache_read).toBe(2_500)
+  expect(page.items[0]?.nano_cost_input).toBe(100_000)
+  expect(page.items[0]?.nano_cost_output).toBe(400_000)
+  expect(page.items[0]?.total_nano_aiu).toBe(502_500)
 })
 
 test("messages Responses flow preserves the configured tool_search alias in non-streaming responses", async () => {

--- a/tests/provider-openai-compatible.test.ts
+++ b/tests/provider-openai-compatible.test.ts
@@ -53,7 +53,6 @@ const fetchMock = mock((_url: string | URL | Request, _init?: RequestInit) =>
           completion_tokens: 2,
           total_tokens: 10,
           prompt_tokens_details: {
-            cache_creation_input_tokens: 2,
             cached_tokens: 1,
           },
         },
@@ -217,9 +216,8 @@ describe("openai-compatible provider messages", () => {
       role: "assistant",
       stop_reason: "end_turn",
       usage: {
-        cache_creation_input_tokens: 2,
         cache_read_input_tokens: 1,
-        input_tokens: 5,
+        input_tokens: 7,
         output_tokens: 2,
       },
     })

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -702,6 +702,29 @@ describe("responses handler token usage", () => {
         streamChunks([
           {
             data: JSON.stringify({
+              copilot_usage: {
+                token_details: [
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 25_000_000_000,
+                    token_count: 4,
+                    token_type: "input",
+                  },
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 2_500_000_000,
+                    token_count: 1,
+                    token_type: "cache_read",
+                  },
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 200_000_000_000,
+                    token_count: 2,
+                    token_type: "output",
+                  },
+                ],
+                total_nano_aiu: 502_500,
+              },
               response: {
                 created_at: 0,
                 error: {
@@ -767,8 +790,12 @@ describe("responses handler token usage", () => {
       items: Array<{
         cache_read_input_tokens: number
         input_tokens: number
+        nano_cost_cache_read: number | null
+        nano_cost_input: number | null
+        nano_cost_output: number | null
         output_tokens: number
         session_id: string
+        total_nano_aiu: number | null
         total_tokens: number
       }>
     }
@@ -782,7 +809,11 @@ describe("responses handler token usage", () => {
     expect(page.items[0]?.session_id).toBe(expectedInteractionId)
     expect(page.items[0]?.cache_read_input_tokens).toBe(1)
     expect(page.items[0]?.input_tokens).toBe(4)
+    expect(page.items[0]?.nano_cost_cache_read).toBe(2_500)
+    expect(page.items[0]?.nano_cost_input).toBe(100_000)
+    expect(page.items[0]?.nano_cost_output).toBe(400_000)
     expect(page.items[0]?.output_tokens).toBe(2)
+    expect(page.items[0]?.total_nano_aiu).toBe(502_500)
     expect(page.items[0]?.total_tokens).toBe(7)
   })
 })

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -816,4 +816,183 @@ describe("responses handler token usage", () => {
     expect(page.items[0]?.total_nano_aiu).toBe(502_500)
     expect(page.items[0]?.total_tokens).toBe(7)
   })
+
+  test("records usage from incomplete streaming responses with top-level copilot_usage", async () => {
+    createResponses.mockImplementation(() =>
+      Promise.resolve(
+        streamChunks([
+          {
+            data: JSON.stringify({
+              copilot_usage: {
+                token_details: [
+                  {
+                    batch_size: 1_000_000,
+                    cost_per_batch: 30_000_000_000,
+                    token_count: 2,
+                    token_type: "input",
+                  },
+                ],
+                total_nano_aiu: 60_000,
+              },
+              response: {
+                created_at: 0,
+                error: null,
+                id: "resp_234",
+                incomplete_details: { reason: "max_output_tokens" },
+                instructions: null,
+                metadata: null,
+                model: "gpt-test",
+                object: "response",
+                output: [],
+                output_text: "",
+                parallel_tool_calls: false,
+                status: "incomplete",
+                temperature: null,
+                tool_choice: "auto",
+                tools: [],
+                top_p: null,
+                usage: {
+                  input_tokens: 2,
+                  output_tokens: 0,
+                  total_tokens: 2,
+                },
+              },
+              sequence_number: 1,
+              type: "response.incomplete",
+            }),
+            event: "response.incomplete",
+            id: "event_2",
+          },
+        ]),
+      ),
+    )
+
+    const app = createApp()
+    const payload = {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    }
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+
+    expect(response.status).toBe(200)
+    await response.text()
+
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=day&page=1&page_size=10",
+    )
+    expect(eventsResponse.status).toBe(200)
+
+    const page = (await eventsResponse.json()) as {
+      items: Array<{
+        input_tokens: number
+        nano_cost_input: number | null
+        total_nano_aiu: number | null
+        total_tokens: number
+      }>
+    }
+    expect(page.items).toHaveLength(1)
+    expect(page.items[0]?.input_tokens).toBe(2)
+    expect(page.items[0]?.nano_cost_input).toBe(60_000)
+    expect(page.items[0]?.total_nano_aiu).toBe(60_000)
+    expect(page.items[0]?.total_tokens).toBe(2)
+  })
+
+  test("falls back to nested copilot_usage when top-level streaming payload is empty", async () => {
+    createResponses.mockImplementation(() =>
+      Promise.resolve(
+        streamChunks([
+          {
+            data: JSON.stringify({
+              copilot_usage: {},
+              response: {
+                created_at: 0,
+                error: {
+                  message: "request failed",
+                },
+                id: "resp_345",
+                incomplete_details: null,
+                instructions: null,
+                metadata: null,
+                model: "gpt-test",
+                object: "response",
+                output: [],
+                output_text: "",
+                parallel_tool_calls: false,
+                status: "failed",
+                temperature: null,
+                tool_choice: "auto",
+                tools: [],
+                top_p: null,
+                copilot_usage: {
+                  token_details: [
+                    {
+                      batch_size: 1_000_000,
+                      cost_per_batch: 15_000_000_000,
+                      token_count: 2,
+                      token_type: "input",
+                    },
+                  ],
+                  total_nano_aiu: 30_000,
+                },
+                usage: {
+                  input_tokens: 2,
+                  output_tokens: 0,
+                  total_tokens: 2,
+                },
+              },
+              sequence_number: 1,
+              type: "response.failed",
+            }),
+            event: "response.failed",
+            id: "event_3",
+          },
+        ]),
+      ),
+    )
+
+    const app = createApp()
+    const payload = {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    }
+
+    const response = await app.request("/v1/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    })
+
+    expect(response.status).toBe(200)
+    await response.text()
+
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=day&page=1&page_size=10",
+    )
+    expect(eventsResponse.status).toBe(200)
+
+    const page = (await eventsResponse.json()) as {
+      items: Array<{
+        input_tokens: number
+        nano_cost_input: number | null
+        total_nano_aiu: number | null
+        total_tokens: number
+      }>
+    }
+    expect(page.items).toHaveLength(1)
+    expect(page.items[0]?.input_tokens).toBe(2)
+    expect(page.items[0]?.nano_cost_input).toBe(30_000)
+    expect(page.items[0]?.total_nano_aiu).toBe(30_000)
+    expect(page.items[0]?.total_tokens).toBe(2)
+  })
 })

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -179,7 +179,6 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
-      nano_cost_cache_creation: null,
       nano_cost_cache_read: null,
       nano_cost_cache_write: null,
       nano_cost_input: null,
@@ -269,7 +268,7 @@ describe("token usage storage", () => {
             batch_size: 1_000_000,
             cost_per_batch: 5_000_000_000,
             token_count: 4,
-            token_type: "cache_creation",
+            token_type: "cache_write",
           },
           {
             batch_size: 1_000_000,
@@ -290,15 +289,14 @@ describe("token usage storage", () => {
     expect(summary.totals.total_nano_aiu).toBe(15_477_500)
     expect(summary.totals.nano_cost_input).toBe(450_000)
     expect(summary.totals.nano_cost_cache_read).toBe(7_500)
-    expect(summary.totals.nano_cost_cache_write).toBe(0)
-    expect(summary.totals.nano_cost_cache_creation).toBe(20_000)
+    expect(summary.totals.nano_cost_cache_write).toBe(20_000)
     expect(summary.totals.nano_cost_output).toBe(15_000_000)
     expect(summary.byModel[0]?.total_nano_aiu).toBe(15_477_500)
-    expect(summary.byModel[0]?.nano_cost_cache_creation).toBe(20_000)
+    expect(summary.byModel[0]?.nano_cost_cache_write).toBe(20_000)
 
     const eventsPage = await fetchEventsPage()
     expect(eventsPage.items[0]?.total_nano_aiu).toBe(15_477_500)
-    expect(eventsPage.items[0]?.nano_cost_cache_creation).toBe(20_000)
+    expect(eventsPage.items[0]?.nano_cost_cache_write).toBe(20_000)
     expect(eventsPage.items[0]?.nano_cost_output).toBe(15_000_000)
   })
 
@@ -380,7 +378,6 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 36,
-      nano_cost_cache_creation: null,
       nano_cost_cache_read: null,
       nano_cost_cache_write: null,
       nano_cost_input: null,
@@ -407,7 +404,6 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
-      nano_cost_cache_creation: null,
       nano_cost_cache_read: null,
       nano_cost_cache_write: null,
       nano_cost_input: null,

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -64,21 +64,19 @@ function localDateLabel(date: Date): string {
 }
 
 describe("token usage storage", () => {
-  test("normalizes OpenAI cache creation usage details", () => {
+  test("normalizes OpenAI cached usage details", () => {
     expect(
       normalizeOpenAIUsage({
         completion_tokens: 10,
         prompt_tokens: 100,
         prompt_tokens_details: {
-          cache_creation_input_tokens: 20,
           cached_tokens: 12,
         },
         total_tokens: 110,
       }),
     ).toEqual({
-      cache_creation_input_tokens: 20,
       cache_read_input_tokens: 12,
-      input_tokens: 68,
+      input_tokens: 88,
       output_tokens: 10,
       total_tokens: 110,
     })
@@ -152,7 +150,6 @@ describe("token usage storage", () => {
 
   test("summarizes by model with total token and user fields", async () => {
     recordTokenUsageEvent({
-      cache_creation_input_tokens: 1,
       cache_read_input_tokens: 2,
       endpoint: "chat_completions",
       input_tokens: 10,
@@ -176,7 +173,6 @@ describe("token usage storage", () => {
 
     const summary = (await response.json()) as TokenUsageSummary
     expect(summary.totals).toEqual({
-      cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
       nano_cost_cache_read: null,
@@ -186,9 +182,9 @@ describe("token usage storage", () => {
       output_tokens: 9,
       request_count: 2,
       total_nano_aiu: null,
-      total_tokens: 46,
+      total_tokens: 45,
     })
-    expect(summary.totals.total_tokens).toBe(46)
+    expect(summary.totals.total_tokens).toBe(45)
     expect(summary.byModel).toHaveLength(2)
     expect(summary.byModel.every((row) => row.total_tokens > 0)).toBe(true)
   })
@@ -239,7 +235,6 @@ describe("token usage storage", () => {
     recordUsage(
       {
         cache_read_input_tokens: 3,
-        cache_creation_input_tokens: 4,
         input_tokens: 18,
         output_tokens: 75,
         total_tokens: 100,
@@ -338,7 +333,6 @@ describe("token usage storage", () => {
 
     setSystemTime(localDate(2026, 4, 12, 10))
     recordTokenUsageEvent({
-      cache_creation_input_tokens: 1,
       cache_read_input_tokens: 2,
       endpoint: "chat_completions",
       input_tokens: 10,
@@ -375,7 +369,6 @@ describe("token usage storage", () => {
     expect(daily.period).toBe("week")
     expect(daily.days).toHaveLength(7)
     expect(daily.totals).toEqual({
-      cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 36,
       nano_cost_cache_read: null,
@@ -385,13 +378,13 @@ describe("token usage storage", () => {
       output_tokens: 12,
       request_count: 3,
       total_nano_aiu: null,
-      total_tokens: 145,
+      total_tokens: 144,
     })
     expect(daily.byModel.map((model) => model.model)).toEqual([
       "gpt-a",
       "gpt-b",
     ])
-    expect(daily.byModel[0]?.total_tokens).toBe(116)
+    expect(daily.byModel[0]?.total_tokens).toBe(115)
 
     const firstDay = daily.days[0]
     expect(firstDay?.date).toBe(localDateLabel(localDate(2026, 4, 9)))
@@ -401,7 +394,6 @@ describe("token usage storage", () => {
       (day) => day.date === localDateLabel(localDate(2026, 4, 12)),
     )
     expect(may12?.totals).toEqual({
-      cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
       nano_cost_cache_read: null,
@@ -411,7 +403,7 @@ describe("token usage storage", () => {
       output_tokens: 8,
       request_count: 2,
       total_nano_aiu: null,
-      total_tokens: 45,
+      total_tokens: 44,
     })
     expect(may12?.byModel.map((model) => model.model)).toEqual([
       "gpt-b",

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -179,8 +179,14 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
+      nano_cost_cache_creation: null,
+      nano_cost_cache_read: null,
+      nano_cost_cache_write: null,
+      nano_cost_input: null,
+      nano_cost_output: null,
       output_tokens: 9,
       request_count: 2,
+      total_nano_aiu: null,
       total_tokens: 46,
     })
     expect(summary.totals.total_tokens).toBe(46)
@@ -222,6 +228,78 @@ describe("token usage storage", () => {
     expect(page.items[0]?.trace_id).toBe("trace-provider")
     expect(page.items[0]?.session_id).toBe("claude-session")
     expect(page.items[0]?.total_tokens).toBe(25)
+  })
+
+  test("records copilot nano cost totals and category breakdowns", async () => {
+    const recordUsage = createCopilotTokenUsageRecorder({
+      endpoint: "chat_completions",
+      fallbackSessionId: "cost-session",
+      model: "gpt-cost",
+    })
+
+    recordUsage(
+      {
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 4,
+        input_tokens: 18,
+        output_tokens: 75,
+        total_tokens: 100,
+      },
+      {
+        token_details: [
+          {
+            batch_size: 1_000_000,
+            cost_per_batch: 25_000_000_000,
+            token_count: 18,
+            token_type: "input",
+          },
+          {
+            batch_size: 1_000_000,
+            cost_per_batch: 2_500_000_000,
+            token_count: 3,
+            token_type: "cache_read",
+          },
+          {
+            batch_size: 1_000_000,
+            cost_per_batch: 0,
+            token_count: 2,
+            token_type: "cache_write",
+          },
+          {
+            batch_size: 1_000_000,
+            cost_per_batch: 5_000_000_000,
+            token_count: 4,
+            token_type: "cache_creation",
+          },
+          {
+            batch_size: 1_000_000,
+            cost_per_batch: 200_000_000_000,
+            token_count: 75,
+            token_type: "output",
+          },
+        ],
+        total_nano_aiu: 15_477_500,
+      },
+    )
+
+    const summaryResponse = await createTokenUsageApp().request(
+      "/token-usage?period=day",
+    )
+    expect(summaryResponse.status).toBe(200)
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    expect(summary.totals.total_nano_aiu).toBe(15_477_500)
+    expect(summary.totals.nano_cost_input).toBe(450_000)
+    expect(summary.totals.nano_cost_cache_read).toBe(7_500)
+    expect(summary.totals.nano_cost_cache_write).toBe(0)
+    expect(summary.totals.nano_cost_cache_creation).toBe(20_000)
+    expect(summary.totals.nano_cost_output).toBe(15_000_000)
+    expect(summary.byModel[0]?.total_nano_aiu).toBe(15_477_500)
+    expect(summary.byModel[0]?.nano_cost_cache_creation).toBe(20_000)
+
+    const eventsPage = await fetchEventsPage()
+    expect(eventsPage.items[0]?.total_nano_aiu).toBe(15_477_500)
+    expect(eventsPage.items[0]?.nano_cost_cache_creation).toBe(20_000)
+    expect(eventsPage.items[0]?.nano_cost_output).toBe(15_000_000)
   })
 
   test("only falls back to interaction id when no real session id exists", async () => {
@@ -302,8 +380,14 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 36,
+      nano_cost_cache_creation: null,
+      nano_cost_cache_read: null,
+      nano_cost_cache_write: null,
+      nano_cost_input: null,
+      nano_cost_output: null,
       output_tokens: 12,
       request_count: 3,
+      total_nano_aiu: null,
       total_tokens: 145,
     })
     expect(daily.byModel.map((model) => model.model)).toEqual([
@@ -323,8 +407,14 @@ describe("token usage storage", () => {
       cache_creation_input_tokens: 1,
       cache_read_input_tokens: 6,
       input_tokens: 30,
+      nano_cost_cache_creation: null,
+      nano_cost_cache_read: null,
+      nano_cost_cache_write: null,
+      nano_cost_input: null,
+      nano_cost_output: null,
       output_tokens: 8,
       request_count: 2,
+      total_nano_aiu: null,
       total_tokens: 45,
     })
     expect(may12?.byModel.map((model) => model.model)).toEqual([


### PR DESCRIPTION
## Summary
- persist Copilot nano AIU cost totals and per-token-type breakdowns in token usage storage
- plumb copilot_usage through chat completions, responses, and messages routes
- show total/input/output/cache cost fields in the usage UI

## Verification
- bun test tests/token-usage.test.ts
- bun test
- bun run typecheck
- bun run lint:all
- bun run build