### PR TITLE
fix(messages): don't forward reasoning effort to models that don't support it

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -900,4 +900,19 @@ export const prepareMessagesApiPayload = (
       effort: effort,
     }
   }
+
+  // Drop reasoning effort for models that can't use it. A model that supports
+  // adaptive_thinking accepts an effort (handled in the branch above), so this
+  // only targets non-adaptive_thinking models (e.g. claude-haiku-4.5) that also
+  // declare no supported efforts. For those, an effort arriving on the request
+  // would otherwise be forwarded and rejected with `invalid_reasoning_effort`.
+  if (
+    !selectedModel?.capabilities.supports.adaptive_thinking
+    && payload.output_config?.effort
+  ) {
+    const supported = selectedModel?.capabilities.supports.reasoning_effort
+    if (!supported || supported.length === 0) {
+      delete payload.output_config
+    }
+  }
 }


### PR DESCRIPTION
## Problem

In `prepareMessagesApiPayload` (`src/routes/messages/preprocess.ts`), reasoning effort is only sanitized **inside** the `adaptive_thinking` branch:

```ts
if (selectedModel?.capabilities.supports.adaptive_thinking && !disableThink) {
  ...
  payload.output_config = { effort }
}
```

Models that don't support `adaptive_thinking` (e.g. `claude-haiku-4.5`, whose `capabilities.supports` declares neither `adaptive_thinking` nor `reasoning_effort`) never enter the branch. So an `output_config.effort` that arrives on the incoming request is forwarded upstream unchanged, and rejected:

```
output_config.effort "high" was provided, but model claude-haiku-4.5 does not support reasoning effort
code: invalid_reasoning_effort
```

This breaks any haiku-backed request carrying a reasoning effort, e.g. lightweight tool-less probes from clients that inherit a session-level effort (Claude Code's `WebFetch` is how I hit it).

## Fix

After the thinking setup, drop `output_config` for **non-adaptive_thinking** models that declare no supported efforts:

```ts
if (
  !selectedModel?.capabilities.supports.adaptive_thinking
  && payload.output_config?.effort
) {
  const supported = selectedModel?.capabilities.supports.reasoning_effort
  if (!supported || supported.length === 0) {
    delete payload.output_config
  }
}
```

Gating on `!adaptive_thinking` leaves adaptive models untouched (they accept an effort, set in the branch above), so the existing fixture expecting `{ effort: "xhigh" }` still holds. The in-branch clamp is unchanged.

## Verification

Built the branch, ran it as the proxy against the Copilot upstream:

| request | result |
|---------|--------|
| `claude-haiku-4-5` + `effort: high` | **200** (effort stripped) |
| `claude-sonnet-4-6` + `effort: high` | **200** (effort kept, thinking active) |
| `claude-haiku-4-5`, no effort | **200** |

Unpatched, the first row returns `400 invalid_reasoning_effort`. `tsc --noEmit` and `eslint` both pass.

Ref: #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)