### PR TITLE
fix(messages): preserve Claude Code Auto Mode classifier model

### DIFF
--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -40,6 +40,21 @@ import { tryHandleWebSearch } from "./web-search/fulfill"
 import consola from "consola"
 
 const logger = createHandlerLogger("messages-handler")
+const CLASSIFIER_SYSTEM_PROMPT_MARKER = "<classifier_system_prompt>"
+
+const isAutoModeClassifierRequest = (
+  system: AnthropicMessagesPayload["system"],
+): boolean => {
+  if (typeof system === "string") {
+    return system.includes(CLASSIFIER_SYSTEM_PROMPT_MARKER)
+  }
+
+  return (
+    system?.some((block) =>
+      block.text.includes(CLASSIFIER_SYSTEM_PROMPT_MARKER),
+    ) ?? false
+  )
+}
 
 export const messagesFlowHandlers = {
   handleWithChatCompletions,
@@ -92,10 +107,16 @@ export async function handleCompletion(c: Context) {
 
   // fix claude code 2.0.28+ warmup request consume premium request, forcing small model if no tools are used
   // set "CLAUDE_CODE_SUBAGENT_MODEL": "you small model" also can avoid this
+  // Auto Mode's classifier has the same request shape, but must retain its requested model.
   const anthropicBeta = c.req.header("anthropic-beta")
   logger.debug("Anthropic Beta header:", anthropicBeta)
   const noTools = !anthropicPayload.tools || anthropicPayload.tools.length === 0
-  if (anthropicBeta && noTools && compactType === 0) {
+  if (
+    anthropicBeta
+    && noTools
+    && !isAutoModeClassifierRequest(anthropicPayload.system)
+    && compactType === 0
+  ) {
     anthropicPayload.model = getSmallModel()
   }
 

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -695,4 +695,44 @@ describe("messages handler orchestration", () => {
     })
     expect(options.anthropicBetaHeader).toBe("warmup-beta")
   })
+
+  test("keeps the classifier model for Claude Code Auto Mode requests", async () => {
+    selectedModel = {
+      id: "messages-model",
+      supported_endpoints: ["/v1/messages"],
+    }
+
+    const classifierSystems: Array<AnthropicMessagesPayload["system"]> = [
+      "<classifier_system_prompt>Classify this action.</classifier_system_prompt>",
+      [
+        {
+          type: "text",
+          text: "<classifier_system_prompt>Classify this action.</classifier_system_prompt>",
+        },
+      ],
+    ]
+    const app = createApp()
+
+    for (const system of classifierSystems) {
+      findEndpointModel.mockClear()
+
+      const response = await app.request("/", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "anthropic-beta": "classifier-beta",
+        },
+        body: JSON.stringify(
+          createPayload({
+            model: "classifier-model",
+            system,
+          }),
+        ),
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe("messages")
+      expect(findEndpointModel).toHaveBeenCalledWith("classifier-model")
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- preserve the requested model for Claude Code Auto Mode classifier requests
- retain the existing `smallModel` warmup rewrite for ordinary tool-less beta requests
- add regression coverage for string and text-block `system` prompts

Fixes #332

## Testing

- `bun test` — 459 passed
- `tsc --noEmit`
- targeted ESLint on the changed files