### PR TITLE
fix: recover responses from rejected opaque state

### DIFF
--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -575,6 +575,10 @@ export type ResponsesStream = ReturnType<typeof events>
 export type CreateResponsesReturn = ResponsesResult | ResponsesStream
 export type ResponsesTransport = "http" | "websocket"
 
+const INVALID_RESPONSE_STATUS = 400
+const INVALID_RESPONSE_CODE = "invalid_request_body"
+const OPAQUE_STATE_ERROR_FRAGMENT = "encrypted content"
+
 type ResponsesStreamChunk = {
   data?: string
   event?: string
@@ -642,13 +646,13 @@ const createHttpResponses = async (
   payload: ResponsesPayload,
   headers: Record<string, string>,
 ): Promise<CreateResponsesReturn> => {
-  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  let response = await postHttpResponses(payload, headers)
+  const retryPayload = await createOpaqueStateRetryPayload(payload, response)
 
-  logCopilotRateLimits(response.headers)
+  if (retryPayload) {
+    consola.warn("Retrying responses request without rejected opaque state")
+    response = await postHttpResponses(retryPayload, headers)
+  }
 
   if (!response.ok) {
     consola.error("Failed to create responses", response)
@@ -660,6 +664,77 @@ const createHttpResponses = async (
   }
 
   return (await response.json()) as ResponsesResult
+}
+
+const postHttpResponses = async (
+  payload: ResponsesPayload,
+  headers: Record<string, string>,
+): Promise<Response> => {
+  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  })
+
+  logCopilotRateLimits(response.headers)
+
+  return response
+}
+
+const createOpaqueStateRetryPayload = async (
+  payload: ResponsesPayload,
+  response: Response,
+): Promise<ResponsesPayload | undefined> => {
+  if (!(await isOpaqueStateRejection(response))) return undefined
+  return removeOpaqueState(payload)
+}
+
+const removeOpaqueState = (
+  payload: ResponsesPayload,
+): ResponsesPayload | undefined => {
+  const retryPayload = { ...payload }
+  let changed = false
+
+  if (Array.isArray(payload.input)) {
+    retryPayload.input = payload.input.filter(
+      (item) => !isOpaqueStateItem(item),
+    )
+    changed = retryPayload.input.length !== payload.input.length
+  }
+
+  if (typeof payload.previous_response_id === "string") {
+    delete retryPayload.previous_response_id
+    changed = true
+  }
+
+  return changed ? retryPayload : undefined
+}
+
+const isOpaqueStateItem = (item: unknown): boolean => {
+  if (typeof item !== "object" || item === null || !("type" in item)) {
+    return false
+  }
+  if (item.type !== "reasoning" && item.type !== "compaction") return false
+  return (
+    "encrypted_content" in item && typeof item.encrypted_content === "string"
+  )
+}
+
+const isOpaqueStateRejection = async (response: Response): Promise<boolean> => {
+  if (response.status !== INVALID_RESPONSE_STATUS) return false
+
+  try {
+    const body = (await response.clone().json()) as {
+      error?: { code?: unknown; message?: unknown }
+    }
+    return (
+      body.error?.code === INVALID_RESPONSE_CODE
+      && typeof body.error.message === "string"
+      && body.error.message.toLowerCase().includes(OPAQUE_STATE_ERROR_FRAGMENT)
+    )
+  } catch {
+    return false
+  }
 }
 
 type ResponsesWebSocketPayload = ResponsesPayload & {

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -63,6 +63,57 @@ const fetchMock = mock((_url: string | URL | Request, _init?: RequestInit) =>
   ),
 )
 
+const createInvalidResponse = (message: string): Response =>
+  new Response(
+    JSON.stringify({
+      error: {
+        code: "invalid_request_body",
+        message,
+      },
+    }),
+    { status: 400 },
+  )
+
+const createOpaqueStateRejectionResponse = (): Response =>
+  createInvalidResponse("Encrypted content could not be verified")
+
+const createRecoverablePayload = (
+  overrides: Partial<ResponsesPayload> = {},
+): ResponsesPayload => ({
+  input: [
+    {
+      encrypted_content: "opaque-reasoning",
+      id: "reasoning-1",
+      summary: [],
+      type: "reasoning",
+    },
+    { content: "Continue", role: "user", type: "message" },
+  ],
+  model: "gpt-test",
+  ...overrides,
+})
+
+const createTestResponse = (payload: ResponsesPayload) =>
+  createResponses(payload, {
+    initiator: "user",
+    requestId: "request-1",
+    vision: false,
+  })
+
+const queueFetchResponse = (response: Response): void => {
+  fetchMock.mockImplementationOnce(() => Promise.resolve(response))
+}
+
+const captureResponseError = async (
+  payload: ResponsesPayload,
+): Promise<unknown> => {
+  try {
+    await createTestResponse(payload)
+  } catch (error) {
+    return error
+  }
+}
+
 beforeEach(() => {
   delete process.env.COPILOT_API_OAUTH_APP
   state.accountType = "individual"
@@ -94,6 +145,106 @@ afterEach(() => {
 })
 
 describe("createResponses", () => {
+  test("retries rejected opaque state while preserving conversation records", async () => {
+    queueFetchResponse(createOpaqueStateRejectionResponse())
+    const preservedInput: NonNullable<ResponsesPayload["input"]> = [
+      { content: "Earlier answer", role: "assistant", type: "message" },
+      {
+        arguments: "{}",
+        call_id: "call-1",
+        name: "lookup",
+        type: "function_call",
+      },
+      {
+        call_id: "call-1",
+        output: "Tool result",
+        type: "function_call_output",
+      },
+      { content: "Continue", role: "user", type: "message" },
+    ]
+    const payload: ResponsesPayload = {
+      input: [
+        preservedInput[0],
+        {
+          encrypted_content: "opaque-reasoning",
+          id: "reasoning-1",
+          summary: [],
+          type: "reasoning",
+        },
+        preservedInput[1],
+        preservedInput[2],
+        {
+          encrypted_content: "opaque-compaction",
+          id: "compaction-1",
+          type: "compaction",
+        },
+        preservedInput[3],
+      ],
+      model: "gpt-test",
+      previous_response_id: "response-1",
+    }
+
+    const result = await createTestResponse(payload)
+
+    expect(result).toEqual(createResponsesResult("gpt-test"))
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const retryInit = fetchMock.mock.calls[1][1] as RequestInit
+    const retryBody = JSON.parse(retryInit.body as string) as ResponsesPayload
+    expect(retryBody.input).toEqual(preservedInput)
+    expect(retryBody.previous_response_id).toBeUndefined()
+  })
+
+  test("returns the recovered HTTP response stream", async () => {
+    queueFetchResponse(createOpaqueStateRejectionResponse())
+    queueFetchResponse(
+      new Response(
+        [
+          "event: response.completed",
+          'data: {"type":"response.completed"}',
+          "",
+          "data: [DONE]",
+          "",
+        ].join("\n"),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+    )
+
+    const response = await createTestResponse(
+      createRecoverablePayload({ stream: true }),
+    )
+    const chunks = []
+    for await (const chunk of response as AsyncIterable<{
+      data?: string
+      event?: string
+    }>) {
+      chunks.push(chunk)
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(chunks).toContainEqual({
+      data: '{"type":"response.completed"}',
+      event: "response.completed",
+    })
+  })
+
+  test("retries rejected opaque state only once", async () => {
+    queueFetchResponse(createOpaqueStateRejectionResponse())
+    queueFetchResponse(createOpaqueStateRejectionResponse())
+
+    const thrown = await captureResponseError(createRecoverablePayload())
+    expect(thrown).toBeInstanceOf(Error)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("does not retry unrelated invalid responses", async () => {
+    queueFetchResponse(createInvalidResponse("Unsupported request field"))
+
+    const thrown = await captureResponseError(createRecoverablePayload())
+    expect(thrown).toBeInstanceOf(Error)
+    expect((thrown as Error).message).toBe("Failed to create responses")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   test("keeps HTTP responses requests using x-initiator header", async () => {
     const payload: ResponsesPayload = {
       input: "hello",


### PR DESCRIPTION
## Summary

- retry a rejected HTTP Responses request once without opaque response state
- preserve conversation and tool records while leaving unrelated failures unchanged
- cover non-streaming, streaming, and retry-limit behavior

## Checks

- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Related: #309