### PR TITLE
docs: document Codex auto-review model mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,18 @@ enabled = false
 > This configuration is specific to Codex and the GitHub Copilot provider. `name` must be set to `"OpenAI"`. It can help mitigate Codex local compact cache miss issues.
 > If you are using the codex provider, it is recommended to set `base_url` to `"http://localhost:4141/codex"`.
 
+When Codex uses the top-level GitHub Copilot route with `approvals_reviewer = "auto_review"`, map its internal review model to a Responses-capable Copilot model in the gateway's `config.json`:
+
+```json
+{
+  "modelMappings": {
+    "codex-auto-review": "gpt-5.6-luna"
+  }
+}
+```
+
+This mapping only applies to the top-level GitHub Copilot route. Provider-scoped routes do not use `modelMappings`, so the built-in `/codex` provider continues to handle `codex-auto-review` natively.
+
 ## GPT Tool Search
 
 For GPT Responses models such as `gpt-5.4+`, this AI gateway can expose Responses `tool_search` through a small MCP bridge. The same bridge can be used by Claude Code and opencode, as long as the client loads MCP servers and sends Anthropic Messages traffic through this gateway.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -332,6 +332,18 @@ enabled = false
 > 此配置仅限于 Codex 与 GitHub Copilot provider。`name` 一定要配置为 `"OpenAI"`。它可以缓解 Codex local compact 不命中缓存的问题。
 > 如果使用 codex provider，建议将 `base_url` 配置为 `"http://localhost:4141/codex"`。
 
+当 Codex 通过顶层 GitHub Copilot 路由并设置 `approvals_reviewer = "auto_review"` 时，可在网关的 `config.json` 中将内部审核模型映射到一个支持 Responses API 的 Copilot 模型：
+
+```json
+{
+  "modelMappings": {
+    "codex-auto-review": "gpt-5.6-luna"
+  }
+}
+```
+
+该映射只作用于顶层 GitHub Copilot 路由。provider-scoped 路由不会使用 `modelMappings`，因此内置 `/codex` provider 仍会原生处理 `codex-auto-review`。
+
 ## GPT Tool Search
 
 对于 `gpt-5.4+` 这类 GPT Responses 模型，这个 AI gateway 可以通过一个很小的 MCP bridge 暴露 Responses `tool_search`。Claude Code 和 opencode 都可以使用同一个 bridge，前提是客户端会加载 MCP server，并且 Anthropic Messages 流量会经过这个 AI gateway。


### PR DESCRIPTION
Documents the `codex-auto-review` model mapping in both READMEs.

After reinstalling, I had to look up this configuration again. An explicit example should make it easier to find.

No Claude Code-style special handling is needed because Codex uses a distinct `codex-auto-review` model name, which existing `modelMappings` can target directly. The built-in `/codex` provider is unaffected.

Docs-only change.
