### PR TITLE
fix: filter unsupported image_gen namespace

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -231,6 +231,7 @@ const removeWebSearchTool = (payload: ResponsesPayload): void => {
 }
 
 const COPILOT_UNSUPPORTED_TOOL_TYPES = new Set(["image_generation"])
+const COPILOT_UNSUPPORTED_TOOL_NAMESPACES = new Set(["image_gen"])
 
 export const removeUnsupportedTools = (payload: ResponsesPayload): void => {
   if (!Array.isArray(payload.tools) || payload.tools.length === 0) return
@@ -238,8 +239,13 @@ export const removeUnsupportedTools = (payload: ResponsesPayload): void => {
   const dropped: Array<string> = []
   payload.tools = payload.tools.filter((t) => {
     const type = t.type as string
-    if (COPILOT_UNSUPPORTED_TOOL_TYPES.has(type)) {
-      dropped.push(type)
+    const name = "name" in t && typeof t.name === "string" ? t.name : undefined
+    const isUnsupportedNamespace =
+      type === "namespace"
+      && name !== undefined
+      && COPILOT_UNSUPPORTED_TOOL_NAMESPACES.has(name)
+    if (COPILOT_UNSUPPORTED_TOOL_TYPES.has(type) || isUnsupportedNamespace) {
+      dropped.push(isUnsupportedNamespace ? `${type}:${name}` : type)
       return false
     }
     return true

--- a/tests/responses-remove-unsupported-tools.test.ts
+++ b/tests/responses-remove-unsupported-tools.test.ts
@@ -20,6 +20,22 @@ describe("removeUnsupportedTools", () => {
     expect((payload.tools as Array<{ type: string }>)[0].type).toBe("function")
   })
 
+  it("removes image_gen namespace tools", () => {
+    const payload = makePayload([
+      {
+        type: "namespace",
+        name: "image_gen",
+        tools: [{ type: "function", name: "imagegen" }],
+      },
+      { type: "function", name: "foo" },
+    ] as ResponsesPayload["tools"])
+
+    removeUnsupportedTools(payload)
+
+    expect(payload.tools).toHaveLength(1)
+    expect((payload.tools as Array<{ name: string }>)[0].name).toBe("foo")
+  })
+
   it("leaves payload unchanged when no unsupported tools present", () => {
     const tools = [
       { type: "function", name: "foo" },


### PR DESCRIPTION
## Summary

- filter the client-defined `image_gen` namespace before forwarding Responses API requests to Copilot
- keep the existing `image_generation` hosted-tool filtering behavior
- add a regression test that preserves unrelated function tools

## Root cause

Codex Desktop can send image generation as a namespace tool:

```json
{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}
```

`removeUnsupportedTools()` only filtered the hosted `image_generation` tool type, so this newer namespace shape reached Copilot and collided with an existing hosted namespace. The upstream then rejected the entire request before inference.

Dropping this namespace matches the existing compatibility behavior for unsupported image generation. Translating it to `image_generation` would not help because Copilot already rejects that hosted tool type.

Fixes #312.

## Validation

- `bun test tests/responses-remove-unsupported-tools.test.ts` — 4 passed
- `bun run typecheck` — passed
- `bun run lint -- src/routes/responses/handler.ts tests/responses-remove-unsupported-tools.test.ts` — passed
- `bun test` — 393 passed; 1 unrelated existing timeout in `auth login validation > rejects an unknown provider name before starting a login flow`
