### PR TITLE
feat: translate /chat/completions to Responses API for responses-only models

### DIFF
--- a/src/routes/chat-completions/completions-responses-stream-translation.ts
+++ b/src/routes/chat-completions/completions-responses-stream-translation.ts
@@ -1,0 +1,259 @@
+/**
+ * Translate Responses API streaming events back to Chat Completions
+ * chunked streaming format (SSE with `chat.completion.chunk` objects).
+ *
+ * This is the completions-side counterpart of the Anthropic-to-Responses
+ * stream translator in routes/messages/responses-stream-translation.ts.
+ */
+
+import type {
+  ChatCompletionChunk,
+  CopilotUsage,
+} from "~/services/copilot/create-chat-completions"
+import type {
+  ResponseOutputItem,
+  ResponsesResult,
+  ResponseStreamEvent,
+  ResponseUsage,
+} from "~/services/copilot/create-responses"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CompletionsStreamState {
+  responseId: string
+  createdAt: number
+  model: string
+  started: boolean
+}
+
+interface SSEMessage {
+  data?: string
+  event?: string
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const createCompletionsStreamState = (): CompletionsStreamState => ({
+  responseId: "",
+  createdAt: Math.floor(Date.now() / 1000),
+  model: "",
+  started: false,
+})
+
+/**
+ * Translate a single Responses API stream event into zero or more
+ * Chat Completions chunk SSE messages.
+ */
+export const translateResponsesStreamEventToCompletions = (
+  event: ResponseStreamEvent,
+  state: CompletionsStreamState,
+): Array<SSEMessage> => {
+  const messages: Array<SSEMessage> = []
+
+  // Capture metadata from response envelope events
+  if ("response" in event && event.response) {
+    state.responseId = event.response.id
+    state.createdAt = event.response.created_at
+    state.model = event.response.model
+  }
+
+  switch (event.type) {
+    case "response.output_item.added": {
+      handleOutputItemAdded(event.item, event.output_index, state, messages)
+      break
+    }
+
+    case "response.output_text.delta": {
+      emitRoleChunkIfNeeded(state, messages)
+      messages.push(
+        createChunkMessage(state, {
+          delta: { content: event.delta },
+        }),
+      )
+      break
+    }
+
+    case "response.function_call_arguments.delta": {
+      if (event.output_index === undefined) {
+        break
+      }
+      emitRoleChunkIfNeeded(state, messages)
+      messages.push(
+        createChunkMessage(state, {
+          delta: {
+            tool_calls: [
+              {
+                index: event.output_index,
+                type: "function",
+                function: {
+                  arguments: event.delta ?? "",
+                },
+              },
+            ],
+          },
+        }),
+      )
+      break
+    }
+
+    case "response.completed":
+    case "response.incomplete": {
+      const response = event.response
+      const hasFunctionCalls = response.output.some(
+        (item: ResponseOutputItem) => item.type === "function_call",
+      )
+      messages.push(
+        createChunkMessage(state, {
+          delta: {},
+          finishReason: getFinishReason(response, hasFunctionCalls),
+          usage: translateUsage(response.usage),
+          copilotUsage: event.copilot_usage,
+        }),
+      )
+      messages.push({ data: "[DONE]" })
+      break
+    }
+
+    case "response.failed": {
+      messages.push(
+        createChunkMessage(state, {
+          delta: {},
+          finishReason: "stop",
+        }),
+      )
+      messages.push({ data: "[DONE]" })
+      break
+    }
+
+    // Reasoning, web search, content part events - no completions equivalent,
+    // silently skip them.
+    default: {
+      break
+    }
+  }
+
+  return messages
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const handleOutputItemAdded = (
+  item: ResponseOutputItem,
+  outputIndex: number,
+  state: CompletionsStreamState,
+  messages: Array<SSEMessage>,
+): void => {
+  if (item.type === "message") {
+    emitRoleChunkIfNeeded(state, messages)
+    return
+  }
+
+  if (item.type === "function_call") {
+    const fc = item
+    state.started = true
+    messages.push(
+      createChunkMessage(state, {
+        delta: {
+          role: "assistant",
+          tool_calls: [
+            {
+              index: outputIndex,
+              id: fc.call_id,
+              type: "function",
+              function: {
+                name: fc.name,
+                arguments: "",
+              },
+            },
+          ],
+        },
+      }),
+    )
+  }
+}
+
+const emitRoleChunkIfNeeded = (
+  state: CompletionsStreamState,
+  messages: Array<SSEMessage>,
+): void => {
+  if (state.started) {
+    return
+  }
+  state.started = true
+  messages.push(createChunkMessage(state, { delta: { role: "assistant" } }))
+}
+
+interface CreateChunkOptions {
+  delta: ChatCompletionChunk["choices"][0]["delta"]
+  finishReason?: ChatCompletionChunk["choices"][0]["finish_reason"]
+  usage?: ChatCompletionChunk["usage"]
+  copilotUsage?: CopilotUsage | null
+}
+
+const createChunkMessage = (
+  state: CompletionsStreamState,
+  { delta, finishReason = null, usage, copilotUsage }: CreateChunkOptions,
+): SSEMessage => {
+  const chunk: ChatCompletionChunk = {
+    id: state.responseId,
+    object: "chat.completion.chunk",
+    created: state.createdAt,
+    model: state.model,
+    choices: [
+      {
+        index: 0,
+        delta,
+        finish_reason: finishReason,
+        logprobs: null,
+      },
+    ],
+    ...(usage ? { usage } : {}),
+    ...(copilotUsage ? { copilot_usage: copilotUsage } : {}),
+  }
+
+  return { data: JSON.stringify(chunk) }
+}
+
+// ---------------------------------------------------------------------------
+// Usage and finish reason (shared with non-stream translation)
+// ---------------------------------------------------------------------------
+
+const translateUsage = (
+  usage: ResponseUsage | null | undefined,
+): ChatCompletionChunk["usage"] | undefined => {
+  if (!usage) {
+    return undefined
+  }
+  return {
+    prompt_tokens: usage.input_tokens,
+    completion_tokens: usage.output_tokens ?? 0,
+    total_tokens: usage.total_tokens,
+    ...(usage.input_tokens_details?.cached_tokens !== undefined && {
+      prompt_tokens_details: {
+        cached_tokens: usage.input_tokens_details.cached_tokens,
+      },
+    }),
+  }
+}
+
+const getFinishReason = (
+  response: ResponsesResult,
+  hasFunctionCalls: boolean,
+): "stop" | "length" | "tool_calls" | "content_filter" => {
+  if (hasFunctionCalls) {
+    return "tool_calls"
+  }
+  if (response.incomplete_details?.reason === "max_output_tokens") {
+    return "length"
+  }
+  if (response.incomplete_details?.reason === "content_filter") {
+    return "content_filter"
+  }
+  return "stop"
+}

--- a/src/routes/chat-completions/completions-responses-translation.ts
+++ b/src/routes/chat-completions/completions-responses-translation.ts
@@ -1,0 +1,444 @@
+/**
+ * Translate OpenAI Chat Completions payloads to Responses API payloads
+ * and translate Responses API results back to Chat Completions format.
+ *
+ * This is the completions-side counterpart of the Anthropic-to-Responses
+ * translator in routes/messages/responses-translation.ts.
+ */
+
+import { getReasoningEffortForModel } from "~/lib/config"
+import type {
+  ChatCompletionResponse,
+  ChatCompletionsPayload,
+  ContentPart,
+  Message,
+  Tool,
+} from "~/services/copilot/create-chat-completions"
+import type {
+  FunctionTool,
+  Reasoning,
+  ResponseInputContent,
+  ResponseInputItem,
+  ResponseInputMessage,
+  ResponseFunctionCallOutputItem,
+  ResponseFunctionToolCallItem,
+  ResponseOutputFunctionCall,
+  ResponseOutputMessage,
+  ResponsesPayload,
+  ResponsesResult,
+  ResponseUsage,
+  ToolChoiceFunction,
+  ToolChoiceOptions,
+} from "~/services/copilot/create-responses"
+
+// ---------------------------------------------------------------------------
+// Payload: Completions -> Responses
+// ---------------------------------------------------------------------------
+
+export const translateCompletionsToResponsesPayload = (
+  payload: ChatCompletionsPayload,
+): ResponsesPayload => {
+  const { instructions, input } = translateMessages(payload.messages)
+  const reasoningEffort = resolveReasoningEffort(payload)
+
+  const responsesPayload: ResponsesPayload = {
+    model: payload.model,
+    input,
+    instructions,
+    stream: payload.stream,
+    max_output_tokens: payload.max_completion_tokens ?? payload.max_tokens,
+    // temperature intentionally omitted - reasoning models reject it
+    top_p: payload.top_p,
+    user: payload.user,
+    tools: translateTools(payload.tools),
+    tool_choice: translateToolChoice(payload.tool_choice),
+    parallel_tool_calls: payload.parallel_tool_calls ?? true,
+    reasoning:
+      reasoningEffort ? ({ effort: reasoningEffort } as Reasoning) : undefined,
+    store: false,
+    text: translateResponseFormat(payload.response_format),
+  }
+
+  return responsesPayload
+}
+
+// ---------------------------------------------------------------------------
+// Result: Responses -> Completions
+// ---------------------------------------------------------------------------
+
+export const translateResponsesResultToCompletions = (
+  response: ResponsesResult,
+): ChatCompletionResponse => {
+  const messageItems = response.output.filter(
+    (item): item is ResponseOutputMessage => item.type === "message",
+  )
+  const functionCalls = response.output.filter(
+    (item): item is ResponseOutputFunctionCall => item.type === "function_call",
+  )
+
+  const content = messageItems
+    .flatMap((item) => item.content ?? [])
+    .filter((part) => part.type === "output_text" && "text" in part)
+    .map((part) => (part as { text: string }).text)
+    .join("")
+
+  return {
+    id: response.id,
+    object: "chat.completion",
+    created: response.created_at,
+    model: response.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: content || null,
+          ...(functionCalls.length > 0 && {
+            tool_calls: functionCalls.map((fc) => ({
+              id: fc.call_id,
+              type: "function" as const,
+              function: {
+                name: fc.name,
+                arguments: fc.arguments,
+              },
+            })),
+          }),
+        },
+        logprobs: null,
+        finish_reason: getFinishReason(response, functionCalls.length > 0),
+      },
+    ],
+    usage: translateUsage(response.usage),
+    ...(response.copilot_usage ?
+      { copilot_usage: response.copilot_usage }
+    : {}),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Messages translation
+// ---------------------------------------------------------------------------
+
+const translateMessages = (
+  messages: Array<Message>,
+): { instructions: string | null; input: Array<ResponseInputItem> } => {
+  let instructions: string | null = null
+  const input: Array<ResponseInputItem> = []
+
+  for (const message of messages) {
+    if (message.role === "system" || message.role === "developer") {
+      // Accumulate system/developer messages into instructions
+      const text = extractTextContent(message.content)
+      if (text) {
+        instructions = instructions ? `${instructions}\n\n${text}` : text
+      }
+      continue
+    }
+
+    if (message.role === "tool") {
+      input.push({
+        type: "function_call_output",
+        call_id: message.tool_call_id ?? "",
+        output: stringifyContent(message.content),
+      } satisfies ResponseFunctionCallOutputItem)
+      continue
+    }
+
+    // user or assistant
+    if (hasContent(message.content)) {
+      input.push({
+        role: message.role,
+        content: translateContent(message.content),
+      } satisfies ResponseInputMessage)
+    }
+
+    if (message.role === "assistant" && message.tool_calls) {
+      for (const toolCall of message.tool_calls) {
+        input.push({
+          type: "function_call",
+          call_id: toolCall.id,
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+          status: "completed",
+        } satisfies ResponseFunctionToolCallItem)
+      }
+    }
+  }
+
+  return { instructions, input }
+}
+
+// ---------------------------------------------------------------------------
+// Content helpers
+// ---------------------------------------------------------------------------
+
+const hasContent = (content: Message["content"]): boolean => {
+  if (content === null || content === undefined) {
+    return false
+  }
+  if (typeof content === "string") {
+    return content.length > 0
+  }
+  return content.length > 0
+}
+
+const extractTextContent = (content: Message["content"]): string | null => {
+  if (typeof content === "string") {
+    return content
+  }
+  if (!content || content.length === 0) {
+    return null
+  }
+  const text = content
+    .filter(
+      (part): part is Extract<ContentPart, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n\n")
+  return text || null
+}
+
+const translateContent = (
+  content: Message["content"],
+): ResponseInputMessage["content"] => {
+  if (typeof content === "string") {
+    return content
+  }
+  if (!content || content.length === 0) {
+    return ""
+  }
+  return content.map((part) => translateContentPart(part))
+}
+
+const translateContentPart = (part: ContentPart): ResponseInputContent => {
+  if (part.type === "text") {
+    return { type: "input_text", text: part.text }
+  }
+  if (part.type === "image_url") {
+    return {
+      type: "input_image",
+      image_url: part.image_url.url,
+      detail: part.image_url.detail ?? "auto",
+    }
+  }
+  // file parts - pass through as input_file
+  if (part.type === "file") {
+    return {
+      type: "input_file",
+      file_data: part.file.file_data ?? null,
+      filename: part.file.filename ?? null,
+    }
+  }
+  // Fallback for unknown content types
+  return { type: "input_text", text: "" }
+}
+
+const stringifyContent = (content: Message["content"]): string => {
+  if (typeof content === "string") {
+    return content
+  }
+  if (!content) {
+    return ""
+  }
+  const text = content
+    .filter(
+      (part): part is Extract<ContentPart, { type: "text" }> =>
+        part.type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n\n")
+  return text || JSON.stringify(content)
+}
+
+// ---------------------------------------------------------------------------
+// Tools translation
+// ---------------------------------------------------------------------------
+
+const translateTools = (
+  tools: Array<Tool> | null | undefined,
+): Array<FunctionTool> | undefined => {
+  if (!tools || tools.length === 0) {
+    return undefined
+  }
+  return tools.map((tool) => ({
+    type: "function" as const,
+    name: tool.function.name,
+    description: tool.function.description ?? null,
+    parameters: tool.function.parameters,
+    strict: null,
+  }))
+}
+
+const translateToolChoice = (
+  toolChoice: ChatCompletionsPayload["tool_choice"],
+): ToolChoiceOptions | ToolChoiceFunction | undefined => {
+  if (!toolChoice) {
+    return undefined
+  }
+  if (typeof toolChoice === "string") {
+    return toolChoice
+  }
+  return {
+    type: "function",
+    name: toolChoice.function.name,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// response_format -> text.format
+// ---------------------------------------------------------------------------
+
+interface JsonSchemaResponseFormat {
+  type: "json_schema"
+  json_schema: {
+    name: string
+    schema: Record<string, unknown>
+    strict?: boolean
+  }
+}
+
+interface JsonObjectResponseFormat {
+  type: "json_object"
+}
+
+type ResponseFormat = JsonSchemaResponseFormat | JsonObjectResponseFormat
+
+/**
+ * Recursively inject `additionalProperties: false` into every object-type
+ * node of a JSON Schema. The Responses API requires this at every level
+ * when `strict: true` is set, but callers (e.g. the OpenAI Python SDK)
+ * often omit it.
+ */
+const ensureAdditionalPropertiesFalse = (
+  schema: Record<string, unknown>,
+): Record<string, unknown> => {
+  const clone: Record<string, unknown> = { ...schema }
+
+  if (clone.type === "object") {
+    clone.additionalProperties = false
+
+    if (clone.properties && typeof clone.properties === "object") {
+      const props: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(
+        clone.properties as Record<string, unknown>,
+      )) {
+        props[key] =
+          value && typeof value === "object" && !Array.isArray(value) ?
+            ensureAdditionalPropertiesFalse(value as Record<string, unknown>)
+          : value
+      }
+      clone.properties = props
+    }
+  }
+
+  if (
+    clone.items
+    && typeof clone.items === "object"
+    && !Array.isArray(clone.items)
+  ) {
+    clone.items = ensureAdditionalPropertiesFalse(
+      clone.items as Record<string, unknown>,
+    )
+  }
+
+  return clone
+}
+
+interface TextFormat {
+  format:
+    | { type: "json_object" }
+    | {
+        type: "json_schema"
+        name: string
+        schema: Record<string, unknown>
+        strict?: boolean
+      }
+}
+
+const translateResponseFormat = (
+  responseFormat: ResponseFormat | null | undefined,
+): TextFormat | undefined => {
+  if (!responseFormat) {
+    return undefined
+  }
+
+  if (responseFormat.type === "json_object") {
+    return { format: { type: "json_object" } }
+  }
+
+  if (responseFormat.type === "json_schema") {
+    return {
+      format: {
+        type: "json_schema",
+        name: responseFormat.json_schema.name,
+        schema: ensureAdditionalPropertiesFalse(
+          responseFormat.json_schema.schema,
+        ),
+        strict: responseFormat.json_schema.strict ?? true,
+      },
+    }
+  }
+
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Reasoning effort
+// ---------------------------------------------------------------------------
+
+const resolveReasoningEffort = (
+  payload: ChatCompletionsPayload,
+): Reasoning["effort"] => {
+  // Explicit reasoning_effort from the request takes priority
+  if (payload.reasoning_effort) {
+    const effort = payload.reasoning_effort as Reasoning["effort"]
+    if (effort) {
+      return effort
+    }
+  }
+  // Fall back to per-model config
+  return getReasoningEffortForModel(payload.model)
+}
+
+// ---------------------------------------------------------------------------
+// Usage translation
+// ---------------------------------------------------------------------------
+
+const translateUsage = (
+  usage: ResponseUsage | null | undefined,
+): ChatCompletionResponse["usage"] | undefined => {
+  if (!usage) {
+    return undefined
+  }
+  return {
+    prompt_tokens: usage.input_tokens,
+    completion_tokens: usage.output_tokens ?? 0,
+    total_tokens: usage.total_tokens,
+    ...(usage.input_tokens_details?.cached_tokens !== undefined && {
+      prompt_tokens_details: {
+        cached_tokens: usage.input_tokens_details.cached_tokens,
+      },
+    }),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Finish reason
+// ---------------------------------------------------------------------------
+
+const getFinishReason = (
+  response: ResponsesResult,
+  hasFunctionCalls: boolean,
+): "stop" | "length" | "tool_calls" | "content_filter" => {
+  if (hasFunctionCalls) {
+    return "tool_calls"
+  }
+  if (response.incomplete_details?.reason === "max_output_tokens") {
+    return "length"
+  }
+  if (response.incomplete_details?.reason === "content_filter") {
+    return "content_filter"
+  }
+  return "stop"
+}

--- a/src/routes/chat-completions/completions-responses-translation.ts
+++ b/src/routes/chat-completions/completions-responses-translation.ts
@@ -307,8 +307,15 @@ type ResponseFormat = JsonSchemaResponseFormat | JsonObjectResponseFormat
 /**
  * Recursively inject `additionalProperties: false` into every object-type
  * node of a JSON Schema. The Responses API requires this at every level
- * when `strict: true` is set, but callers (e.g. the OpenAI Python SDK)
- * often omit it.
+ * when `strict: true` is set, but callers (e.g. the OpenAI Python SDK,
+ * Pydantic v2 model_json_schema()) often omit it.
+ *
+ * Handles:
+ * - Direct object nodes (type: "object" with properties)
+ * - Nested properties and array items
+ * - $defs blocks (Pydantic v2 puts all nested models here)
+ * - anyOf/oneOf/allOf variants (Pydantic uses anyOf for Optional fields)
+ * - required array enforcement (strict mode demands all property keys listed)
  */
 const ensureAdditionalPropertiesFalse = (
   schema: Record<string, unknown>,
@@ -319,6 +326,10 @@ const ensureAdditionalPropertiesFalse = (
     clone.additionalProperties = false
 
     if (clone.properties && typeof clone.properties === "object") {
+      const propKeys = Object.keys(clone.properties as Record<string, unknown>)
+      // Strict mode requires every property key in required
+      clone.required = propKeys
+
       const props: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(
         clone.properties as Record<string, unknown>,
@@ -340,6 +351,31 @@ const ensureAdditionalPropertiesFalse = (
     clone.items = ensureAdditionalPropertiesFalse(
       clone.items as Record<string, unknown>,
     )
+  }
+
+  // Recurse into $defs (Pydantic v2 schemas reference nested models via $defs)
+  if (clone.$defs && typeof clone.$defs === "object") {
+    const defs: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(
+      clone.$defs as Record<string, unknown>,
+    )) {
+      defs[key] =
+        value && typeof value === "object" && !Array.isArray(value) ?
+          ensureAdditionalPropertiesFalse(value as Record<string, unknown>)
+        : value
+    }
+    clone.$defs = defs
+  }
+
+  // Recurse into anyOf/oneOf/allOf (Pydantic uses anyOf for Optional/Union fields)
+  for (const keyword of ["anyOf", "oneOf", "allOf"]) {
+    if (Array.isArray(clone[keyword])) {
+      clone[keyword] = (clone[keyword] as unknown[]).map((variant) =>
+        variant && typeof variant === "object" && !Array.isArray(variant) ?
+          ensureAdditionalPropertiesFalse(variant as Record<string, unknown>)
+        : variant,
+      )
+    }
   }
 
   return clone

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -4,13 +4,14 @@ import type { Context } from "hono"
 import { streamSSE, type SSEMessage } from "hono/streaming"
 
 import { resolveMappedModel } from "~/lib/config"
-import { createHandlerLogger, debugJson } from "~/lib/logger"
+import { createHandlerLogger, debugJson, debugLazy } from "~/lib/logger"
 import { parseProviderModelAlias } from "~/lib/provider-model"
 import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
   normalizeOptionalToken,
+  normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
 import { generateRequestIdFromPayload, getUUID, isNullish } from "~/lib/utils"
@@ -21,6 +22,22 @@ import {
   type ChatCompletionResponse,
   type ChatCompletionsPayload,
 } from "~/services/copilot/create-chat-completions"
+import {
+  createResponses,
+  type ResponseStreamEvent,
+} from "~/services/copilot/create-responses"
+import {
+  getResponsesTransportForModel,
+  getResponsesRequestOptions,
+} from "~/routes/responses/utils"
+import {
+  translateCompletionsToResponsesPayload,
+  translateResponsesResultToCompletions,
+} from "./completions-responses-translation"
+import {
+  createCompletionsStreamState,
+  translateResponsesStreamEventToCompletions,
+} from "./completions-responses-stream-translation"
 
 const logger = createHandlerLogger("chat-completions-handler")
 
@@ -66,6 +83,14 @@ export async function handleCompletion(c: Context) {
       payload.max_completion_tokens = payload.max_tokens
     }
     delete payload.max_tokens
+  }
+
+  // Check if this model requires the Responses API (supports /responses but NOT /chat/completions)
+  const responsesTransport = getResponsesTransportForModel(selectedModel)
+  const supportsChatCompletions =
+    selectedModel?.supported_endpoints?.includes("/chat/completions") ?? false
+  if (responsesTransport && !supportsChatCompletions) {
+    return await handleWithResponsesApi(c, payload)
   }
 
   // not support subagent marker for now , set sessionId = getUUID(requestId)
@@ -118,9 +143,122 @@ export async function handleCompletion(c: Context) {
   })
 }
 
+// ---------------------------------------------------------------------------
+// Responses API flow for models that don't support /chat/completions
+// ---------------------------------------------------------------------------
+
+const handleWithResponsesApi = async (
+  c: Context,
+  payload: ChatCompletionsPayload,
+) => {
+  const responsesPayload = translateCompletionsToResponsesPayload(payload)
+
+  const requestId = generateRequestIdFromPayload(payload)
+  logger.debug("Generated request ID (responses flow):", requestId)
+
+  const sessionId = getUUID(requestId)
+  logger.debug("Extracted session ID (responses flow):", sessionId)
+
+  const recordUsage = createCopilotTokenUsageRecorder({
+    endpoint: "responses",
+    fallbackSessionId: sessionId,
+    model: payload.model,
+  })
+
+  debugJson(logger, "Translated Responses payload:", responsesPayload)
+
+  const { vision, initiator } = getResponsesRequestOptions(responsesPayload)
+  const selectedModel = state.models?.data.find(
+    (model) => model.id === payload.model,
+  )
+  const transport = getResponsesTransportForModel(selectedModel) ?? "http"
+
+  const response = await createResponses(responsesPayload, {
+    vision,
+    initiator,
+    requestId,
+    sessionId,
+    transport,
+  })
+
+  // Non-streaming
+  if (!payload.stream && !isAsyncIterable(response)) {
+    const result = response
+    debugJson(logger, "Non-streaming Responses result:", result)
+    const completionResponse = translateResponsesResultToCompletions(result)
+    recordUsage({
+      ...normalizeResponsesUsage(result.usage),
+      total_nano_aiu: normalizeOptionalToken(
+        result.copilot_usage?.total_nano_aiu,
+      ),
+    })
+    debugJson(logger, "Translated Completions response:", completionResponse)
+    return c.json(completionResponse)
+  }
+
+  // Streaming
+  logger.debug("Streaming response from Copilot (Responses API)")
+  return streamSSE(c, async (stream) => {
+    const streamState = createCompletionsStreamState()
+    let usage: UsageTokens = {}
+
+    for await (const chunk of response as AsyncIterable<{
+      data?: string
+      event?: string
+    }>) {
+      const eventName = chunk.event
+      if (eventName === "ping") {
+        continue
+      }
+
+      const data = chunk.data
+      if (!data) {
+        continue
+      }
+
+      debugLazy(logger, () => ["Responses raw stream event:", data])
+
+      const responseEvent = JSON.parse(data) as ResponseStreamEvent
+      if (
+        responseEvent.type === "response.completed"
+        || responseEvent.type === "response.failed"
+        || responseEvent.type === "response.incomplete"
+      ) {
+        usage = {
+          ...normalizeResponsesUsage(responseEvent.response.usage),
+          total_nano_aiu: normalizeOptionalToken(
+            responseEvent.copilot_usage?.total_nano_aiu,
+          ),
+        }
+      }
+
+      const sseMessages = translateResponsesStreamEventToCompletions(
+        responseEvent,
+        streamState,
+      )
+      for (const msg of sseMessages) {
+        if (msg.data) {
+          debugLazy(logger, () => ["Translated Completions chunk:", msg.data])
+          await stream.writeSSE(msg as SSEMessage)
+        }
+      }
+    }
+
+    recordUsage(usage)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 const isNonStreaming = (
   response: Awaited<ReturnType<typeof createChatCompletions>>,
 ): response is ChatCompletionResponse => Object.hasOwn(response, "choices")
+
+const isAsyncIterable = <T>(value: unknown): value is AsyncIterable<T> =>
+  Boolean(value)
+  && typeof (value as AsyncIterable<T>)[Symbol.asyncIterator] === "function"
 
 const parseChatCompletionChunk = (
   chunk: unknown,

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -191,7 +191,17 @@ export interface ChatCompletionsPayload {
   presence_penalty?: number | null
   logit_bias?: Record<string, number> | null
   logprobs?: boolean | null
-  response_format?: { type: "json_object" } | null
+  response_format?:
+    | { type: "json_object" }
+    | {
+        type: "json_schema"
+        json_schema: {
+          name: string
+          schema: Record<string, unknown>
+          strict?: boolean
+        }
+      }
+    | null
   seed?: number | null
   tools?: Array<Tool> | null
   tool_choice?:

--- a/tests/completions-responses-stream-translation.test.ts
+++ b/tests/completions-responses-stream-translation.test.ts
@@ -1,0 +1,589 @@
+import { describe, expect, it } from "bun:test"
+
+import type { ChatCompletionChunk } from "~/services/copilot/create-chat-completions"
+import type {
+  ResponseCompletedEvent,
+  ResponseFailedEvent,
+  ResponseIncompleteEvent,
+  ResponseOutputFunctionCall,
+  ResponseOutputItemAddedEvent,
+  ResponseOutputMessage,
+  ResponsesResult,
+  ResponseStreamEvent,
+  ResponseTextDeltaEvent,
+} from "~/services/copilot/create-responses"
+
+import {
+  createCompletionsStreamState,
+  translateResponsesStreamEventToCompletions,
+} from "~/routes/chat-completions/completions-responses-stream-translation"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const parseChunks = (
+  messages: Array<{ data?: string }>,
+): Array<ChatCompletionChunk> =>
+  messages
+    .filter((m) => m.data && m.data !== "[DONE]")
+    .map((m) => JSON.parse(m.data!) as ChatCompletionChunk)
+
+const isDone = (messages: Array<{ data?: string }>): boolean =>
+  messages.some((m) => m.data === "[DONE]")
+
+const baseResponse = (
+  overrides: Partial<ResponsesResult> = {},
+): ResponsesResult => ({
+  id: "resp-1",
+  object: "response",
+  created_at: 1000,
+  model: "gpt-5.4-mini",
+  output: [],
+  output_text: "",
+  status: "completed",
+  usage: {
+    input_tokens: 10,
+    output_tokens: 20,
+    total_tokens: 30,
+  },
+  error: null,
+  incomplete_details: null,
+  instructions: null,
+  metadata: null,
+  parallel_tool_calls: true,
+  temperature: null,
+  tool_choice: null,
+  tools: [],
+  top_p: null,
+  ...overrides,
+})
+
+// ---------------------------------------------------------------------------
+// Text streaming
+// ---------------------------------------------------------------------------
+
+describe("text delta streaming", () => {
+  it("emits role chunk on first text delta, then content", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs1 = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_text.delta",
+        delta: "Hello",
+        content_index: 0,
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseTextDeltaEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs1)
+    expect(chunks).toHaveLength(2)
+    // First chunk is the role marker
+    expect(chunks[0].choices[0].delta).toEqual({ role: "assistant" })
+    // Second chunk is the actual content
+    expect(chunks[1].choices[0].delta).toEqual({ content: "Hello" })
+  })
+
+  it("skips role chunk on subsequent text deltas", () => {
+    const state = createCompletionsStreamState()
+
+    // First delta - triggers role chunk
+    translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_text.delta",
+        delta: "Hello",
+        content_index: 0,
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseTextDeltaEvent,
+      state,
+    )
+
+    // Second delta - no role chunk
+    const msgs2 = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_text.delta",
+        delta: " world",
+        content_index: 0,
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 2,
+      } as ResponseTextDeltaEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs2)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].delta).toEqual({ content: " world" })
+  })
+
+  it("emits role chunk when message item is added", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        sequence_number: 1,
+        item: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+        } satisfies ResponseOutputMessage,
+      } satisfies ResponseOutputItemAddedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].delta).toEqual({ role: "assistant" })
+    expect(state.started).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Function call streaming
+// ---------------------------------------------------------------------------
+
+describe("function call streaming", () => {
+  it("emits tool_call start when function_call item is added", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        sequence_number: 1,
+        item: {
+          id: "fc-1",
+          type: "function_call",
+          call_id: "call-1",
+          name: "get_weather",
+          arguments: "",
+          status: "in_progress",
+        } satisfies ResponseOutputFunctionCall,
+      } satisfies ResponseOutputItemAddedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].delta.tool_calls).toEqual([
+      {
+        index: 1,
+        id: "call-1",
+        type: "function",
+        function: {
+          name: "get_weather",
+          arguments: "",
+        },
+      },
+    ])
+    expect(state.started).toBe(true)
+  })
+
+  it("streams function call argument deltas", () => {
+    const state = createCompletionsStreamState()
+
+    // Start the function call first
+    translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        sequence_number: 1,
+        item: {
+          id: "fc-1",
+          type: "function_call",
+          call_id: "call-1",
+          name: "get_weather",
+          arguments: "",
+          status: "in_progress",
+        } satisfies ResponseOutputFunctionCall,
+      } satisfies ResponseOutputItemAddedEvent,
+      state,
+    )
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc-1",
+        output_index: 1,
+        sequence_number: 2,
+        delta: '{"location":',
+      },
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].delta.tool_calls).toEqual([
+      {
+        index: 1,
+        type: "function",
+        function: {
+          arguments: '{"location":',
+        },
+      },
+    ])
+  })
+
+  it("skips arguments delta when output_index is undefined", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc-1",
+        output_index: undefined,
+        sequence_number: 2,
+        delta: '{"x":1}',
+      } as unknown as ResponseStreamEvent,
+      state,
+    )
+
+    expect(msgs).toHaveLength(0)
+  })
+
+  it("uses empty string when delta is undefined", () => {
+    const state = createCompletionsStreamState()
+    state.started = true // skip role chunk
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc-1",
+        output_index: 1,
+        sequence_number: 2,
+        delta: undefined,
+      } as unknown as ResponseStreamEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].delta.tool_calls![0].function!.arguments).toBe(
+      "",
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Terminal events
+// ---------------------------------------------------------------------------
+
+describe("terminal events", () => {
+  it("emits finish_reason stop and [DONE] on response.completed", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        response: baseResponse(),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].finish_reason).toBe("stop")
+    expect(isDone(msgs)).toBe(true)
+  })
+
+  it("emits tool_calls finish_reason when function calls present in completed", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        response: baseResponse({
+          output: [
+            {
+              id: "fc-1",
+              type: "function_call",
+              call_id: "call-1",
+              name: "fn",
+              arguments: "{}",
+              status: "completed",
+            } satisfies ResponseOutputFunctionCall,
+          ],
+        }),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].choices[0].finish_reason).toBe("tool_calls")
+  })
+
+  it("emits length finish_reason on response.incomplete with max_output_tokens", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.incomplete",
+        sequence_number: 10,
+        response: baseResponse({
+          incomplete_details: { reason: "max_output_tokens" },
+        }),
+      } satisfies ResponseIncompleteEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].choices[0].finish_reason).toBe("length")
+    expect(isDone(msgs)).toBe(true)
+  })
+
+  it("emits content_filter finish_reason on response.incomplete with content_filter", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.incomplete",
+        sequence_number: 10,
+        response: baseResponse({
+          incomplete_details: { reason: "content_filter" },
+        }),
+      } satisfies ResponseIncompleteEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].choices[0].finish_reason).toBe("content_filter")
+  })
+
+  it("emits stop and [DONE] on response.failed", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.failed",
+        sequence_number: 10,
+        response: baseResponse({
+          status: "failed",
+          error: { code: "server_error", message: "Internal error" },
+        }),
+      } satisfies ResponseFailedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].choices[0].finish_reason).toBe("stop")
+    expect(isDone(msgs)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Usage and copilot_usage on stream
+// ---------------------------------------------------------------------------
+
+describe("usage on stream completion", () => {
+  it("includes translated usage on completed chunk", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        response: baseResponse({
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+            input_tokens_details: { cached_tokens: 80 },
+          },
+        }),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+      prompt_tokens_details: { cached_tokens: 80 },
+    })
+  })
+
+  it("includes copilot_usage on completed chunk when present", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        copilot_usage: { total_nano_aiu: 42 },
+        response: baseResponse(),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].copilot_usage).toEqual({ total_nano_aiu: 42 })
+  })
+
+  it("omits copilot_usage when absent", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        response: baseResponse(),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0]).not.toHaveProperty("copilot_usage")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Metadata capture
+// ---------------------------------------------------------------------------
+
+describe("metadata capture from response envelope", () => {
+  it("captures responseId, model, and createdAt from completed event", () => {
+    const state = createCompletionsStreamState()
+
+    translateResponsesStreamEventToCompletions(
+      {
+        type: "response.completed",
+        sequence_number: 10,
+        response: baseResponse({
+          id: "resp-abc",
+          model: "gpt-5.5",
+          created_at: 9999,
+        }),
+      } satisfies ResponseCompletedEvent,
+      state,
+    )
+
+    expect(state.responseId).toBe("resp-abc")
+    expect(state.model).toBe("gpt-5.5")
+    expect(state.createdAt).toBe(9999)
+  })
+
+  it("uses captured metadata in subsequent chunk ids", () => {
+    const state = createCompletionsStreamState()
+
+    // First event sets metadata
+    translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        sequence_number: 1,
+        item: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          status: "in_progress",
+        } satisfies ResponseOutputMessage,
+      } satisfies ResponseOutputItemAddedEvent,
+      state,
+    )
+
+    // Manually set metadata as if a response.created event came first
+    state.responseId = "resp-xyz"
+    state.model = "gpt-5.4-mini"
+    state.createdAt = 2000
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_text.delta",
+        delta: "hi",
+        content_index: 0,
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 2,
+      } as ResponseTextDeltaEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    expect(chunks[0].id).toBe("resp-xyz")
+    expect(chunks[0].model).toBe("gpt-5.4-mini")
+    expect(chunks[0].created).toBe(2000)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Unknown / unhandled events
+// ---------------------------------------------------------------------------
+
+describe("unhandled events", () => {
+  it("produces no output for unknown event types", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.reasoning_summary_text.delta",
+        delta: "thinking...",
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 1,
+        content_index: 0,
+        summary_index: 0,
+      } as unknown as ResponseStreamEvent,
+      state,
+    )
+
+    expect(msgs).toHaveLength(0)
+  })
+
+  it("produces no output for web search events", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.web_search_call.searching",
+        item_id: "ws-1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseStreamEvent,
+      state,
+    )
+
+    expect(msgs).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Chunk structure
+// ---------------------------------------------------------------------------
+
+describe("chunk structure", () => {
+  it("produces valid chat.completion.chunk objects", () => {
+    const state = createCompletionsStreamState()
+
+    const msgs = translateResponsesStreamEventToCompletions(
+      {
+        type: "response.output_text.delta",
+        delta: "test",
+        content_index: 0,
+        item_id: "item-1",
+        output_index: 0,
+        sequence_number: 1,
+      } as ResponseTextDeltaEvent,
+      state,
+    )
+
+    const chunks = parseChunks(msgs)
+    for (const chunk of chunks) {
+      expect(chunk.object).toBe("chat.completion.chunk")
+      expect(chunk.choices).toHaveLength(1)
+      expect(chunk.choices[0].index).toBe(0)
+      expect(chunk.choices[0].logprobs).toBeNull()
+    }
+  })
+})

--- a/tests/completions-responses-translation.test.ts
+++ b/tests/completions-responses-translation.test.ts
@@ -538,6 +538,274 @@ describe("translateCompletionsToResponsesPayload", () => {
     })
   })
 
+  describe("ensureAdditionalPropertiesFalse — $defs, anyOf, and required", () => {
+    it("patches object schemas inside $defs", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: {
+                $defs: {
+                  Entity: {
+                    type: "object",
+                    properties: {
+                      text: { type: "string" },
+                    },
+                    required: ["text"],
+                  },
+                },
+                type: "object",
+                properties: {
+                  entities: {
+                    type: "array",
+                    items: { $ref: "#/$defs/Entity" },
+                  },
+                },
+                required: ["entities"],
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const defs = text.format.schema.$defs as Record<
+        string,
+        Record<string, unknown>
+      >
+      expect(defs.Entity.additionalProperties).toBe(false)
+      expect(text.format.schema.additionalProperties).toBe(false)
+    })
+
+    it("recurses into anyOf variants", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: {
+                type: "object",
+                properties: {
+                  value: {
+                    anyOf: [
+                      {
+                        type: "object",
+                        properties: { name: { type: "string" } },
+                        required: ["name"],
+                      },
+                      { type: "null" },
+                    ],
+                  },
+                },
+                required: ["value"],
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const valueField = (
+        text.format.schema.properties as Record<string, Record<string, unknown>>
+      ).value
+      const variants = valueField.anyOf as Record<string, unknown>[]
+      const objectVariant = variants.find((v) => v.type === "object")
+      expect(objectVariant!.additionalProperties).toBe(false)
+    })
+
+    it("handles Pydantic v2 style schema with $defs and $ref at root", () => {
+      const pydanticSchema = {
+        $defs: {
+          Entity: {
+            description: "An entity extracted from text.",
+            properties: {
+              text: { type: "string", title: "Text" },
+            },
+            required: ["text"],
+            title: "Entity",
+            type: "object",
+          },
+          Fact: {
+            description: "A single extracted fact.",
+            properties: {
+              what: { type: "string", title: "What" },
+              entities: {
+                anyOf: [
+                  { items: { $ref: "#/$defs/Entity" }, type: "array" },
+                  { type: "null" },
+                ],
+                default: null,
+                title: "Entities",
+              },
+            },
+            required: ["what"],
+            title: "Fact",
+            type: "object",
+          },
+        },
+        properties: {
+          facts: {
+            items: { $ref: "#/$defs/Fact" },
+            title: "Facts",
+            type: "array",
+          },
+        },
+        required: ["facts"],
+        title: "FactExtractionResponse",
+        type: "object",
+      }
+
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: pydanticSchema,
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const schema = text.format.schema
+      const defs = schema.$defs as Record<string, Record<string, unknown>>
+
+      expect(schema.additionalProperties).toBe(false)
+      expect(defs.Entity.additionalProperties).toBe(false)
+      expect(defs.Fact.additionalProperties).toBe(false)
+    })
+
+    it("recurses into oneOf and allOf variants", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: {
+                type: "object",
+                properties: {
+                  a: {
+                    oneOf: [
+                      { type: "object", properties: { x: { type: "string" } } },
+                      { type: "string" },
+                    ],
+                  },
+                  b: {
+                    allOf: [
+                      { type: "object", properties: { y: { type: "number" } } },
+                    ],
+                  },
+                },
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const props = text.format.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >
+      const oneOfVariants = props.a.oneOf as Record<string, unknown>[]
+      const allOfVariants = props.b.allOf as Record<string, unknown>[]
+      expect(oneOfVariants[0].additionalProperties).toBe(false)
+      expect(allOfVariants[0].additionalProperties).toBe(false)
+    })
+
+    it("ensures required includes all property keys for strict mode", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  kind: { type: "string", default: "default" },
+                  score: { type: "number" },
+                },
+                required: ["name"],
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const required = text.format.schema.required as string[]
+      expect(required).toContain("name")
+      expect(required).toContain("kind")
+      expect(required).toContain("score")
+      expect(required).toHaveLength(3)
+    })
+
+    it("fills required in $defs objects with default fields", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              schema: {
+                $defs: {
+                  Fact: {
+                    type: "object",
+                    properties: {
+                      what: { type: "string" },
+                      fact_kind: {
+                        type: "string",
+                        default: "conversation",
+                      },
+                    },
+                    required: ["what"],
+                  },
+                },
+                type: "object",
+                properties: {
+                  facts: {
+                    type: "array",
+                    items: { $ref: "#/$defs/Fact" },
+                  },
+                },
+                required: ["facts"],
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const defs = text.format.schema.$defs as Record<
+        string,
+        Record<string, unknown>
+      >
+      const factRequired = defs.Fact.required as string[]
+      expect(factRequired).toContain("what")
+      expect(factRequired).toContain("fact_kind")
+      expect(factRequired).toHaveLength(2)
+    })
+  })
+
   describe("parallel_tool_calls", () => {
     it("defaults to true when absent", () => {
       const result = translateCompletionsToResponsesPayload(basePayload())

--- a/tests/completions-responses-translation.test.ts
+++ b/tests/completions-responses-translation.test.ts
@@ -1,0 +1,853 @@
+import { describe, expect, it } from "bun:test"
+
+import type {
+  ChatCompletionsPayload,
+  Message,
+  Tool,
+} from "~/services/copilot/create-chat-completions"
+import type {
+  ResponseFunctionCallOutputItem,
+  ResponseFunctionToolCallItem,
+  ResponseInputMessage,
+  ResponseOutputFunctionCall,
+  ResponseOutputMessage,
+  ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+import {
+  translateCompletionsToResponsesPayload,
+  translateResponsesResultToCompletions,
+} from "~/routes/chat-completions/completions-responses-translation"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const basePayload = (
+  overrides: Partial<ChatCompletionsPayload> = {},
+): ChatCompletionsPayload =>
+  ({
+    model: "gpt-5.4-mini",
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  }) as ChatCompletionsPayload
+
+const baseResult = (
+  overrides: Partial<ResponsesResult> = {},
+): ResponsesResult => ({
+  id: "resp-1",
+  object: "response",
+  created_at: 1000,
+  model: "gpt-5.4-mini",
+  output: [],
+  output_text: "",
+  status: "completed",
+  usage: {
+    input_tokens: 10,
+    output_tokens: 20,
+    total_tokens: 30,
+  },
+  error: null,
+  incomplete_details: null,
+  instructions: null,
+  metadata: null,
+  parallel_tool_calls: true,
+  temperature: null,
+  tool_choice: null,
+  tools: [],
+  top_p: null,
+  ...overrides,
+})
+
+const sampleTools: Array<Tool> = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Gets the weather",
+      parameters: {
+        type: "object",
+        properties: { location: { type: "string" } },
+        required: ["location"],
+      },
+    },
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Payload translation: Completions -> Responses
+// ---------------------------------------------------------------------------
+
+describe("translateCompletionsToResponsesPayload", () => {
+  describe("message translation", () => {
+    it("hoists a system message into instructions", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "hi" },
+          ],
+        }),
+      )
+
+      expect(result.instructions).toBe("You are helpful.")
+      const input = result.input as Array<ResponseInputMessage>
+      expect(input).toHaveLength(1)
+      expect(input[0].role).toBe("user")
+    })
+
+    it("concatenates multiple system messages with double newline", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            { role: "system", content: "Rule one." },
+            { role: "developer", content: "Rule two." },
+            { role: "user", content: "hi" },
+          ],
+        }),
+      )
+
+      expect(result.instructions).toBe("Rule one.\n\nRule two.")
+    })
+
+    it("sets instructions to null when no system messages present", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      )
+
+      expect(result.instructions).toBeNull()
+    })
+
+    it("translates user and assistant messages into input", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            { role: "user", content: "question" },
+            { role: "assistant", content: "answer" },
+            { role: "user", content: "follow-up" },
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseInputMessage>
+      expect(input).toHaveLength(3)
+      expect(input[0].role).toBe("user")
+      expect(input[1].role).toBe("assistant")
+      expect(input[2].role).toBe("user")
+    })
+
+    it("translates tool messages into function_call_output", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            {
+              role: "tool",
+              content: "sunny, 22C",
+              tool_call_id: "call-1",
+            } as Message,
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseFunctionCallOutputItem>
+      expect(input).toHaveLength(1)
+      expect(input[0]).toEqual({
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "sunny, 22C",
+      })
+    })
+
+    it("translates assistant tool_calls into function_call items", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "call-1",
+                  type: "function",
+                  function: {
+                    name: "get_weather",
+                    arguments: '{"location":"London"}',
+                  },
+                },
+              ],
+            } as Message,
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseFunctionToolCallItem>
+      const fc = input.find((item) => item.type === "function_call")
+      expect(fc).toBeDefined()
+      expect(fc!.call_id).toBe("call-1")
+      expect(fc!.name).toBe("get_weather")
+      expect(fc!.arguments).toBe('{"location":"London"}')
+      expect(fc!.status).toBe("completed")
+    })
+  })
+
+  describe("content part translation", () => {
+    it("translates text parts to input_text", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "hello world" }],
+            },
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseInputMessage>
+      const content = input[0].content as Array<{ type: string; text: string }>
+      expect(content[0]).toEqual({ type: "input_text", text: "hello world" })
+    })
+
+    it("translates image_url parts to input_image", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: "https://example.com/img.png",
+                    detail: "high",
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseInputMessage>
+      const content = input[0].content as Array<Record<string, unknown>>
+      expect(content[0]).toEqual({
+        type: "input_image",
+        image_url: "https://example.com/img.png",
+        detail: "high",
+      })
+    })
+
+    it("defaults image detail to auto when omitted", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "image_url",
+                  image_url: { url: "https://example.com/img.png" },
+                },
+              ],
+            },
+          ],
+        }),
+      )
+
+      const input = result.input as Array<ResponseInputMessage>
+      const content = input[0].content as Array<Record<string, unknown>>
+      expect(content[0].detail).toBe("auto")
+    })
+
+    it("translates string content directly", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          messages: [{ role: "user", content: "plain string" }],
+        }),
+      )
+
+      const input = result.input as Array<ResponseInputMessage>
+      expect(input[0].content).toBe("plain string")
+    })
+  })
+
+  describe("tools translation", () => {
+    it("translates tools array to function tools", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ tools: sampleTools }),
+      )
+
+      expect(result.tools).toEqual([
+        {
+          type: "function",
+          name: "get_weather",
+          description: "Gets the weather",
+          parameters: {
+            type: "object",
+            properties: { location: { type: "string" } },
+            required: ["location"],
+          },
+          strict: null,
+        },
+      ])
+    })
+
+    it("returns undefined for null tools", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ tools: null }),
+      )
+
+      expect(result.tools).toBeUndefined()
+    })
+
+    it("returns undefined for empty tools array", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ tools: [] }),
+      )
+
+      expect(result.tools).toBeUndefined()
+    })
+  })
+
+  describe("tool_choice translation", () => {
+    it("passes string tool_choice through", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ tool_choice: "auto" }),
+      )
+
+      expect(result.tool_choice).toBe("auto")
+    })
+
+    it("translates object tool_choice to function form", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          tool_choice: {
+            type: "function",
+            function: { name: "get_weather" },
+          },
+        }),
+      )
+
+      expect(result.tool_choice).toEqual({
+        type: "function",
+        name: "get_weather",
+      })
+    })
+
+    it("returns undefined when tool_choice is absent", () => {
+      const result = translateCompletionsToResponsesPayload(basePayload())
+
+      expect(result.tool_choice).toBeUndefined()
+    })
+  })
+
+  describe("response_format translation", () => {
+    it("translates json_object format", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: { type: "json_object" },
+        }),
+      )
+
+      const text = result.text as { format: Record<string, unknown> }
+      expect(text).toEqual({
+        format: { type: "json_object" },
+      })
+    })
+
+    it("translates json_schema format with strict", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "extract",
+              schema: {
+                type: "object",
+                properties: {
+                  facts: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        text: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+
+      const text = result.text as { format: Record<string, unknown> }
+      expect(text.format.type).toBe("json_schema")
+      expect(text.format.name).toBe("extract")
+      expect(text.format.strict).toBe(true)
+    })
+
+    it("defaults strict to true when omitted in json_schema", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "test",
+              schema: { type: "object", properties: {} },
+            },
+          },
+        }),
+      )
+
+      const text = result.text as { format: Record<string, unknown> }
+      expect(text.format.strict).toBe(true)
+    })
+
+    it("returns undefined when response_format is absent", () => {
+      const result = translateCompletionsToResponsesPayload(basePayload())
+
+      expect(result.text).toBeUndefined()
+    })
+  })
+
+  describe("ensureAdditionalPropertiesFalse", () => {
+    it("injects additionalProperties: false into object schemas", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "test",
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      expect(text.format.schema.additionalProperties).toBe(false)
+    })
+
+    it("recursively patches nested object properties", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "test",
+              schema: {
+                type: "object",
+                properties: {
+                  address: {
+                    type: "object",
+                    properties: {
+                      city: { type: "string" },
+                    },
+                  },
+                },
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const address = (
+        text.format.schema.properties as Record<string, Record<string, unknown>>
+      ).address
+      expect(address.additionalProperties).toBe(false)
+    })
+
+    it("patches object items inside arrays", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "test",
+              schema: {
+                type: "object",
+                properties: {
+                  items: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        id: { type: "number" },
+                      },
+                    },
+                  },
+                },
+              },
+              strict: true,
+            },
+          },
+        }),
+      )
+
+      const text = result.text as {
+        format: { schema: Record<string, unknown> }
+      }
+      const items = (
+        text.format.schema.properties as Record<string, Record<string, unknown>>
+      ).items
+      const arrayItems = items.items as Record<string, unknown>
+      expect(arrayItems.additionalProperties).toBe(false)
+    })
+
+    it("does not mutate the original schema", () => {
+      const originalSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      }
+      const frozen = JSON.parse(
+        JSON.stringify(originalSchema),
+      ) as typeof originalSchema
+
+      translateCompletionsToResponsesPayload(
+        basePayload({
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "test",
+              schema: originalSchema,
+              strict: true,
+            },
+          },
+        }),
+      )
+
+      expect(originalSchema).toEqual(frozen)
+    })
+  })
+
+  describe("parallel_tool_calls", () => {
+    it("defaults to true when absent", () => {
+      const result = translateCompletionsToResponsesPayload(basePayload())
+
+      expect(result.parallel_tool_calls).toBe(true)
+    })
+
+    it("preserves explicit false", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ parallel_tool_calls: false }),
+      )
+
+      expect(result.parallel_tool_calls).toBe(false)
+    })
+  })
+
+  describe("reasoning effort", () => {
+    it("uses explicit reasoning_effort from payload", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ reasoning_effort: "medium" }),
+      )
+
+      expect(result.reasoning).toEqual({ effort: "medium" })
+    })
+
+    it("falls back to config when payload has no reasoning_effort", () => {
+      // getReasoningEffortForModel defaults to "high" per config.ts
+      const result = translateCompletionsToResponsesPayload(basePayload())
+
+      expect(result.reasoning).toBeDefined()
+      expect(result.reasoning!.effort).toBeTruthy()
+    })
+  })
+
+  describe("field mapping", () => {
+    it("omits temperature", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ temperature: 0.7 }),
+      )
+
+      expect(result).not.toHaveProperty("temperature")
+    })
+
+    it("maps max_completion_tokens to max_output_tokens", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ max_completion_tokens: 500 }),
+      )
+
+      expect(result.max_output_tokens).toBe(500)
+    })
+
+    it("falls back to max_tokens for max_output_tokens", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ max_tokens: 300 }),
+      )
+
+      expect(result.max_output_tokens).toBe(300)
+    })
+
+    it("sets store to false", () => {
+      const result = translateCompletionsToResponsesPayload(basePayload())
+
+      expect(result.store).toBe(false)
+    })
+
+    it("passes model through", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ model: "gpt-5.5" }),
+      )
+
+      expect(result.model).toBe("gpt-5.5")
+    })
+
+    it("passes stream through", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ stream: true }),
+      )
+
+      expect(result.stream).toBe(true)
+    })
+
+    it("passes user through", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ user: "user-123" }),
+      )
+
+      expect(result.user).toBe("user-123")
+    })
+
+    it("passes top_p through", () => {
+      const result = translateCompletionsToResponsesPayload(
+        basePayload({ top_p: 0.9 }),
+      )
+
+      expect(result.top_p).toBe(0.9)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Result translation: Responses -> Completions
+// ---------------------------------------------------------------------------
+
+describe("translateResponsesResultToCompletions", () => {
+  it("translates a text response", () => {
+    const result = translateResponsesResultToCompletions(
+      baseResult({
+        output: [
+          {
+            id: "msg-1",
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            content: [
+              {
+                type: "output_text",
+                text: "Hello there!",
+                annotations: [],
+              },
+            ],
+          } satisfies ResponseOutputMessage,
+        ],
+      }),
+    )
+
+    expect(result.id).toBe("resp-1")
+    expect(result.object).toBe("chat.completion")
+    expect(result.model).toBe("gpt-5.4-mini")
+    expect(result.choices).toHaveLength(1)
+    expect(result.choices[0].message.role).toBe("assistant")
+    expect(result.choices[0].message.content).toBe("Hello there!")
+    expect(result.choices[0].finish_reason).toBe("stop")
+    expect(result.choices[0].logprobs).toBeNull()
+  })
+
+  it("sets content to null when no text output", () => {
+    const result = translateResponsesResultToCompletions(
+      baseResult({ output: [] }),
+    )
+
+    expect(result.choices[0].message.content).toBeNull()
+  })
+
+  it("translates function calls to tool_calls", () => {
+    const result = translateResponsesResultToCompletions(
+      baseResult({
+        output: [
+          {
+            id: "fc-1",
+            type: "function_call",
+            call_id: "call-1",
+            name: "get_weather",
+            arguments: '{"location":"London"}',
+            status: "completed",
+          } satisfies ResponseOutputFunctionCall,
+        ],
+      }),
+    )
+
+    expect(result.choices[0].message.tool_calls).toEqual([
+      {
+        id: "call-1",
+        type: "function",
+        function: {
+          name: "get_weather",
+          arguments: '{"location":"London"}',
+        },
+      },
+    ])
+    expect(result.choices[0].finish_reason).toBe("tool_calls")
+  })
+
+  it("omits tool_calls when no function calls present", () => {
+    const result = translateResponsesResultToCompletions(
+      baseResult({ output: [] }),
+    )
+
+    expect(result.choices[0].message).not.toHaveProperty("tool_calls")
+  })
+
+  describe("finish_reason", () => {
+    it("returns stop for normal completion", () => {
+      const result = translateResponsesResultToCompletions(baseResult())
+
+      expect(result.choices[0].finish_reason).toBe("stop")
+    })
+
+    it("returns length for max_output_tokens", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          incomplete_details: { reason: "max_output_tokens" },
+        }),
+      )
+
+      expect(result.choices[0].finish_reason).toBe("length")
+    })
+
+    it("returns content_filter for content_filter", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          incomplete_details: { reason: "content_filter" },
+        }),
+      )
+
+      expect(result.choices[0].finish_reason).toBe("content_filter")
+    })
+
+    it("returns tool_calls when function calls present even with incomplete_details", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          output: [
+            {
+              id: "fc-1",
+              type: "function_call",
+              call_id: "call-1",
+              name: "fn",
+              arguments: "{}",
+              status: "completed",
+            } satisfies ResponseOutputFunctionCall,
+          ],
+          incomplete_details: { reason: "max_output_tokens" },
+        }),
+      )
+
+      expect(result.choices[0].finish_reason).toBe("tool_calls")
+    })
+  })
+
+  describe("usage translation", () => {
+    it("translates usage tokens", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+          },
+        }),
+      )
+
+      expect(result.usage).toEqual({
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+      })
+    })
+
+    it("includes cached tokens in prompt_tokens_details", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+            input_tokens_details: { cached_tokens: 80 },
+          },
+        }),
+      )
+
+      expect(result.usage?.prompt_tokens_details).toEqual({
+        cached_tokens: 80,
+      })
+    })
+
+    it("omits prompt_tokens_details when no cached tokens", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+          },
+        }),
+      )
+
+      expect(result.usage).not.toHaveProperty("prompt_tokens_details")
+    })
+
+    it("returns undefined usage when null", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({ usage: null }),
+      )
+
+      expect(result.usage).toBeUndefined()
+    })
+  })
+
+  describe("copilot_usage", () => {
+    it("preserves copilot_usage when present", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({
+          copilot_usage: { total_nano_aiu: 42 },
+        }),
+      )
+
+      expect(result.copilot_usage).toEqual({ total_nano_aiu: 42 })
+    })
+
+    it("omits copilot_usage key when absent", () => {
+      const result = translateResponsesResultToCompletions(baseResult())
+
+      expect(result).not.toHaveProperty("copilot_usage")
+    })
+
+    it("omits copilot_usage key when null", () => {
+      const result = translateResponsesResultToCompletions(
+        baseResult({ copilot_usage: null }),
+      )
+
+      expect(result).not.toHaveProperty("copilot_usage")
+    })
+  })
+})


### PR DESCRIPTION
### Problem

Newer GPT models from GitHub Copilot (`gpt-5.4-mini`, `gpt-5.4`, `gpt-5.5`) only support the Responses API (`/v1/responses`) and reject `/v1/chat/completions` requests with `unsupported_api_for_model`. The proxy already translates incoming Anthropic `/v1/messages` requests to `/v1/responses` (via `routes/messages/responses-translation.ts`), but the `/v1/chat/completions` endpoint passes requests through to Copilot's `/chat/completions` unchanged - so any OpenAI-format client targeting a responses-only model fails.

This means any tool, agent framework, or application that uses the OpenAI SDK (which always calls `/v1/chat/completions`) cannot use responses-only models through the proxy.

Additionally, the `ChatCompletionsPayload` type only defines `response_format` as `{ type: "json_object" }`, missing the `json_schema` variant needed for grammar-enforced structured output.

### Solution

Add a completions-to-responses translation layer that mirrors the existing Anthropic-to-Responses pattern:

**Routing** (`handler.ts`): After model resolution, check `supported_endpoints` from the live model list. If the model supports `/responses` but NOT `/chat/completions`, route to the new `handleWithResponsesApi` flow. Models with both endpoints continue to use the native `/chat/completions` path.

**Payload translation** (`completions-responses-translation.ts`):
- `messages` -> `instructions` (system/developer) + `input` (user/assistant/tool)
- `response_format.json_schema` -> `text.format` with `strict` preserved
- `ensureAdditionalPropertiesFalse` recursively patches all object nodes (required by Responses API in strict mode)
- `tools` / `tool_choice` / `parallel_tool_calls` -> direct mapping
- `reasoning_effort` -> `reasoning.effort` with `modelReasoningEfforts` config fallback
- `temperature` intentionally omitted (reasoning models reject it)
- `copilot_usage` preserved on non-streaming responses

**Stream translation** (`completions-responses-stream-translation.ts`):
- Responses API events -> `chat.completion.chunk` delta format
- Handles `response.completed`, `response.incomplete`, and `response.failed`
- Guards against undefined `output_index` and `delta` in function call argument events
- Emits proper `[DONE]` termination

**Type extension** (`create-chat-completions.ts`):
- `response_format` type expanded to include `json_schema` with `name`, `schema`, and `strict`

### Files changed

| File | Change |
|---|---|
| `src/routes/chat-completions/completions-responses-translation.ts` | **New.** Payload and result translation. |
| `src/routes/chat-completions/completions-responses-stream-translation.ts` | **New.** Stream event translation. |
| `src/routes/chat-completions/handler.ts` | **Modified.** Responses API routing and flow. |
| `src/services/copilot/create-chat-completions.ts` | **Modified.** Extended `response_format` type. |
| `tests/completions-responses-translation.test.ts` | **New.** 51 test cases for payload and result translation. |
| `tests/completions-responses-stream-translation.test.ts` | **New.** 20 test cases for stream event translation. |

### Verification

- `bun run typecheck` passes (zero errors)
- `bun run lint` passes (zero errors)
- `bun test tests/completions-responses-translation.test.ts tests/completions-responses-stream-translation.test.ts` - 71 tests pass
- `bun test` - full suite passes (429 tests)

### Regression risk

Low. The new code path only activates for models whose `supported_endpoints` does NOT include `/chat/completions`. All existing models that support `/chat/completions` continue on the native path with zero changes. If `state.models` has not loaded yet (cold start edge case), `selectedModel` is undefined, `getResponsesTransportForModel` returns null, and the request falls through to the native path - same behavior as before this change.