### PR TITLE
feat: add Copilot token usage costs

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -283,6 +283,7 @@
           input_tokens: 0,
           output_tokens: 0,
           request_count: 0,
+          total_nano_aiu: null,
           total_tokens: 0,
         };
 
@@ -497,6 +498,12 @@
 
         function formatNumber(value) {
           return Number.isFinite(value) ? Number(value).toLocaleString() : "0";
+        }
+
+        function formatNanoAiuCost(value) {
+          return Number.isFinite(value)
+            ? `$${(Number(value) / 100_000_000_000).toFixed(6)}`
+            : "—";
         }
 
         function formatDateTime(value) {
@@ -1215,6 +1222,9 @@
                   <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
                     model.total_tokens
                   )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNanoAiuCost(
+                    model.total_nano_aiu
+                  )}</td>
                 </tr>
               `;
             })
@@ -1222,7 +1232,7 @@
 
           return `
             <div class="overflow-auto ${state.isTokenUsageLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[760px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[860px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Model</th>
@@ -1231,7 +1241,8 @@
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Tokens</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1290,6 +1301,9 @@
                   <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNumber(
                     event.total_tokens
                   )}</td>
+                  <td class="px-4 py-2 text-right font-semibold" style="color: var(--color-yellow-accent);">${formatNanoAiuCost(
+                    event.total_nano_aiu
+                  )}</td>
                 </tr>
               `;
             })
@@ -1297,7 +1311,7 @@
 
           return `
             <div class="overflow-auto ${state.isEventsLoading ? "opacity-60" : ""}">
-              <table class="w-full min-w-[1180px] text-left text-xs sm:text-sm">
+              <table class="w-full min-w-[1280px] text-left text-xs sm:text-sm">
                 <thead style="background-color: var(--color-bg-light-1); color: var(--color-fg-medium);">
                   <tr>
                     <th class="px-4 py-2 font-semibold">Time</th>
@@ -1310,7 +1324,8 @@
                     <th class="px-4 py-2 text-right font-semibold">Output</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Read</th>
                     <th class="px-4 py-2 text-right font-semibold">Cache Write</th>
-                    <th class="px-4 py-2 text-right font-semibold">Total</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Tokens</th>
+                    <th class="px-4 py-2 text-right font-semibold">Total Cost</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -19,6 +19,8 @@ export {
   getTokenUsageDailySummary,
   getTokenUsageEventsPage,
   getTokenUsageSummary,
+  normalizeOptionalToken,
+  normalizeToken,
 } from "./store"
 
 export type {
@@ -121,6 +123,10 @@ function toPersistedEvent(
       input.fallbackSessionId,
     ),
     source: input.source,
+    total_nano_aiu:
+      input.total_nano_aiu === undefined || input.total_nano_aiu === null ?
+        null
+      : normalizeToken(input.total_nano_aiu),
     total_tokens: resolveTotalTokens(input),
     trace_id: resolveTraceId(input.traceId),
     user_id: resolveUserId(input),

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -25,6 +25,7 @@ export interface UsageTokens {
   cache_read_input_tokens?: number | null
   input_tokens?: number | null
   output_tokens?: number | null
+  total_nano_aiu?: number | null
   total_tokens?: number | null
 }
 
@@ -40,6 +41,7 @@ export interface PersistedTokenUsageEvent {
   provider_name: string | null
   session_id: string
   source: TokenUsageSource
+  total_nano_aiu: number | null
   total_tokens: number
   trace_id: string
   user_id: string
@@ -51,6 +53,7 @@ export interface TokenUsageTotals {
   input_tokens: number
   output_tokens: number
   request_count: number
+  total_nano_aiu: number | null
   total_tokens: number
 }
 
@@ -71,6 +74,7 @@ export interface TokenUsageEventRecord {
   provider_name: string | null
   session_id: string
   source: TokenUsageSource
+  total_nano_aiu: number | null
   total_tokens: number
   trace_id: string
   user_id: string
@@ -167,11 +171,13 @@ function initializeTokenUsageDb(db: SqliteDatabase): void {
       output_tokens INTEGER NOT NULL DEFAULT 0,
       cache_read_input_tokens INTEGER NOT NULL DEFAULT 0,
       cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
-      total_tokens INTEGER NOT NULL DEFAULT 0
+      total_tokens INTEGER NOT NULL DEFAULT 0,
+      total_nano_aiu INTEGER
     )
   `)
   ensureColumn(db, "user_id", "TEXT NOT NULL DEFAULT ''")
   ensureColumn(db, "total_tokens", "INTEGER NOT NULL DEFAULT 0")
+  ensureColumn(db, "total_nano_aiu", "INTEGER")
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_token_usage_events_created_at_ms
     ON token_usage_events(created_at_ms)
@@ -230,6 +236,7 @@ export function hasAnyToken(tokens: UsageTokens): boolean {
     || normalizeToken(tokens.cache_read_input_tokens) > 0
     || normalizeToken(tokens.cache_creation_input_tokens) > 0
     || normalizeToken(tokens.total_tokens) > 0
+    || normalizeToken(tokens.total_nano_aiu) > 0
   )
 }
 
@@ -266,8 +273,9 @@ async function writeTokenUsageEvent(
         output_tokens,
         cache_read_input_tokens,
         cache_creation_input_tokens,
-        total_tokens
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        total_tokens,
+        total_nano_aiu
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
   ).run(
     event.created_at_ms,
@@ -284,6 +292,7 @@ async function writeTokenUsageEvent(
     event.cache_read_input_tokens,
     event.cache_creation_input_tokens,
     event.total_tokens,
+    event.total_nano_aiu,
   )
 }
 
@@ -394,6 +403,7 @@ function createEmptyTotals(): TokenUsageTotals {
     input_tokens: 0,
     output_tokens: 0,
     request_count: 0,
+    total_nano_aiu: null,
     total_tokens: 0,
   }
 }
@@ -404,7 +414,20 @@ function addTotals(target: TokenUsageTotals, next: TokenUsageTotals): void {
   target.input_tokens += next.input_tokens
   target.output_tokens += next.output_tokens
   target.request_count += next.request_count
+  target.total_nano_aiu = addNullableNumbers(
+    target.total_nano_aiu,
+    next.total_nano_aiu,
+  )
   target.total_tokens += next.total_tokens
+}
+
+function addNullableNumbers(
+  current: number | null,
+  next: number | null,
+): number | null {
+  if (current === null) return next
+  if (next === null) return current
+  return current + next
 }
 
 function createEmptySummary(period: TokenUsagePeriod): TokenUsageSummary {
@@ -490,6 +513,14 @@ function numberFromRow(
   return typeof value === "number" && Number.isFinite(value) ? value : 0
 }
 
+function nullableNumberFromRow(
+  row: Record<string, unknown> | undefined,
+  key: string,
+): number | null {
+  const value = row?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
 function totalsFromRow(
   row: Record<string, unknown> | undefined,
 ): TokenUsageTotals {
@@ -502,6 +533,7 @@ function totalsFromRow(
     input_tokens: numberFromRow(row, "input_tokens"),
     output_tokens: numberFromRow(row, "output_tokens"),
     request_count: numberFromRow(row, "request_count"),
+    total_nano_aiu: nullableNumberFromRow(row, "total_nano_aiu"),
     total_tokens: numberFromRow(row, "total_tokens"),
   }
 }
@@ -547,6 +579,7 @@ function usageEventFromRow(
     provider_name: nullableStringFromRow(row, "provider_name"),
     session_id: stringFromRow(row, "session_id"),
     source: stringFromRow(row, "source") as TokenUsageSource,
+    total_nano_aiu: nullableNumberFromRow(row, "total_nano_aiu"),
     total_tokens: numberFromRow(row, "total_tokens"),
     trace_id: stringFromRow(row, "trace_id"),
     user_id: stringFromRow(row, "user_id"),
@@ -566,6 +599,7 @@ function getTotalsRow(
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
       COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+      SUM(total_nano_aiu) AS total_nano_aiu,
       COALESCE(SUM(total_tokens), 0) AS total_tokens
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
@@ -588,6 +622,7 @@ function getModelRows(
       COALESCE(SUM(output_tokens), 0) AS output_tokens,
       COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
       COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+      SUM(total_nano_aiu) AS total_nano_aiu,
       COALESCE(SUM(total_tokens), 0) AS total_tokens
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?
@@ -707,6 +742,7 @@ export async function getTokenUsageEventsPage(input: {
       output_tokens,
       cache_read_input_tokens,
       cache_creation_input_tokens,
+      total_nano_aiu,
       total_tokens
     FROM token_usage_events
     WHERE created_at_ms >= ? AND created_at_ms < ?

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -12,6 +12,7 @@ import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
+  normalizeOptionalToken,
   type UsageTokens,
 } from "~/lib/token-usage"
 import { generateRequestIdFromPayload, getUUID, isNullish } from "~/lib/utils"
@@ -92,7 +93,12 @@ export async function handleCompletion(c: Context) {
 
   if (isNonStreaming(response)) {
     debugJson(logger, "Non-streaming response:", response)
-    recordUsage(normalizeOpenAIUsage(response.usage))
+    recordUsage({
+      ...normalizeOpenAIUsage(response.usage),
+      total_nano_aiu: normalizeOptionalToken(
+        response.copilot_usage?.total_nano_aiu,
+      ),
+    })
     return c.json(response)
   }
 
@@ -103,8 +109,13 @@ export async function handleCompletion(c: Context) {
     for await (const chunk of response) {
       debugJson(logger, "Streaming chunk:", chunk)
       const parsedChunk = parseChatCompletionChunk(chunk)
-      if (parsedChunk?.usage) {
-        usage = normalizeOpenAIUsage(parsedChunk.usage)
+      if (parsedChunk?.usage || parsedChunk?.copilot_usage) {
+        usage = {
+          ...normalizeOpenAIUsage(parsedChunk.usage),
+          total_nano_aiu: normalizeOptionalToken(
+            parsedChunk.copilot_usage?.total_nano_aiu,
+          ),
+        }
       }
       await stream.writeSSE(chunk as SSEMessage)
     }

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -14,6 +14,7 @@ import {
   mergeAnthropicUsage,
   normalizeAnthropicUsage,
   normalizeOpenAIUsage,
+  normalizeOptionalToken,
   normalizeResponsesUsage,
   type TokenUsageEndpoint,
   type UsageTokens,
@@ -135,7 +136,12 @@ export const handleWithChatCompletions = async (
 
   if (isNonStreaming(response)) {
     debugJson(logger, "Non-streaming response from Copilot:", response)
-    recordUsage(normalizeOpenAIUsage(response.usage))
+    recordUsage({
+      ...normalizeOpenAIUsage(response.usage),
+      total_nano_aiu: normalizeOptionalToken(
+        response.copilot_usage?.total_nano_aiu,
+      ),
+    })
     const anthropicResponse = translateToAnthropic(response)
     debugJson(logger, "Translated Anthropic response:", anthropicResponse)
     return c.json(anthropicResponse)
@@ -163,8 +169,13 @@ export const handleWithChatCompletions = async (
       }
 
       const chunk = JSON.parse(rawEvent.data) as ChatCompletionChunk
-      if (chunk.usage) {
-        usage = normalizeOpenAIUsage(chunk.usage)
+      if (chunk.usage || chunk.copilot_usage) {
+        usage = {
+          ...normalizeOpenAIUsage(chunk.usage),
+          total_nano_aiu: normalizeOptionalToken(
+            chunk.copilot_usage?.total_nano_aiu,
+          ),
+        }
       }
       const events = translateChunkToAnthropicEvents(chunk, streamState)
 
@@ -261,7 +272,12 @@ export const handleWithResponsesApi = async (
           || responseEvent.type === "response.failed"
           || responseEvent.type === "response.incomplete"
         ) {
-          usage = normalizeResponsesUsage(responseEvent.response.usage)
+          usage = {
+            ...normalizeResponsesUsage(responseEvent.response.usage),
+            total_nano_aiu: normalizeOptionalToken(
+              responseEvent.response.copilot_usage?.total_nano_aiu,
+            ),
+          }
         }
 
         const events = translateResponsesStreamEvent(responseEvent, streamState)
@@ -307,7 +323,13 @@ export const handleWithResponsesApi = async (
       toolSearchName: resolveBridgeToolSearchName(anthropicPayload.tools),
     },
   )
-  recordUsage(normalizeResponsesUsage((response as ResponsesResult).usage))
+  const responsesResult = response as ResponsesResult
+  recordUsage({
+    ...normalizeResponsesUsage(responsesResult.usage),
+    total_nano_aiu: normalizeOptionalToken(
+      responsesResult.copilot_usage?.total_nano_aiu,
+    ),
+  })
   debugJson(logger, "Translated Anthropic response:", anthropicResponse)
   return c.json(anthropicResponse)
 }

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -14,6 +14,7 @@ import { handleProviderResponsesForProvider } from "~/routes/provider/responses/
 import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
+  normalizeOptionalToken,
   normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
@@ -160,7 +161,12 @@ export const handleResponses = async (c: Context) => {
           || parsedEvent?.type === "response.failed"
           || parsedEvent?.type === "response.incomplete"
         ) {
-          usage = normalizeResponsesUsage(parsedEvent.response.usage)
+          usage = {
+            ...normalizeResponsesUsage(parsedEvent.response.usage),
+            total_nano_aiu: normalizeOptionalToken(
+              parsedEvent.response.copilot_usage?.total_nano_aiu,
+            ),
+          }
         }
 
         const processedData = fixStreamIds(
@@ -184,8 +190,14 @@ export const handleResponses = async (c: Context) => {
     value: response,
     tailLength: 400,
   })
-  recordUsage(normalizeResponsesUsage((response as ResponsesResult).usage))
-  return c.json(response as ResponsesResult)
+  const result = response as ResponsesResult
+  recordUsage({
+    ...normalizeResponsesUsage(result.usage),
+    total_nano_aiu: normalizeOptionalToken(
+      result.copilot_usage?.total_nano_aiu,
+    ),
+  })
+  return c.json(result)
 }
 
 const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -86,6 +86,7 @@ export interface ChatCompletionChunk {
   created: number
   model: string
   choices: Array<Choice>
+  copilot_usage?: CopilotUsage | null
   system_fingerprint?: string
   usage?: {
     prompt_tokens: number
@@ -134,6 +135,7 @@ export interface ChatCompletionResponse {
   created: number
   model: string
   choices: Array<ChoiceNonStreaming>
+  copilot_usage?: CopilotUsage | null
   system_fingerprint?: string
   usage?: {
     prompt_tokens: number
@@ -144,6 +146,10 @@ export interface ChatCompletionResponse {
       cached_tokens?: number
     }
   }
+}
+
+export interface CopilotUsage {
+  total_nano_aiu?: number | null
 }
 
 interface ResponseMessage {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -209,6 +209,7 @@ export interface ResponsesResult {
   output: Array<ResponseOutputItem>
   output_text: string
   status: string
+  copilot_usage?: CopilotUsage | null
   usage?: ResponseUsage | null
   error: ResponseError | null
   incomplete_details: IncompleteDetails | null
@@ -219,6 +220,10 @@ export interface ResponsesResult {
   tool_choice: unknown
   tools: Array<Tool>
   top_p: number | null
+}
+
+export interface CopilotUsage {
+  total_nano_aiu?: number | null
 }
 
 export type Metadata = { [key: string]: string }

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -721,6 +721,9 @@ describe("responses handler token usage", () => {
                 tool_choice: "auto",
                 tools: [],
                 top_p: null,
+                copilot_usage: {
+                  total_nano_aiu: 1234,
+                },
                 usage: {
                   input_tokens: 5,
                   input_tokens_details: {
@@ -769,6 +772,7 @@ describe("responses handler token usage", () => {
         input_tokens: number
         output_tokens: number
         session_id: string
+        total_nano_aiu: number | null
         total_tokens: number
       }>
     }
@@ -783,6 +787,7 @@ describe("responses handler token usage", () => {
     expect(page.items[0]?.cache_read_input_tokens).toBe(1)
     expect(page.items[0]?.input_tokens).toBe(4)
     expect(page.items[0]?.output_tokens).toBe(2)
+    expect(page.items[0]?.total_nano_aiu).toBe(1234)
     expect(page.items[0]?.total_tokens).toBe(7)
   })
 })

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -159,6 +159,7 @@ describe("token usage storage", () => {
       model: "gpt-a",
       output_tokens: 3,
       source: "copilot",
+      total_nano_aiu: 1000,
     })
     recordTokenUsageEvent({
       cache_read_input_tokens: 4,
@@ -167,6 +168,7 @@ describe("token usage storage", () => {
       model: "gpt-b",
       output_tokens: 6,
       source: "copilot",
+      total_nano_aiu: 2500,
     })
 
     const response = await createTokenUsageApp().request(
@@ -181,11 +183,16 @@ describe("token usage storage", () => {
       input_tokens: 30,
       output_tokens: 9,
       request_count: 2,
+      total_nano_aiu: 3500,
       total_tokens: 46,
     })
     expect(summary.totals.total_tokens).toBe(46)
+    expect(summary.totals.total_nano_aiu).toBe(3500)
     expect(summary.byModel).toHaveLength(2)
     expect(summary.byModel.every((row) => row.total_tokens > 0)).toBe(true)
+    expect(summary.byModel.map((row) => row.total_nano_aiu)).toEqual([
+      2500, 1000,
+    ])
   })
 
   test("returns paginated usage events with user id", async () => {
@@ -195,6 +202,7 @@ describe("token usage storage", () => {
       model: "gpt-a",
       output_tokens: 2,
       source: "copilot",
+      total_nano_aiu: 1200,
     })
     recordTokenUsageEvent({
       endpoint: "provider_messages",
@@ -218,6 +226,7 @@ describe("token usage storage", () => {
     expect(page.page_size).toBe(1)
     expect(page.total_pages).toBe(2)
     expect(page.items).toHaveLength(1)
+    expect(page.items[0]?.total_nano_aiu).toBe(null)
     expect(page.items[0]?.user_id).toBe("anthropic")
     expect(page.items[0]?.trace_id).toBe("trace-provider")
     expect(page.items[0]?.session_id).toBe("claude-session")
@@ -269,6 +278,7 @@ describe("token usage storage", () => {
       model: "gpt-a",
       output_tokens: 3,
       source: "copilot",
+      total_nano_aiu: 100,
     })
     recordTokenUsageEvent({
       cache_read_input_tokens: 4,
@@ -277,6 +287,7 @@ describe("token usage storage", () => {
       model: "gpt-b",
       output_tokens: 5,
       source: "copilot",
+      total_nano_aiu: 200,
     })
 
     setSystemTime(localDate(2026, 4, 14, 9))
@@ -286,6 +297,7 @@ describe("token usage storage", () => {
       model: "gpt-a",
       output_tokens: 4,
       source: "copilot",
+      total_nano_aiu: 300,
       total_tokens: 100,
     })
 
@@ -304,6 +316,7 @@ describe("token usage storage", () => {
       input_tokens: 36,
       output_tokens: 12,
       request_count: 3,
+      total_nano_aiu: 600,
       total_tokens: 145,
     })
     expect(daily.byModel.map((model) => model.model)).toEqual([
@@ -311,6 +324,7 @@ describe("token usage storage", () => {
       "gpt-b",
     ])
     expect(daily.byModel[0]?.total_tokens).toBe(116)
+    expect(daily.byModel[0]?.total_nano_aiu).toBe(400)
 
     const firstDay = daily.days[0]
     expect(firstDay?.date).toBe(localDateLabel(localDate(2026, 4, 9)))
@@ -325,6 +339,7 @@ describe("token usage storage", () => {
       input_tokens: 30,
       output_tokens: 8,
       request_count: 2,
+      total_nano_aiu: 300,
       total_tokens: 45,
     })
     expect(may12?.byModel.map((model) => model.model)).toEqual([


### PR DESCRIPTION
Clean redo of #292 based on the latest `dev` branch.

## What this does

Persists Copilot's `total_nano_aiu` cost into the token usage store and adds a single **Total Cost** column to the usage dashboard, placed after the renamed **Total Tokens** column. Column order is otherwise unchanged.

## Changes

- **Store layer**: `total_nano_aiu` nullable column added to the token usage schema. Totals aggregation uses NULL-preserving semantics so events without cost data stay null instead of being coerced to 0.
- **Copilot service types**: `CopilotUsage` interface added to `ChatCompletionChunk`, `ChatCompletionResponse`, and `ResponsesResult` so downstream routes can read `copilot_usage.total_nano_aiu`.
- **Three routes**: `chat/completions`, `responses`, and `messages` all read `copilot_usage.total_nano_aiu` from both streaming and non-streaming responses and persist it via `normalizeOptionalToken` (absent cost → null, not 0).
- **Dashboard**: `Total` column renamed to `Total Tokens`, `Total Cost` column appended after it in both the model breakdown table and the events table. Cost is formatted as $X.XXXXXX (divided by 1e11) with an em dash for null/non-finite values.
- **Tests**: store-layer tests assert nullable cost totals and per-model breakdowns; responses handler test asserts cost extraction from a failed streaming terminal event.

## Verification

- `bun run typecheck` — exit 0
- `bun run lint` — 0 errors
- `bun run build` — exit 0
- `bun test` (full suite) — 331 pass / 0 fail / 918 expect

## Notes

- No per-category cost columns — single `Total Cost` only, per the feedback on #292.
- `cache_creation_input_tokens` token field is preserved for Anthropic compatibility; no `cache_creation` cost concept exists.
- No `nano_cost_*` or `cost_per_batch` fields.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>
