### PR TITLE
feat(providers): add provider-scoped OpenAI Images proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,11 +541,12 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
 - **auth.adminApiKey:** Single admin key used only for `/admin/*` routes. If missing, the server generates a random key at startup and writes it back to `config.json`. Requests use the same `x-api-key` or `Authorization: Bearer` headers, but regular `auth.apiKeys` never grant access to `/admin/*`.
 - **modelMappings:** Exact `sourceModel -> targetModel` rewrites shared by top-level `POST /v1/messages`, `POST /v1/messages/count_tokens`, `POST /v1/responses`, and `POST /v1/chat/completions` requests. Omit it or leave it as `{}` to disable rewrites. Both the source and target must be non-empty strings. Targets can be regular model IDs or `provider/model` aliases such as `dashscope/qwen3.6-plus`, and the rewrite happens before provider alias parsing. These mappings are not split per interface. The admin endpoints `GET/POST /admin/config/model-mappings` read and update only this field.
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Responses API. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts. For GPT-5.3+ models (e.g. `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`), a built-in commentary prompt is used as fallback when not explicitly configured. The built-in prompts enable phase-aware commentary, which lets the model emit a short user-facing progress update before tools or deeper reasoning.
-- **providers:** Global upstream provider map. Each provider key (for example `dashscope`) becomes a route prefix (`/dashscope/v1/messages`). Supports `type: "anthropic"`, `type: "openai-compatible"`, and `type: "openai-responses"`. Top-level clients can also use `model: "dashscope/model-id"` with `/v1/messages`, `/v1/messages/count_tokens`, `/v1/responses`, and `/v1/chat/completions`; the gateway strips the `dashscope/` prefix before forwarding upstream. `openai-compatible` providers support both chat and Messages flows: `/v1/chat/completions` is proxied to upstream `/v1/chat/completions`, while `/v1/messages` and `/:provider/v1/messages` are translated to upstream chat completions and translated back to Anthropic Messages responses. `GET /v1/models` aggregates enabled provider models with `provider/model-id` IDs; use `GET /dashscope/v1/models` for a single provider's raw model list.
+- **providers:** Global upstream provider map. Each provider key (for example `dashscope`) becomes a route prefix (`/dashscope/v1/messages`). Supports `type: "anthropic"`, `type: "openai-compatible"`, and `type: "openai-responses"`. Top-level clients can also use `model: "dashscope/model-id"` with `/v1/messages`, `/v1/messages/count_tokens`, `/v1/responses`, and `/v1/chat/completions`; the gateway strips the `dashscope/` prefix before forwarding upstream. `openai-compatible` providers support both chat and Messages flows: `/v1/chat/completions` is proxied to upstream `/v1/chat/completions`, while `/v1/messages` and `/:provider/v1/messages` are translated to upstream chat completions and translated back to Anthropic Messages responses. Provider-scoped Images requests can be enabled explicitly with `imageEndpoints`; their bodies are streamed to the native upstream endpoints without Responses API translation. `GET /v1/models` aggregates enabled provider models with `provider/model-id` IDs; use `GET /dashscope/v1/models` for a single provider's raw model list.
   - `enabled` defaults to `true` if omitted.
-  - `baseUrl` should be provider API base URL without the final endpoint. For Anthropic providers, omit `/v1/messages`; for OpenAI-compatible providers, omit `/v1/chat/completions`; for OpenAI Responses providers, omit `/v1/responses`.
+  - `baseUrl` should be provider API base URL without the final endpoint. For Anthropic providers, omit `/v1/messages`; for OpenAI-compatible providers, omit `/v1/chat/completions` and `/v1/images/*`; for OpenAI Responses providers, omit `/v1/responses`.
   - `apiKey` is used as the upstream credential value and is required for regular providers.
   - `authType` (optional): Controls how `apiKey` is sent upstream. Supports `x-api-key` and `authorization` for regular providers. Anthropic providers default to `x-api-key`; OpenAI-compatible and OpenAI Responses providers default to `authorization`. When set to `authorization`, the proxy sends `Authorization: Bearer <apiKey>`. `oauth2` is reserved for the built-in `codex` provider and is written automatically by `auth login --provider codex`.
+  - `imageEndpoints` (optional): Explicit allowlist of native OpenAI Images endpoints exposed for this provider. Supported values are `generations` and `edits`. Omit it or use `[]` to disable Images. This is a provider-level capability and is not inferred from `type` or the configured `models` map.
   - `pricingCurrency` (optional): Provider-level currency used for token cost calculation, for example `USD` or `CNY`. Quick providers default to `CNY` for DashScope and DeepSeek, and `USD` for Codex/OpenRouter. Costs are grouped by currency and are not exchange-rate converted.
   - `models` (optional): Per-model configuration map. Each key is a model ID (matching the model name in requests), and the value is:
     - `temperature` (optional): Default temperature value used when the request does not specify one.
@@ -665,6 +666,8 @@ These endpoints mimic the OpenAI API structure.
 | `POST /v1/chat/completions` | `POST` | Creates a model response for the given chat conversation. Supports `provider/model` aliases for `openai-compatible` providers and can be used without Copilot when the target provider is configured. |
 | `GET /v1/models`            | `GET`  | Lists Copilot models plus enabled provider models using `provider/model-id` IDs. Requests from Codex clients (`User-Agent` beginning with `codex`) are forwarded to the Codex Models upstream. |
 | `POST /v1/embeddings`       | `POST` | Creates an embedding vector representing the input text.         |
+| `POST /:provider/v1/images/generations` | `POST` | When enabled by `imageEndpoints`, streams an OpenAI Images generation request to the provider's native `/v1/images/generations` endpoint and preserves its status and body. |
+| `POST /:provider/v1/images/edits` | `POST` | When enabled by `imageEndpoints`, streams an OpenAI Images edit request to the provider's native `/v1/images/edits` endpoint and preserves its status and body. |
 
 ### Codex Backend Proxy Endpoints
 
@@ -737,6 +740,44 @@ curl http://localhost:4141/v1/chat/completions \
 curl http://localhost:4141/dashscope/v1/messages \
   -H "content-type: application/json" \
   -d '{"model":"qwen3.6-plus","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}'
+```
+
+Enable only the native Images endpoints that the provider implements. The relevant `config.json` fields are:
+
+```json
+{
+  "auth": {
+    "apiKeys": ["local-gateway-key"]
+  },
+  "providers": {
+    "my-provider": {
+      "type": "openai-compatible",
+      "baseUrl": "https://images.example.com",
+      "apiKey": "upstream-provider-key",
+      "imageEndpoints": ["generations", "edits"]
+    }
+  }
+}
+```
+
+Use `["generations"]` for generation only, `["edits"]` for editing only, and omit `imageEndpoints` or use `[]` to disable both. The gateway always forwards to `${baseUrl}/v1/images/<endpoint>`; configure a separate provider when Images uses a different upstream base URL. The built-in `codex` OAuth provider is not supported. `auth.apiKeys` controls client access to the gateway, while the provider's `apiKey` is used only upstream.
+
+OpenAI Images clients should put the provider in the base URL. When `auth.apiKeys` is configured, `OPENAI_API_KEY` must match one of those gateway keys:
+
+```sh
+export OPENAI_BASE_URL="http://localhost:4141/my-provider/v1"
+export OPENAI_API_KEY="your_local_gateway_key"
+
+curl "$OPENAI_BASE_URL/images/generations" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"A red circle on a white background","quality":"low","size":"1024x1024"}'
+
+curl "$OPENAI_BASE_URL/images/edits" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F "model=gpt-image-2" \
+  -F "prompt=Change only the background" \
+  -F "image=@input.png"
 ```
 
 ## Usage Tips

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -547,11 +547,12 @@ Copilot API 现在使用子命令结构，主要命令包括：
 - **auth.adminApiKey：** 仅用于 `/admin/*` 路由的单个 admin key。若未配置，服务会在启动时自动生成一个随机 key，并回写到 `config.json`。它同样使用 `x-api-key` 或 `Authorization: Bearer` 这两种头，但普通 `auth.apiKeys` 不能访问 `/admin/*`。
 - **modelMappings：** 用于顶层 `POST /v1/messages`、`POST /v1/messages/count_tokens`、`POST /v1/responses` 和 `POST /v1/chat/completions` 请求的精确 `sourceModel -> targetModel` 重写映射，这几类接口共用同一份规则。省略该字段或保留为 `{}` 时，不会做模型重写。`source` 和 `target` 都必须是非空字符串。`target` 可以是普通模型 ID，也可以是 `provider/model` 形式的别名，例如 `dashscope/qwen3.6-plus`；重写发生在 provider alias 解析之前。这些映射不再按接口区分。`GET/POST /admin/config/model-mappings` 管理接口读写的也只有这个字段。
 - **extraPrompts：** `model -> prompt` 的映射。把 Anthropic 风格请求翻译为 Responses API 时，会将其附加到第一条 system prompt 后面。你可以借此为不同模型注入护栏或指引。缺失的默认项会自动补齐，但不会覆盖你自定义的 prompt。对于 GPT-5.3+ 模型（如 `gpt-5.3-codex`、`gpt-5.4`、`gpt-5.5`），未显式配置时会自动使用内置的 commentary prompt。内置 prompt 会启用带阶段感知的 commentary，让模型在工具调用或更深层推理前先发出简短的用户可见进度说明。
-- **providers：** 全局上游 provider 映射。每个 provider key（例如 `dashscope`）都会变成一个路由前缀（`/dashscope/v1/messages`）。支持 `type: "anthropic"`、`type: "openai-compatible"` 和 `type: "openai-responses"`。顶层客户端也可以在 `/v1/messages`、`/v1/messages/count_tokens`、`/v1/responses` 和 `/v1/chat/completions` 中使用 `model: "dashscope/model-id"`；AI gateway 会在转发上游前移除 `dashscope/` 前缀。`openai-compatible` provider 同时支持 chat 和 Messages 流程：`/v1/chat/completions` 会直连上游 `/v1/chat/completions`，而 `/v1/messages` 和 `/:provider/v1/messages` 会先翻译为上游 Chat Completions，再把响应翻译回 Anthropic Messages。`GET /v1/models` 会聚合已启用 provider 的模型，并以 `provider/model-id` 形式返回；单个 provider 的原始模型列表仍可使用 `GET /dashscope/v1/models`。
+- **providers：** 全局上游 provider 映射。每个 provider key（例如 `dashscope`）都会变成一个路由前缀（`/dashscope/v1/messages`）。支持 `type: "anthropic"`、`type: "openai-compatible"` 和 `type: "openai-responses"`。顶层客户端也可以在 `/v1/messages`、`/v1/messages/count_tokens`、`/v1/responses` 和 `/v1/chat/completions` 中使用 `model: "dashscope/model-id"`；AI gateway 会在转发上游前移除 `dashscope/` 前缀。`openai-compatible` provider 同时支持 chat 和 Messages 流程：`/v1/chat/completions` 会直连上游 `/v1/chat/completions`，而 `/v1/messages` 和 `/:provider/v1/messages` 会先翻译为上游 Chat Completions，再把响应翻译回 Anthropic Messages。provider-scoped Images 请求可通过 `imageEndpoints` 显式启用，其请求体会以流式方式转发到原生上游端点，不会转换为 Responses API。`GET /v1/models` 会聚合已启用 provider 的模型，并以 `provider/model-id` 形式返回；单个 provider 的原始模型列表仍可使用 `GET /dashscope/v1/models`。
   - `enabled`：可选，若省略则默认为 `true`。
-  - `baseUrl`：provider API 的基础 URL，不要带结尾的 endpoint。Anthropic provider 不要带 `/v1/messages`；OpenAI 兼容 provider 不要带 `/v1/chat/completions`；OpenAI Responses provider 不要带 `/v1/responses`。
+  - `baseUrl`：provider API 的基础 URL，不要带结尾的 endpoint。Anthropic provider 不要带 `/v1/messages`；OpenAI 兼容 provider 不要带 `/v1/chat/completions` 和 `/v1/images/*`；OpenAI Responses provider 不要带 `/v1/responses`。
   - `apiKey`：作为上游凭据值使用；普通 provider 必须配置。
   - `authType`：可选，控制 `apiKey` 如何发送到上游。普通 provider 支持 `x-api-key` 和 `authorization`。Anthropic provider 默认 `x-api-key`；OpenAI 兼容和 OpenAI Responses provider 默认 `authorization`。当设置为 `authorization` 时，代理会发送 `Authorization: Bearer <apiKey>`。`oauth2` 仅保留给内置 `codex` provider，并由 `auth login --provider codex` 自动写入。
+  - `imageEndpoints`：可选，显式声明该 provider 开放的原生 OpenAI Images 端点。仅支持 `generations` 和 `edits`。省略或设为 `[]` 时禁用 Images。它是 provider 级能力，不会根据 `type` 或 `models` 配置自动推断。
   - `pricingCurrency`：可选，provider 维度的 token 费用币种，例如 `USD` 或 `CNY`。快捷 provider 默认 DashScope、DeepSeek 为 `CNY`，Codex/OpenRouter 为 `USD`。费用按币种分别汇总，不做汇率换算。
   - `models`：可选，按模型 ID 配置的映射。每个键为请求中的模型名，值支持：
     - `temperature`：可选，当请求未指定时使用的默认温度。
@@ -671,6 +672,8 @@ curl http://localhost:4141/admin/config/model-mappings \
 | `POST /v1/chat/completions` | `POST` | 为给定聊天对话创建模型响应。支持 `openai-compatible` provider 的 `provider/model` 别名；目标 provider 已配置时可在没有 Copilot 的情况下使用。 |
 | `GET /v1/models` | `GET` | 列出 Copilot 模型以及已启用 provider 的 `provider/model-id` 模型。来自 Codex 客户端（`User-Agent` 以 `codex` 开头）的请求会转发到 Codex Models 上游。 |
 | `POST /v1/embeddings` | `POST` | 创建表示输入文本的向量嵌入。 |
+| `POST /:provider/v1/images/generations` | `POST` | 当 `imageEndpoints` 启用该能力时，将 OpenAI Images 生成请求流式转发到 provider 原生 `/v1/images/generations` 端点，并保留上游状态码和响应体。 |
+| `POST /:provider/v1/images/edits` | `POST` | 当 `imageEndpoints` 启用该能力时，将 OpenAI Images 编辑请求流式转发到 provider 原生 `/v1/images/edits` 端点，并保留上游状态码和响应体。 |
 
 ### Codex 后端代理端点
 
@@ -743,6 +746,44 @@ curl http://localhost:4141/v1/chat/completions \
 curl http://localhost:4141/dashscope/v1/messages \
   -H "content-type: application/json" \
   -d '{"model":"qwen3.6-plus","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}'
+```
+
+只启用该 provider 实际实现的原生 Images 端点。`config.json` 中相关配置如下：
+
+```json
+{
+  "auth": {
+    "apiKeys": ["local-gateway-key"]
+  },
+  "providers": {
+    "my-provider": {
+      "type": "openai-compatible",
+      "baseUrl": "https://images.example.com",
+      "apiKey": "upstream-provider-key",
+      "imageEndpoints": ["generations", "edits"]
+    }
+  }
+}
+```
+
+仅生成使用 `["generations"]`，仅编辑使用 `["edits"]`；省略 `imageEndpoints` 或设为 `[]` 时两个端点均禁用。网关固定转发到 `${baseUrl}/v1/images/<endpoint>`；如果 Images 使用不同的上游 base URL，应单独配置一个 provider。内置 `codex` OAuth provider 不支持 Images。`auth.apiKeys` 用于客户端访问本地网关，而 provider 的 `apiKey` 只用于访问上游。
+
+OpenAI Images 客户端应把 provider 放入 base URL。当配置了 `auth.apiKeys` 时，`OPENAI_API_KEY` 必须匹配其中一个网关 key：
+
+```sh
+export OPENAI_BASE_URL="http://localhost:4141/my-provider/v1"
+export OPENAI_API_KEY="your_local_gateway_key"
+
+curl "$OPENAI_BASE_URL/images/generations" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-2","prompt":"A red circle on a white background","quality":"low","size":"1024x1024"}'
+
+curl "$OPENAI_BASE_URL/images/edits" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F "model=gpt-image-2" \
+  -F "prompt=Change only the background" \
+  -F "image=@input.png"
 ```
 
 ## 使用建议

--- a/desktop/electron/provider-auth.ts
+++ b/desktop/electron/provider-auth.ts
@@ -123,6 +123,9 @@ function buildProviderConfig(
     ...(options.authType ? { authType: options.authType } : {}),
     pricingCurrency:
       options.pricingCurrency ?? existingProviderConfig.pricingCurrency,
+    ...(existingProviderConfig.imageEndpoints ?
+      { imageEndpoints: existingProviderConfig.imageEndpoints }
+    : {}),
     ...(existingProviderConfig.models ?
       { models: existingProviderConfig.models }
     : {}),

--- a/desktop/tests/desktop-provider-auth.test.ts
+++ b/desktop/tests/desktop-provider-auth.test.ts
@@ -61,6 +61,7 @@ describe('desktop provider auth', () => {
       {
         getEnabledProviders: () => ['custom_deepseek'],
         getRawProviderConfig: () => ({
+          imageEndpoints: ['generations', 'edits'],
           models: {
             'deepseek-v4-pro': {
               temperature: 0.2,
@@ -86,6 +87,7 @@ describe('desktop provider auth', () => {
       apiKey: 'custom-key',
       baseUrl: 'https://custom.example/api',
       enabled: true,
+      imageEndpoints: ['generations', 'edits'],
       models: {
         'deepseek-v4-pro': {
           temperature: 0.2,

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -383,6 +383,9 @@ function buildCustomProviderConfig(
     ...(options.authType ? { authType: options.authType } : {}),
     pricingCurrency:
       options.pricingCurrency ?? existingProviderConfig.pricingCurrency,
+    ...(existingProviderConfig.imageEndpoints ?
+      { imageEndpoints: existingProviderConfig.imageEndpoints }
+    : {}),
     ...(existingProviderConfig.models ?
       { models: existingProviderConfig.models }
     : {}),

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,6 +64,12 @@ export interface TokenUsagePricingConfig extends TokenUsagePricingTier {
 }
 
 export type ProviderAuthType = "authorization" | "oauth2" | "x-api-key"
+export const SUPPORTED_PROVIDER_IMAGE_ENDPOINTS = [
+  "generations",
+  "edits",
+] as const
+export type ProviderImageEndpoint =
+  (typeof SUPPORTED_PROVIDER_IMAGE_ENDPOINTS)[number]
 export const SUPPORTED_PROVIDER_TYPES = [
   "anthropic",
   "openai-compatible",
@@ -78,6 +84,7 @@ export interface ProviderConfig {
   baseUrl?: string
   apiKey?: string
   authType?: ProviderAuthType
+  imageEndpoints?: Array<ProviderImageEndpoint>
   pricingCurrency?: string
   models?: Record<string, ModelConfig>
 }
@@ -88,6 +95,7 @@ export interface ResolvedProviderConfig {
   baseUrl: string
   apiKey: string
   authType: ProviderAuthType
+  imageEndpoints?: Array<ProviderImageEndpoint>
   pricingCurrency?: string
   models?: Record<string, ModelConfig>
 }
@@ -557,6 +565,39 @@ export function isSupportedProviderType(value: string): value is ProviderType {
   return SUPPORTED_PROVIDER_TYPES.includes(value as ProviderType)
 }
 
+function normalizeProviderImageEndpoints(
+  providerName: string,
+  value: unknown,
+): Array<ProviderImageEndpoint> {
+  if (value === undefined) {
+    return []
+  }
+
+  if (!Array.isArray(value)) {
+    consola.warn(
+      `Provider ${providerName} has invalid imageEndpoints; expected an array containing 'generations' and/or 'edits'`,
+    )
+    return []
+  }
+
+  const validEndpoints = value.filter(
+    (endpoint): endpoint is ProviderImageEndpoint =>
+      typeof endpoint === "string"
+      && SUPPORTED_PROVIDER_IMAGE_ENDPOINTS.includes(
+        endpoint as ProviderImageEndpoint,
+      ),
+  )
+  const normalizedEndpoints = [...new Set(validEndpoints)]
+
+  if (normalizedEndpoints.length !== value.length) {
+    consola.warn(
+      `Provider ${providerName} has invalid or duplicate imageEndpoints entries; only 'generations' and 'edits' are supported`,
+    )
+  }
+
+  return normalizedEndpoints
+}
+
 function getDefaultProviderAuthType(
   providerType: ProviderType,
 ): ProviderAuthType {
@@ -701,6 +742,10 @@ export function getProviderConfig(name: string): ResolvedProviderConfig | null {
     baseUrl,
     apiKey,
     authType,
+    imageEndpoints: normalizeProviderImageEndpoints(
+      providerName,
+      provider.imageEndpoints,
+    ),
     pricingCurrency: normalizePricingCurrency(provider.pricingCurrency),
     models: provider.models,
   }

--- a/src/routes/provider/images/route.ts
+++ b/src/routes/provider/images/route.ts
@@ -1,0 +1,99 @@
+import type { Context } from "hono"
+import type { ProviderImageEndpoint } from "~/lib/config"
+
+import { Hono } from "hono"
+
+import { createHandlerLogger } from "~/lib/logger"
+import { resolveProviderConfig } from "~/lib/provider-resolver"
+import {
+  createProviderProxyResponse,
+  forwardProviderImageRequest,
+} from "~/services/providers/provider-proxy"
+
+const logger = createHandlerLogger("provider-images-handler")
+
+export const providerImageRoutes = new Hono()
+
+providerImageRoutes.post("/generations", async (c) => {
+  return await handleProviderImageRequest(c, "generations")
+})
+
+providerImageRoutes.post("/edits", async (c) => {
+  return await handleProviderImageRequest(c, "edits")
+})
+
+const handleProviderImageRequest = async (
+  c: Context,
+  endpoint: ProviderImageEndpoint,
+): Promise<Response> => {
+  const provider = c.req.param("provider") ?? ""
+  if (provider === "codex") {
+    return createUnsupportedProviderResponse(c, provider, endpoint)
+  }
+
+  try {
+    const providerConfig = await resolveProviderConfig(provider)
+    if (!providerConfig) {
+      return c.json(
+        {
+          error: {
+            message: `Provider '${provider}' not found or disabled`,
+            type: "invalid_request_error",
+          },
+        },
+        404,
+      )
+    }
+
+    if (providerConfig.authType === "oauth2") {
+      return createUnsupportedProviderResponse(c, provider, endpoint)
+    }
+
+    if (!providerConfig.imageEndpoints?.includes(endpoint)) {
+      return createUnsupportedProviderResponse(c, provider, endpoint)
+    }
+
+    const upstreamResponse = await forwardProviderImageRequest(
+      providerConfig,
+      endpoint,
+      c.req.raw,
+    )
+
+    logger.debug("provider.images.response", {
+      endpoint,
+      provider,
+      statusCode: upstreamResponse.status,
+    })
+    return createProviderProxyResponse(upstreamResponse)
+  } catch (error) {
+    logger.error("provider.images.error", {
+      endpoint,
+      errorType: error instanceof Error ? error.name : "unknown",
+      provider,
+    })
+    return c.json(
+      {
+        error: {
+          message: "Failed to reach the image provider",
+          type: "api_error",
+        },
+      },
+      502,
+    )
+  }
+}
+
+const createUnsupportedProviderResponse = (
+  c: Context,
+  provider: string,
+  endpoint: ProviderImageEndpoint,
+): Response =>
+  c.json(
+    {
+      error: {
+        message: `Provider '${provider}' does not enable /v1/images/${endpoint}`,
+        type: "invalid_request_error",
+      },
+    },
+    400,
+  )

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { configRoutes } from "./routes/admin/config/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
 import { messageRoutes } from "./routes/messages/route"
 import { modelRoutes } from "./routes/models/route"
+import { providerImageRoutes } from "./routes/provider/images/route"
 import { providerMessageRoutes } from "./routes/provider/messages/route"
 import { providerModelRoutes } from "./routes/provider/models/route"
 import { responsesRoutes } from "./routes/responses/route"
@@ -70,6 +71,7 @@ server.route("/v1/responses", responsesRoutes)
 // Anthropic compatible endpoints
 server.route("/v1/messages", messageRoutes)
 
-// Provider scoped Anthropic-compatible endpoints
+// Provider-scoped endpoints
 server.route("/:provider/v1/messages", providerMessageRoutes)
 server.route("/:provider/v1/models", providerModelRoutes)
+server.route("/:provider/v1/images", providerImageRoutes)

--- a/src/services/providers/provider-proxy.ts
+++ b/src/services/providers/provider-proxy.ts
@@ -1,5 +1,8 @@
 import consola from "consola"
-import type { ResolvedProviderConfig } from "~/lib/config"
+import type {
+  ProviderImageEndpoint,
+  ResolvedProviderConfig,
+} from "~/lib/config"
 import type { AnthropicMessagesPayload } from "~/routes/messages/anthropic-types"
 import type { ChatCompletionsPayload } from "~/services/copilot/create-chat-completions"
 import type { ResponsesPayload } from "~/services/copilot/create-responses"
@@ -24,9 +27,19 @@ const STRIPPED_RESPONSE_HEADERS = [
   "upgrade",
 ] as const
 
+interface ProviderUpstreamHeaderOptions {
+  contentEncoding?: string
+  contentType?: string
+}
+
+type StreamingRequestInit = RequestInit & {
+  duplex?: "half"
+}
+
 export function buildProviderUpstreamHeaders(
   providerConfig: ResolvedProviderConfig,
   requestHeaders: Headers,
+  options: ProviderUpstreamHeaderOptions = {},
 ): Record<string, string> {
   const authHeaders: Record<string, string> = {}
   if (providerConfig.authType === "x-api-key") {
@@ -36,7 +49,10 @@ export function buildProviderUpstreamHeaders(
   }
 
   const headers: Record<string, string> = {
-    "content-type": "application/json",
+    "content-type": options.contentType ?? "application/json",
+    ...(options.contentEncoding ?
+      { "content-encoding": options.contentEncoding }
+    : {}),
     accept: "application/json",
     ...authHeaders,
   }
@@ -126,4 +142,30 @@ export async function forwardProviderModels(
     method: "GET",
     headers: buildProviderUpstreamHeaders(providerConfig, requestHeaders),
   })
+}
+
+export async function forwardProviderImageRequest(
+  providerConfig: ResolvedProviderConfig,
+  endpoint: ProviderImageEndpoint,
+  request: Request,
+): Promise<Response> {
+  const body = request.body
+  const requestInit: StreamingRequestInit = {
+    method: "POST",
+    headers: buildProviderUpstreamHeaders(providerConfig, request.headers, {
+      contentEncoding: request.headers.get("content-encoding") ?? undefined,
+      contentType: request.headers.get("content-type") ?? "application/json",
+    }),
+    body,
+    signal: request.signal,
+  }
+
+  if (body) {
+    requestInit.duplex = "half"
+  }
+
+  return await fetch(
+    `${providerConfig.baseUrl}/v1/images/${endpoint}`,
+    requestInit,
+  )
 }

--- a/tests/auth-login.test.ts
+++ b/tests/auth-login.test.ts
@@ -12,6 +12,7 @@ interface ConfigFileShape {
       authType?: string
       baseUrl?: string
       enabled?: boolean
+      imageEndpoints?: Array<string>
       models?: Record<string, unknown>
       pricingCurrency?: string
       type?: string
@@ -392,6 +393,7 @@ describe("auth login validation", () => {
           apiKey: "old-key",
           baseUrl: "https://old.example",
           enabled: true,
+          imageEndpoints: ["generations", "edits"],
           models: {
             "qwen-plus": {
               temperature: 0.2,
@@ -420,6 +422,7 @@ describe("auth login validation", () => {
       apiKey: "new-key",
       baseUrl: "https://dashscope.aliyuncs.com/compatible-mode",
       enabled: true,
+      imageEndpoints: ["generations", "edits"],
       models: {
         "qwen-plus": {
           temperature: 0.2,

--- a/tests/builtin-provider-config.test.ts
+++ b/tests/builtin-provider-config.test.ts
@@ -21,6 +21,7 @@ interface ConfigFileShape {
       baseUrl?: string
       apiKey?: string
       authType?: string
+      imageEndpoints?: unknown
     }
   >
 }
@@ -137,6 +138,47 @@ describe("builtin provider config", () => {
     )
 
     expect(readConfigFile(configPath).providers).toEqual({})
+  })
+
+  test("normalizes provider image endpoint capabilities", () => {
+    const tempDir = createTempConfigDir()
+    writeConfigFile(tempDir, {
+      providers: {
+        invalid: {
+          apiKey: "provider-key",
+          baseUrl: "https://invalid.example",
+          imageEndpoints: "generations",
+          type: "openai-compatible",
+        },
+        missing: {
+          apiKey: "provider-key",
+          baseUrl: "https://missing.example",
+          type: "openai-compatible",
+        },
+        valid: {
+          apiKey: "provider-key",
+          baseUrl: "https://valid.example",
+          imageEndpoints: [
+            "generations",
+            "unsupported",
+            "edits",
+            "generations",
+          ],
+          type: "openai-compatible",
+        },
+      },
+    })
+
+    const output = runScript(
+      tempDir,
+      'const { getProviderConfig } = await import("./src/lib/config"); console.log(JSON.stringify({ invalid: getProviderConfig("invalid")?.imageEndpoints, missing: getProviderConfig("missing")?.imageEndpoints, valid: getProviderConfig("valid")?.imageEndpoints }));',
+    )
+
+    expect(JSON.parse(output)).toEqual({
+      invalid: [],
+      missing: [],
+      valid: ["generations", "edits"],
+    })
   })
 
   test("isGpt56OrAbove detects gpt-5.6 and above models", () => {

--- a/tests/provider-images.test.ts
+++ b/tests/provider-images.test.ts
@@ -1,0 +1,557 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import { cors } from "hono/cors"
+import { brotliCompressSync, gzipSync } from "node:zlib"
+
+import type { ResolvedProviderConfig } from "../src/lib/config"
+import { zstdDecompressionMiddleware } from "../src/lib/zstd-request"
+
+const actualConfigModule = await import("../src/lib/config")
+
+let providerConfig: ResolvedProviderConfig | null = null
+let localApiKeys: Array<string> = []
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getConfig: () => ({ auth: { apiKeys: localApiKeys } }),
+  getProviderConfig: () => providerConfig,
+}))
+
+const { createAuthMiddleware } = await import("../src/lib/request-auth")
+const { providerImageRoutes } = await import(
+  "../src/routes/provider/images/route"
+)
+
+const originalFetch = globalThis.fetch
+
+type StreamingRequestInit = RequestInit & {
+  duplex?: "half"
+}
+
+let upstreamResponse: Response
+let upstreamError: Error | null = null
+let capturedUrl = ""
+let capturedHeaders = new Headers()
+let capturedBody = new Uint8Array()
+let capturedDuplex: StreamingRequestInit["duplex"]
+
+const fetchMock = mock(
+  async (
+    url: string | URL | Request,
+    init?: StreamingRequestInit,
+  ): Promise<Response> => {
+    capturedUrl =
+      typeof url === "string" ? url
+      : url instanceof URL ? url.toString()
+      : url.url
+    capturedHeaders = new Headers(init?.headers)
+    capturedDuplex = init?.duplex
+    capturedBody =
+      init?.body ?
+        new Uint8Array(await new Response(init.body).arrayBuffer())
+      : new Uint8Array()
+    if (upstreamError) {
+      throw upstreamError
+    }
+    return upstreamResponse.clone() as unknown as Response
+  },
+)
+
+const createApp = () => {
+  const app = new Hono()
+  app.use(cors())
+  app.use(
+    "*",
+    createAuthMiddleware({
+      allowUnauthenticatedPaths: [],
+    }),
+  )
+  app.use(zstdDecompressionMiddleware)
+  app.route("/:provider/v1/images", providerImageRoutes)
+  return app
+}
+
+const createProviderConfig = (
+  overrides: Partial<ResolvedProviderConfig> = {},
+): ResolvedProviderConfig => ({
+  apiKey: "provider-key",
+  authType: "authorization",
+  baseUrl: "https://images.example/openai",
+  imageEndpoints: ["generations", "edits"],
+  name: "images",
+  type: "openai-compatible",
+  ...overrides,
+})
+
+beforeEach(() => {
+  providerConfig = createProviderConfig()
+  localApiKeys = ["local-client-key"]
+  upstreamError = null
+  upstreamResponse = Response.json(
+    {
+      created: 0,
+      data: [{ b64_json: "encoded-image" }],
+    },
+    {
+      headers: {
+        "x-request-id": "upstream-request-id",
+      },
+    },
+  )
+  capturedUrl = ""
+  capturedHeaders = new Headers()
+  capturedBody = new Uint8Array()
+  capturedDuplex = undefined
+  fetchMock.mockClear()
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
+    fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
+  providerConfig = null
+  localApiKeys = []
+})
+
+describe("provider Images API", () => {
+  test("forwards image generation JSON with provider auth", async () => {
+    const payload = {
+      model: "gpt-image-2",
+      prompt: "A red circle on white",
+      quality: "low",
+      size: "1024x1024",
+    }
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: JSON.stringify(payload),
+        headers: {
+          accept: "application/json",
+          authorization: "Bearer local-client-key",
+          cookie: "session=do-not-forward",
+          "content-type": "application/json",
+          "user-agent": "image-client/test",
+          "x-api-key": "local-client-key",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      created: 0,
+      data: [{ b64_json: "encoded-image" }],
+    })
+    expect(response.headers.get("x-request-id")).toBe("upstream-request-id")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(capturedUrl).toBe(
+      "https://images.example/openai/v1/images/generations",
+    )
+    expect(capturedHeaders.get("authorization")).toBe("Bearer provider-key")
+    expect(capturedHeaders.get("x-api-key")).toBeNull()
+    expect(capturedHeaders.get("cookie")).toBeNull()
+    expect(capturedHeaders.get("content-type")).toBe("application/json")
+    expect(capturedHeaders.get("accept")).toBe("application/json")
+    expect(capturedHeaders.get("user-agent")).toBe("image-client/test")
+    expect(capturedDuplex).toBe("half")
+    expect(JSON.parse(new TextDecoder().decode(capturedBody))).toEqual(payload)
+  })
+
+  test("streams multipart image edits without changing fields or files", async () => {
+    const firstImage = new Uint8Array([137, 80, 78, 71, 1])
+    const secondImage = new Uint8Array([137, 80, 78, 71, 2])
+    const maskImage = new Uint8Array([137, 80, 78, 71, 3])
+    const formData = new FormData()
+    formData.append("model", "gpt-image-2")
+    formData.append("prompt", "Change only the background")
+    formData.append(
+      "image",
+      new File([firstImage], "first.png", { type: "image/png" }),
+    )
+    formData.append(
+      "image",
+      new File([secondImage], "second.png", { type: "image/png" }),
+    )
+    formData.append(
+      "mask",
+      new File([maskImage], "mask.png", { type: "image/png" }),
+    )
+
+    const request = new Request("http://localhost/images/v1/images/edits", {
+      body: formData,
+      headers: {
+        authorization: "Bearer local-client-key",
+      },
+      method: "POST",
+    })
+    const inboundContentType = request.headers.get("content-type")
+
+    const response = await createApp().request(request)
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(capturedUrl).toBe("https://images.example/openai/v1/images/edits")
+    expect(capturedHeaders.get("authorization")).toBe("Bearer provider-key")
+    expect(capturedHeaders.get("content-type")).toBe(inboundContentType)
+    expect(capturedHeaders.get("content-type")).toContain(
+      "multipart/form-data; boundary=",
+    )
+    expect(capturedDuplex).toBe("half")
+
+    const forwardedFormData = await new Response(capturedBody, {
+      headers: {
+        "content-type": capturedHeaders.get("content-type") ?? "",
+      },
+    }).formData()
+    expect(forwardedFormData.get("model")).toBe("gpt-image-2")
+    expect(forwardedFormData.get("prompt")).toBe("Change only the background")
+
+    const forwardedImages = forwardedFormData.getAll(
+      "image",
+    ) as unknown as Array<File>
+    expect(forwardedImages).toHaveLength(2)
+    expect(forwardedImages.map((image) => image.name)).toEqual([
+      "first.png",
+      "second.png",
+    ])
+    expect(forwardedImages.map((image) => image.type)).toEqual([
+      "image/png",
+      "image/png",
+    ])
+    expect(new Uint8Array(await forwardedImages[0].arrayBuffer())).toEqual(
+      firstImage,
+    )
+    expect(new Uint8Array(await forwardedImages[1].arrayBuffer())).toEqual(
+      secondImage,
+    )
+
+    const forwardedMask = forwardedFormData.get("mask") as unknown as File
+    expect(forwardedMask.name).toBe("mask.png")
+    expect(forwardedMask.type).toBe("image/png")
+    expect(new Uint8Array(await forwardedMask.arrayBuffer())).toEqual(maskImage)
+  })
+
+  test("preserves gzip and brotli request encodings", async () => {
+    const payload = new TextEncoder().encode(
+      JSON.stringify({ model: "gpt-image-2", prompt: "compressed" }),
+    )
+    const encodedBodies = [
+      { body: gzipSync(payload), encoding: "gzip" },
+      { body: brotliCompressSync(payload), encoding: "br" },
+    ]
+
+    for (const { body, encoding } of encodedBodies) {
+      const response = await createApp().request(
+        "/images/v1/images/generations",
+        {
+          body,
+          headers: {
+            authorization: "Bearer local-client-key",
+            "content-encoding": encoding,
+            "content-type": "application/json",
+          },
+          method: "POST",
+        },
+      )
+
+      expect(response.status).toBe(200)
+      expect(capturedHeaders.get("content-encoding")).toBe(encoding)
+      expect(capturedBody).toEqual(new Uint8Array(body))
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("forwards decompressed zstd bodies without the encoding header", async () => {
+    const payload = JSON.stringify({
+      model: "gpt-image-2",
+      prompt: "compressed",
+    })
+    const body = await Bun.zstdCompress(payload)
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body,
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-encoding": "zstd",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(capturedHeaders.get("content-encoding")).toBeNull()
+    expect(new TextDecoder().decode(capturedBody)).toBe(payload)
+  })
+
+  test("preserves upstream image API errors", async () => {
+    upstreamResponse = Response.json(
+      {
+        error: {
+          code: "invalid_size",
+          message: "Unsupported image size",
+          type: "invalid_request_error",
+        },
+      },
+      {
+        headers: {
+          "retry-after": "5",
+          "x-request-id": "failed-request-id",
+        },
+        status: 400,
+      },
+    )
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: JSON.stringify({ model: "gpt-image-2", prompt: "test" }),
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": "local-client-key",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get("retry-after")).toBe("5")
+    expect(response.headers.get("x-request-id")).toBe("failed-request-id")
+    expect(await response.json()).toEqual({
+      error: {
+        code: "invalid_size",
+        message: "Unsupported image size",
+        type: "invalid_request_error",
+      },
+    })
+  })
+
+  test("returns a generic error when the image provider is unreachable", async () => {
+    upstreamError = new Error(
+      "connect ECONNREFUSED https://internal-provider.example",
+    )
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: JSON.stringify({ model: "gpt-image-2", prompt: "test" }),
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(response.status).toBe(502)
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Failed to reach the image provider",
+        type: "api_error",
+      },
+    })
+  })
+
+  test("rejects providers that are unavailable or use built-in OAuth", async () => {
+    providerConfig = null
+    const missingResponse = await createApp().request(
+      "/missing/v1/images/generations",
+      {
+        body: "{}",
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(missingResponse.status).toBe(404)
+    expect(await missingResponse.json()).toEqual({
+      error: {
+        message: "Provider 'missing' not found or disabled",
+        type: "invalid_request_error",
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    providerConfig = createProviderConfig({
+      authType: "oauth2",
+      name: "codex",
+      type: "openai-responses",
+    })
+    const unsupportedResponse = await createApp().request(
+      "/codex/v1/images/generations",
+      {
+        body: "{}",
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(unsupportedResponse.status).toBe(400)
+    expect(await unsupportedResponse.json()).toEqual({
+      error: {
+        message: "Provider 'codex' does not enable /v1/images/generations",
+        type: "invalid_request_error",
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("allows only the image endpoints enabled by provider config", async () => {
+    const requestEndpoint = async (
+      endpoint: "edits" | "generations",
+    ): Promise<Response> =>
+      await createApp().request(`/images/v1/images/${endpoint}`, {
+        body: "{}",
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      })
+
+    providerConfig = createProviderConfig({
+      imageEndpoints: ["generations"],
+    })
+    expect((await requestEndpoint("generations")).status).toBe(200)
+    const disabledEditResponse = await requestEndpoint("edits")
+    expect(disabledEditResponse.status).toBe(400)
+    expect(await disabledEditResponse.json()).toEqual({
+      error: {
+        message: "Provider 'images' does not enable /v1/images/edits",
+        type: "invalid_request_error",
+      },
+    })
+
+    providerConfig = createProviderConfig({ imageEndpoints: ["edits"] })
+    expect((await requestEndpoint("generations")).status).toBe(400)
+    expect((await requestEndpoint("edits")).status).toBe(200)
+
+    providerConfig = createProviderConfig({ imageEndpoints: [] })
+    expect((await requestEndpoint("generations")).status).toBe(400)
+    expect((await requestEndpoint("edits")).status).toBe(400)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("leaves request media-type validation to the image provider", async () => {
+    const generationResponse = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: "provider-specific-generation-body",
+        headers: {
+          authorization: "Bearer local-client-key",
+          "content-type": "text/plain",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(generationResponse.status).toBe(200)
+    expect(capturedHeaders.get("content-type")).toBe("text/plain")
+    expect(new TextDecoder().decode(capturedBody)).toBe(
+      "provider-specific-generation-body",
+    )
+
+    const editResponse = await createApp().request("/images/v1/images/edits", {
+      body: '{"image":"provider-specific-reference"}',
+      headers: {
+        authorization: "Bearer local-client-key",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(editResponse.status).toBe(200)
+    expect(capturedHeaders.get("content-type")).toBe("application/json")
+    expect(new TextDecoder().decode(capturedBody)).toBe(
+      '{"image":"provider-specific-reference"}',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("allows image requests when regular API authentication is disabled", async () => {
+    localApiKeys = []
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: JSON.stringify({ model: "gpt-image-2", prompt: "test" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("requires valid credentials when regular API authentication is enabled", async () => {
+    const missingResponse = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: new Uint8Array([1, 2, 3]),
+        headers: {
+          "content-encoding": "zstd",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+    const invalidResponse = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        body: "{}",
+        headers: {
+          authorization: "Bearer wrong-key",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    )
+
+    expect(missingResponse.status).toBe(401)
+    expect(invalidResponse.status).toBe(401)
+    expect(missingResponse.headers.get("www-authenticate")).toBe(
+      'Bearer realm="copilot-api"',
+    )
+    expect(await missingResponse.json()).toEqual({
+      error: {
+        message: "Unauthorized",
+        type: "authentication_error",
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("allows CORS preflight without contacting the image provider", async () => {
+    localApiKeys = []
+
+    const response = await createApp().request(
+      "/images/v1/images/generations",
+      {
+        headers: {
+          "access-control-request-headers": "authorization,content-type",
+          "access-control-request-method": "POST",
+          origin: "https://client.example",
+        },
+        method: "OPTIONS",
+      },
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe("*")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

Providers may expose native OpenAI-compatible Images endpoints, but copilot-api currently has no provider-scoped path for those requests. Image clients therefore cannot reuse the gateway provider configuration and authentication boundary.

## Solution

- add `POST /:provider/v1/images/generations`
- add `POST /:provider/v1/images/edits`
- add an explicit provider-level `imageEndpoints` allowlist
- stream JSON and multipart request bodies to the native upstream Images endpoints without protocol translation
- preserve multipart boundaries, upstream status codes, response bodies, and compatible response headers
- replace client credentials with the configured provider credential
- preserve `imageEndpoints` when provider credentials are updated through CLI or desktop flows
- document configuration and OpenAI client setup in English and Chinese

## Configuration semantics

`imageEndpoints` declares which native Images paths a provider exposes:

- `["generations"]`: generation only
- `["edits"]`: editing only
- both values: enable both endpoints
- omitted or `[]`: disable Images

This is a provider-level endpoint capability, not a model allowlist. Mixed-model providers are supported: the request `model` is forwarded unchanged and the upstream provider remains responsible for validating model/endpoint compatibility.

The proxy targets `${baseUrl}/v1/images/<endpoint>`; providers with a separate Images base URL should use a separate provider entry. The built-in Codex OAuth provider is intentionally unsupported.

## Security

Gateway client credentials are not forwarded upstream. Requests use the configured provider `apiKey`, while the existing global gateway authentication continues to protect the public route.

## Validation

- provider Images tests: 12/12
- tracked test suite: 431/431 with a 20-second timeout
- TypeScript checks
- main and desktop builds
- relevant main-project ESLint checks
