### PR TITLE
feat: add Copilot fallback for Codex alpha search

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
     "useMessagesApi": true,
     "useResponsesApiWebSocket": true,
     "useResponsesApiWebSearch": true,
+    "alphaSearchResponsesFallback": false,
     "messageApiWebSearchModel": "gpt-5-mini"
   }
   ```
@@ -648,6 +649,15 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
 - **useMessagesApi:** When `true`, Claude-family models that support Copilot's native `/v1/messages` endpoint will use the Messages API; otherwise they fall back to `/chat/completions`. Set to `false` to disable Messages API routing and always use `/chat/completions`. Defaults to `true`.
 - **useResponsesApiWebSocket:** When `true`, Responses API requests use Copilot's websocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable websocket routing and use HTTP `/responses` whenever the selected model supports it. Defaults to `true`. If the Responses API WebSocket gets closed, it is usually caused by your own network. If you are using a VPN, try switching to a different node.
 - **useResponsesApiWebSearch:** When `true`, the server keeps Responses API tools with `type: "web_search"` and forwards them upstream. Set to `false` to strip those tools from `/responses` payloads. Defaults to `true`.
+- **alphaSearchResponsesFallback:** When `true` and `useResponsesApiWebSearch` remains enabled, top-level `POST /alpha/search` and `POST /v1/alpha/search` requests use GitHub Copilot Responses web search when no authenticated Codex provider is available. An authenticated Codex provider still takes precedence, and provider-scoped alpha-search routes are unchanged. The fallback recognizes every current Codex search command; unsupported `image_query` and `screenshot` operations return successful no-retry tool output. Defaults to `false`. Configure Codex to call the endpoint with:
+
+  ```toml
+  web_search = "live"
+
+  [model_providers.copilot_api]
+  supports_standalone_web_search = true
+  ```
+
 - **messageApiWebSearchModel:** Global fallback model used when a top-level Copilot `/v1/messages` request contains only the server-side `web_search` tool. Defaults to `gpt-5-mini`. If the value is a `provider/model` alias, the request is routed into that provider's Messages API path with the provider prefix stripped. For Copilot GPT models, web search runs through `/responses`. Mixed `web_search` plus custom tools are not supported and the server-side `web_search` tool is stripped.
 - **claudeAutoModel:** Model used for Claude Code background security-monitor requests on `/v1/messages` and provider message routes. A request is treated as a security-monitor request when it carries no tools, sets `stop_sequences` to `["</block>"]`, and contains a system text block starting with `You are a security monitor for autonomous AI coding agents.`; its model is then replaced with this value. For top-level requests, a `provider/model` alias is forwarded into that provider's Messages API; provider routes keep their current provider and use this configured value directly. Defaults to empty (disabled).
 - **claudeTokenMultiplier:** Multiplier applied to the fallback GPT-tokenizer estimate for Claude `/v1/messages/count_tokens` requests. Defaults to `1.15`. Increase it if your client is still compacting too late. This setting is only used when the proxy is estimating Claude tokens locally; if `anthropicApiKey` is configured and Anthropic token counting succeeds, the exact Anthropic count is returned instead.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -567,6 +567,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
     "useMessagesApi": true,
     "useResponsesApiWebSocket": true,
     "useResponsesApiWebSearch": true,
+    "alphaSearchResponsesFallback": false,
     "messageApiWebSearchModel": "gpt-5-mini"
   }
   ```
@@ -654,6 +655,15 @@ Copilot API 现在使用子命令结构，主要命令包括：
 - **useMessagesApi：** 当为 `true` 时，支持 Copilot 原生 `/v1/messages` 的 Claude 系模型会走 Messages API；否则回退到 `/chat/completions`。设为 `false` 可禁用 Messages API 路由，始终使用 `/chat/completions`。默认值为 `true`。
 - **useResponsesApiWebSocket：** 当为 `true` 时，Responses API 请求会优先对声明了 `ws:/responses` 的模型使用 Copilot websocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用 websocket 路由，并在模型支持 `/responses` 时使用 HTTP `/responses`。默认值为 `true`。如果遇到 Responses API WebSocket closed，一般是自己的网络问题。如果使用了 VPN，建议切换节点。
 - **useResponsesApiWebSearch：** 当为 `true` 时，服务端会保留 Responses API 中 `type: "web_search"` 的工具并透传到上游。设为 `false` 则会从 `/responses` payload 中移除这些工具。默认值为 `true`。
+- **alphaSearchResponsesFallback：** 当设为 `true` 且 `useResponsesApiWebSearch` 保持启用时，如果没有可用的已认证 Codex provider，顶层 `POST /alpha/search` 和 `POST /v1/alpha/search` 会改用 GitHub Copilot Responses web search。已认证的 Codex provider 始终优先，provider-scoped alpha-search 路由不受影响。该 fallback 会识别当前所有 Codex search command；不受支持的 `image_query` 和 `screenshot` 会返回成功且明确要求不要重试的 tool output。默认值为 `false`。Codex 侧需配置：
+
+  ```toml
+  web_search = "live"
+
+  [model_providers.copilot_api]
+  supports_standalone_web_search = true
+  ```
+
 - **messageApiWebSearchModel：** 顶层 Copilot `/v1/messages` 请求只包含服务端 `web_search` 工具时使用的全局模型，默认值为 `gpt-5-mini`。如果该值是 `provider/model` 别名，请求会进入对应 provider 的 Messages API 路径，并在转发前移除 provider 前缀。对于 Copilot GPT 模型，web search 会通过 `/responses` 执行。混合 `web_search` 与自定义工具的场景暂不支持，服务端会移除 server-side `web_search`。
 - **claudeAutoModel：** 用于 Claude Code 后台 security-monitor 请求的模型，作用于 `/v1/messages` 和 provider Messages 路由。当请求不带任何工具、`stop_sequences` 为 `["</block>"]`，且 system 文本块以 `You are a security monitor for autonomous AI coding agents.` 开头时，会被识别为 security-monitor 请求，其模型会被替换为该配置值。对于顶层请求，`provider/model` 别名会转发到对应 provider 的 Messages API；对于 provider 路由，则保持当前 provider，直接使用该配置值。默认为空（禁用）。
 - **claudeTokenMultiplier：** 用于 Claude `/v1/messages/count_tokens` 请求在本地走 GPT tokenizer 估算时的乘数。默认值为 `1.15`。如果你的客户端仍然过晚触发上下文压缩，可以适当调大。这个配置只会在代理本地估算 Claude token 时生效；如果已经配置 `anthropicApiKey` 且 Anthropic token counting 调用成功，则会直接返回 Anthropic 的精确计数，不会使用这个乘数。

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ export interface AppConfig {
   useResponsesApiWebSocket?: boolean
   anthropicApiKey?: string
   useResponsesApiWebSearch?: boolean
+  alphaSearchResponsesFallback?: boolean
   // Copilot rejects Anthropic's web_search server tool on /v1/messages, so a
   // Claude request that only asks for web search is switched to this model.
   // A `provider/model` alias is passed straight through to that provider's
@@ -191,6 +192,7 @@ const defaultConfig: AppConfig = {
   useMessagesApi: true,
   useResponsesApiWebSocket: true,
   useResponsesApiWebSearch: true,
+  alphaSearchResponsesFallback: false,
   messageApiWebSearchModel: "gpt-5-mini",
 }
 
@@ -769,6 +771,11 @@ export function getAnthropicApiKey(): string | undefined {
 export function isResponsesApiWebSearchEnabled(): boolean {
   const config = getConfig()
   return config.useResponsesApiWebSearch ?? true
+}
+
+export function isAlphaSearchResponsesFallbackEnabled(): boolean {
+  const config = getConfig()
+  return config.alphaSearchResponsesFallback ?? false
 }
 
 export function getMessageApiWebSearchModel(): string | undefined {

--- a/src/routes/alpha-search/alpha-search-types.ts
+++ b/src/routes/alpha-search/alpha-search-types.ts
@@ -1,74 +1,173 @@
-export interface AlphaSearchRequest {
-  id: string
-  model: string
-  input: Array<AlphaSearchInputMessage>
-  commands: AlphaSearchCommands
-  settings: AlphaSearchSettings
-  max_output_tokens: number
-}
+import { z } from "zod"
 
-export interface AlphaSearchInputMessage {
-  type: "message"
-  role: AlphaSearchInputRole
-  content: Array<AlphaSearchInputContent>
-  phase?: AlphaSearchMessagePhase
-  internal_chat_message_metadata_passthrough?: AlphaSearchMetadataPassthrough
-}
+const unsignedInteger = z.number().int().nonnegative()
+const passthroughRecord = z.record(z.string(), z.unknown())
 
-export type AlphaSearchInputRole = "user" | "assistant" | "system" | "developer"
+const searchQuerySchema = z
+  .object({
+    q: z.string(),
+    recency: unsignedInteger.optional(),
+    domains: z.array(z.string()).optional(),
+  })
+  .passthrough()
 
-export type AlphaSearchInputContent =
-  | AlphaSearchInputTextContent
-  | AlphaSearchOutputTextContent
+const openOperationSchema = z
+  .object({
+    ref_id: z.string(),
+    lineno: unsignedInteger.optional(),
+  })
+  .passthrough()
 
-export interface AlphaSearchInputTextContent {
-  type: "input_text"
-  text: string
-}
+const clickOperationSchema = z
+  .object({
+    ref_id: z.string(),
+    id: unsignedInteger,
+  })
+  .passthrough()
 
-export interface AlphaSearchOutputTextContent {
-  type: "output_text"
-  text: string
-}
+const findOperationSchema = z
+  .object({
+    ref_id: z.string(),
+    pattern: z.string(),
+  })
+  .passthrough()
 
-export type AlphaSearchMessagePhase = "commentary" | "final_answer"
+const screenshotOperationSchema = z
+  .object({
+    ref_id: z.string(),
+    pageno: unsignedInteger,
+  })
+  .passthrough()
 
-export interface AlphaSearchMetadataPassthrough {
-  turn_id: string
-}
+const financeOperationSchema = z
+  .object({
+    ticker: z.string(),
+    type: z.enum(["equity", "fund", "crypto", "index"]),
+    market: z.string().optional(),
+  })
+  .passthrough()
 
-export interface AlphaSearchSettings {
-  allowed_callers: Array<AlphaSearchAllowedCaller>
-  external_web_access: boolean
-}
+const weatherOperationSchema = z
+  .object({
+    location: z.string(),
+    start: z.string().optional(),
+    duration: unsignedInteger.optional(),
+  })
+  .passthrough()
 
-export type AlphaSearchAllowedCaller = "direct" | (string & {})
+const sportsOperationSchema = z
+  .object({
+    tool: z.literal("sports").optional(),
+    fn: z.enum(["schedule", "standings"]),
+    league: z.enum([
+      "nba",
+      "wnba",
+      "nfl",
+      "nhl",
+      "mlb",
+      "epl",
+      "ncaamb",
+      "ncaawb",
+      "ipl",
+    ]),
+    team: z.string().optional(),
+    opponent: z.string().optional(),
+    date_from: z.string().optional(),
+    date_to: z.string().optional(),
+    num_games: unsignedInteger.optional(),
+    locale: z.string().optional(),
+  })
+  .passthrough()
 
-export interface AlphaSearchCommands {
-  search_query?: Array<AlphaSearchSearchQuery>
-  open?: Array<AlphaSearchOpenCommand>
-  find?: Array<AlphaSearchFindCommand>
-  response_length: AlphaSearchResponseLength
-}
+const timeOperationSchema = z
+  .object({
+    utc_offset: z.string().regex(/^[+-](?:[01]\d|2[0-3]):[0-5]\d$/u),
+  })
+  .passthrough()
 
-export interface AlphaSearchSearchQuery {
-  q: string
-}
+export const alphaSearchCommandsSchema = z
+  .object({
+    search_query: z.array(searchQuerySchema).optional(),
+    image_query: z.array(searchQuerySchema).optional(),
+    open: z.array(openOperationSchema).optional(),
+    click: z.array(clickOperationSchema).optional(),
+    find: z.array(findOperationSchema).optional(),
+    screenshot: z.array(screenshotOperationSchema).optional(),
+    finance: z.array(financeOperationSchema).optional(),
+    weather: z.array(weatherOperationSchema).optional(),
+    sports: z.array(sportsOperationSchema).optional(),
+    time: z.array(timeOperationSchema).optional(),
+    response_length: z.enum(["short", "medium", "long"]).optional(),
+  })
+  .passthrough()
 
-export interface AlphaSearchOpenCommand {
-  ref_id: string
-  lineno?: number
-}
+const reasoningSchema = z
+  .object({
+    effort: z.string().min(1).nullable().optional(),
+    summary: z
+      .enum(["auto", "concise", "detailed", "none"])
+      .nullable()
+      .optional(),
+    context: z
+      .enum(["auto", "current_turn", "all_turns"])
+      .nullable()
+      .optional(),
+  })
+  .passthrough()
 
-export interface AlphaSearchFindCommand {
-  ref_id: string
-  pattern: string
-}
+const settingsSchema = z
+  .object({
+    user_location: z
+      .object({
+        type: z.literal("approximate"),
+        country: z.string().optional(),
+        region: z.string().optional(),
+        city: z.string().optional(),
+        timezone: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    search_context_size: z.enum(["low", "medium", "high"]).optional(),
+    filters: z
+      .object({
+        allowed_domains: z.array(z.string()).optional(),
+        blocked_domains: z.array(z.string()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    image_settings: z
+      .object({
+        max_results: unsignedInteger.optional(),
+        caption: z.boolean().optional(),
+      })
+      .passthrough()
+      .optional(),
+    allowed_callers: z
+      .array(z.enum(["direct", "shell", "code_interpreter"]))
+      .optional(),
+    external_web_access: z
+      .union([z.boolean(), z.enum(["cached", "indexed", "live"])])
+      .optional(),
+  })
+  .passthrough()
 
-export type AlphaSearchResponseLength = "short" | "medium" | "long"
+export const alphaSearchRequestSchema = z
+  .object({
+    id: z.string(),
+    model: z.string(),
+    reasoning: reasoningSchema.optional(),
+    input: z.union([z.string(), z.array(passthroughRecord)]).optional(),
+    commands: alphaSearchCommandsSchema.optional(),
+    settings: settingsSchema.optional(),
+    max_output_tokens: unsignedInteger.optional(),
+  })
+  .passthrough()
+
+export type AlphaSearchRequest = z.infer<typeof alphaSearchRequestSchema>
+export type AlphaSearchCommands = z.infer<typeof alphaSearchCommandsSchema>
 
 export interface AlphaSearchResponse {
-  encrypted_output: string
+  encrypted_output: string | null
   output: string
   results: Array<AlphaSearchResult>
 }

--- a/src/routes/alpha-search/copilot-fallback.ts
+++ b/src/routes/alpha-search/copilot-fallback.ts
@@ -1,0 +1,706 @@
+import type { Context } from "hono"
+import consola from "consola"
+
+import { resolveMappedModel } from "~/lib/config"
+import { debugJson, createHandlerLogger } from "~/lib/logger"
+import { findEndpointModel } from "~/lib/models"
+import {
+  createCopilotTokenUsageRecorder,
+  normalizeOptionalToken,
+  normalizeResponsesUsage,
+  type UsageTokens,
+} from "~/lib/token-usage"
+import { generateRequestIdFromPayload, getUUID } from "~/lib/utils"
+import {
+  alphaSearchRequestSchema,
+  type AlphaSearchResponse,
+  type AlphaSearchTextResult,
+} from "~/routes/alpha-search/alpha-search-types"
+import {
+  buildResponsesWebSearchTool,
+  extractWebSearchResult,
+  type WebSearchSource,
+} from "~/routes/messages/web-search/backend"
+import {
+  createResponses as createCopilotResponses,
+  type ResponsesPayload,
+  type ResponsesResult,
+} from "~/services/copilot/create-responses"
+
+const logger = createHandlerLogger("alpha-search-copilot-handler")
+
+const SESSION_TTL_MS = 60 * 60 * 1000
+const MAX_SESSIONS = 128
+const MAX_URL_REFERENCES = 256
+const MAX_SNAPSHOTS = 16
+const MAX_SNAPSHOT_CHARACTERS = 20_000
+// ponytail: bounded process-local state is intentional; use persistent
+// per-account storage only if measured sessions outgrow these fixed ceilings.
+
+const IMAGE_UNSUPPORTED =
+  "Unsupported by GitHub Copilot web search: image_query. Do not retry this operation; use search_query for image-source pages."
+const SCREENSHOT_UNSUPPORTED =
+  "Unsupported by GitHub Copilot web search: screenshot. Do not retry this operation; open the PDF for text content."
+
+const KNOWN_COMMANDS = new Set([
+  "search_query",
+  "image_query",
+  "open",
+  "click",
+  "find",
+  "screenshot",
+  "finance",
+  "weather",
+  "sports",
+  "time",
+  "response_length",
+])
+
+interface UrlReference {
+  result: AlphaSearchTextResult
+}
+
+interface PageSnapshot {
+  refId: string
+  source: UrlReference
+  text: string
+  links: Array<UrlReference>
+}
+
+interface SearchSession {
+  nextTurn: number
+  touchedAt: number
+  referencesById: Map<string, UrlReference>
+  referencesByUrl: Map<string, UrlReference>
+  snapshots: Map<string, PageSnapshot>
+}
+
+interface RemotePageOperation {
+  kind: "open" | "find"
+  source: UrlReference
+  lineno?: number
+  pattern?: string
+}
+
+interface SearchTurn {
+  number: number
+  nextReferenceIndex: number
+}
+
+const sessions = new Map<string, SearchSession>()
+
+export const alphaSearchFallbackDependencies = {
+  createResponses: createCopilotResponses,
+  findEndpointModel,
+  now: (): number => Date.now(),
+  resolveMappedModel,
+  createUsageRecorder: (
+    model: string,
+    sessionId: string,
+  ): ((usage: UsageTokens) => void) =>
+    createCopilotTokenUsageRecorder({
+      endpoint: "responses",
+      fallbackSessionId: sessionId,
+      model,
+    }),
+}
+
+export function resetAlphaSearchFallbackState(): void {
+  sessions.clear()
+}
+
+function reserveSession(
+  id: string,
+  now: number,
+): {
+  session: SearchSession
+  turn: number
+} {
+  for (const [sessionId, session] of sessions) {
+    if (now - session.touchedAt >= SESSION_TTL_MS) {
+      sessions.delete(sessionId)
+    }
+  }
+
+  let session = sessions.get(id)
+  if (!session) {
+    if (sessions.size >= MAX_SESSIONS) {
+      const oldestSession = sessions.keys().next()
+      if (!oldestSession.done) sessions.delete(oldestSession.value)
+    }
+    session = {
+      nextTurn: 0,
+      touchedAt: now,
+      referencesById: new Map(),
+      referencesByUrl: new Map(),
+      snapshots: new Map(),
+    }
+  } else {
+    sessions.delete(id)
+    session.touchedAt = now
+  }
+  sessions.set(id, session)
+
+  const turn = session.nextTurn
+  session.nextTurn += 1
+  return { session, turn }
+}
+
+function parseHttpUrl(value: string): string | null {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ?
+        url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+function extractMarkdownSources(text: string): Array<WebSearchSource> {
+  // ponytail: Copilot emits simple Markdown links here; add a Markdown parser
+  // only if measured responses exceed this shape.
+  return Array.from(
+    text.matchAll(
+      /(?<!!)\[([^\]\n]+)\]\((https?:\/\/(?:[^\s<>()]|\([^\s<>()]*\))+)\)/gu,
+    ),
+    ([, title, url]) => ({ title, url }),
+  )
+}
+
+function addUrlReference(
+  session: SearchSession,
+  source: WebSearchSource,
+  turn: SearchTurn,
+): UrlReference | null {
+  const url = parseHttpUrl(source.url)
+  if (!url) return null
+
+  const existing = session.referencesByUrl.get(url)
+  if (existing) {
+    if (existing.result.title === existing.result.url && source.title) {
+      existing.result.title = source.title
+    }
+    if (source.snippet) existing.result.snippet = source.snippet
+    return existing
+  }
+
+  if (session.referencesById.size >= MAX_URL_REFERENCES) {
+    const oldest = session.referencesById.entries().next().value
+    if (oldest) {
+      const [refId, reference] = oldest
+      session.referencesById.delete(refId)
+      session.referencesByUrl.delete(reference.result.url)
+    }
+  }
+
+  const refId = `turn${turn.number}search${turn.nextReferenceIndex}`
+  turn.nextReferenceIndex += 1
+
+  const reference: UrlReference = {
+    result: {
+      type: "text_result",
+      domain: new URL(url).hostname,
+      ref_id: refId,
+      snippet: source.snippet?.trim() || source.title || url,
+      title: source.title || url,
+      url,
+    },
+  }
+  session.referencesById.set(refId, reference)
+  session.referencesByUrl.set(url, reference)
+  return reference
+}
+
+function resolveUrlReference(
+  session: SearchSession,
+  refId: string,
+  turn: SearchTurn,
+): UrlReference | null {
+  const stored = session.referencesById.get(refId)
+  if (stored) return stored
+
+  const url = parseHttpUrl(refId)
+  return url ? addUrlReference(session, { title: url, url }, turn) : null
+}
+
+function getSnapshot(
+  session: SearchSession,
+  refId: string,
+): PageSnapshot | null {
+  const snapshot = session.snapshots.get(refId)
+  if (!snapshot) return null
+  session.snapshots.delete(refId)
+  session.snapshots.set(refId, snapshot)
+  return snapshot
+}
+
+function findSnapshotByUrl(
+  session: SearchSession,
+  url: string,
+): PageSnapshot | null {
+  for (const snapshot of session.snapshots.values()) {
+    if (snapshot.source.result.url === url) {
+      return getSnapshot(session, snapshot.refId)
+    }
+  }
+  return null
+}
+
+function addSnapshot(
+  session: SearchSession,
+  source: UrlReference,
+  turn: number,
+  index: number,
+  text: string,
+  links: Array<UrlReference>,
+): PageSnapshot {
+  const existing = findSnapshotByUrl(session, source.result.url)
+  if (existing) {
+    existing.text = text.slice(0, MAX_SNAPSHOT_CHARACTERS)
+    existing.links = links
+    return existing
+  }
+
+  if (session.snapshots.size >= MAX_SNAPSHOTS) {
+    const oldestRefId = session.snapshots.keys().next().value
+    if (oldestRefId) session.snapshots.delete(oldestRefId)
+  }
+
+  const snapshot = {
+    refId: `turn${turn}view${index}`,
+    source,
+    text: text.slice(0, MAX_SNAPSHOT_CHARACTERS),
+    links,
+  }
+  session.snapshots.set(snapshot.refId, snapshot)
+  return snapshot
+}
+
+function renderSnapshot(snapshot: PageSnapshot, lineno?: number): string {
+  const lines = snapshot.text.split("\n")
+  const start =
+    lineno === undefined ? 0 : (
+      Math.max(0, Math.min(lineno, lines.length - 1) - 10)
+    )
+  const end =
+    lineno === undefined ? lines.length : Math.min(lines.length, start + 21)
+  const numbered = lines
+    .slice(start, end)
+    .map((line, index) => `L${start + index}: ${line}`)
+    .join("\n")
+  const links = snapshot.links
+    .map(
+      (link, index) =>
+        `[${index}] ${link.result.title} — ${link.result.url} (${link.result.ref_id})`,
+    )
+    .join("\n")
+
+  return [
+    `Open ${snapshot.refId} (${snapshot.source.result.url})`,
+    numbered,
+    links ? `Links:\n${links}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+function findInSnapshot(
+  snapshot: PageSnapshot,
+  pattern: string,
+): string | null {
+  const normalizedPattern = pattern.toLowerCase()
+  const matches = snapshot.text
+    .split("\n")
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => line.toLowerCase().includes(normalizedPattern))
+    .slice(0, 20)
+  if (matches.length === 0) return null
+
+  return [
+    `Find results for ${JSON.stringify(pattern)} in ${snapshot.refId}:`,
+    ...matches.map(({ line, index }) => `L${index}: ${line}`),
+  ].join("\n")
+}
+
+function formatTime(utcOffset: string, now: number): string {
+  const direction = utcOffset[0] === "+" ? 1 : -1
+  const offsetMinutes =
+    direction
+    * (Number.parseInt(utcOffset.slice(1, 3), 10) * 60
+      + Number.parseInt(utcOffset.slice(4, 6), 10))
+  const localIso = new Date(now + offsetMinutes * 60_000).toISOString()
+  return `Time at UTC${utcOffset}: ${localIso.slice(0, 19).replace("T", " ")}`
+}
+
+function buildInstruction(
+  operations: Array<Record<string, unknown>>,
+  responseLength: "short" | "medium" | "long" | undefined,
+): string {
+  return [
+    "The Operations JSON below is the complete and exclusive request for this response.",
+    "Use web_search to execute every listed operation and only those operations. Do not validate, infer, or mention operations absent from the JSON; the adapter already handled them.",
+    "Return only grounded results and citations for these operations. Do not discuss unrelated tasks or conversations.",
+    "For search operations, honor every query, recency, domain, market, date, league, team, and locale constraint.",
+    "For open operations, open the exact URL and return grounded page text plus cited links.",
+    "For find operations, find the exact pattern in the specified URL and return matching context.",
+    `Requested response length: ${responseLength ?? "medium"}.`,
+    `Operations:\n${JSON.stringify(operations, null, 2)}`,
+  ].join("\n")
+}
+
+function unavailableReference(refId: string): string {
+  return `Reference ${JSON.stringify(refId)} is unavailable or expired. Search or open the URL again.`
+}
+
+function invalidRequest(c: Context, message: string): Response {
+  return c.json(
+    {
+      error: {
+        message,
+        type: "invalid_request_error",
+      },
+    },
+    400,
+  )
+}
+
+export async function handleCopilotAlphaSearch(c: Context): Promise<Response> {
+  let body: unknown
+  try {
+    body = await c.req.json<unknown>()
+  } catch {
+    return invalidRequest(c, "Invalid alpha search request: expected JSON body")
+  }
+
+  const parsed = alphaSearchRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const path = issue?.path.join(".") || "body"
+    return invalidRequest(
+      c,
+      `Invalid alpha search request at ${path}: ${issue?.message ?? "invalid value"}`,
+    )
+  }
+
+  const request = parsed.data
+  const now = alphaSearchFallbackDependencies.now()
+  const reservation = reserveSession(request.id, now)
+  const session = reservation.session
+  const turn: SearchTurn = {
+    number: reservation.turn,
+    nextReferenceIndex: 0,
+  }
+  const commands = request.commands ?? {}
+  const output: Array<string> = []
+  const warnings: Array<string> = []
+  const resultReferences = new Map<string, UrlReference>()
+  const remoteOperations: Array<Record<string, unknown>> = []
+  const remotePages: Array<RemotePageOperation> = []
+
+  const includeResult = (reference: UrlReference): void => {
+    resultReferences.set(reference.result.url, reference)
+  }
+  const queuePage = (
+    kind: "open" | "find",
+    source: UrlReference,
+    options: { lineno?: number; pattern?: string } = {},
+  ): void => {
+    remoteOperations.push({
+      type: kind,
+      url: source.result.url,
+      ...(options.lineno === undefined ? {} : { lineno: options.lineno }),
+      ...(options.pattern === undefined ? {} : { pattern: options.pattern }),
+    })
+    remotePages.push({ kind, source, ...options })
+    includeResult(source)
+  }
+
+  for (const command of commands.search_query ?? []) {
+    remoteOperations.push({ ...command, type: "search_query" })
+  }
+
+  if ((commands.image_query?.length ?? 0) > 0) warnings.push(IMAGE_UNSUPPORTED)
+
+  for (const command of commands.open ?? []) {
+    const directSnapshot = getSnapshot(session, command.ref_id)
+    if (directSnapshot) {
+      output.push(renderSnapshot(directSnapshot, command.lineno))
+      includeResult(directSnapshot.source)
+      continue
+    }
+
+    const source = resolveUrlReference(session, command.ref_id, turn)
+    if (!source) {
+      output.push(unavailableReference(command.ref_id))
+      continue
+    }
+    const cached = findSnapshotByUrl(session, source.result.url)
+    if (cached) {
+      output.push(renderSnapshot(cached, command.lineno))
+      includeResult(source)
+      continue
+    }
+    queuePage("open", source, { lineno: command.lineno })
+  }
+
+  for (const command of commands.click ?? []) {
+    const parent = getSnapshot(session, command.ref_id)
+    const source = parent?.links[command.id]
+    if (!source) {
+      output.push(unavailableReference(`${command.ref_id} link ${command.id}`))
+      continue
+    }
+    const cached = findSnapshotByUrl(session, source.result.url)
+    if (cached) {
+      output.push(renderSnapshot(cached))
+      includeResult(source)
+      continue
+    }
+    queuePage("open", source)
+  }
+
+  for (const command of commands.find ?? []) {
+    const directSnapshot = getSnapshot(session, command.ref_id)
+    const source =
+      directSnapshot?.source
+      ?? resolveUrlReference(session, command.ref_id, turn)
+    if (!source) {
+      output.push(unavailableReference(command.ref_id))
+      continue
+    }
+    const snapshot =
+      directSnapshot ?? findSnapshotByUrl(session, source.result.url)
+    const localResult =
+      snapshot ? findInSnapshot(snapshot, command.pattern) : null
+    if (localResult) {
+      output.push(localResult)
+      includeResult(source)
+      continue
+    }
+    queuePage("find", source, { pattern: command.pattern })
+  }
+
+  if ((commands.screenshot?.length ?? 0) > 0) {
+    warnings.push(SCREENSHOT_UNSUPPORTED)
+  }
+
+  for (const command of commands.finance ?? []) {
+    remoteOperations.push({ ...command, type: "finance" })
+  }
+  for (const command of commands.weather ?? []) {
+    remoteOperations.push({ ...command, type: "weather" })
+  }
+  for (const command of commands.sports ?? []) {
+    remoteOperations.push({ ...command, type: "sports" })
+  }
+  for (const command of commands.time ?? []) {
+    output.push(formatTime(command.utc_offset, now))
+  }
+
+  for (const commandName of Object.keys(commands)) {
+    if (!KNOWN_COMMANDS.has(commandName)) {
+      warnings.push(
+        `Unsupported by GitHub Copilot web search: ${commandName}. Do not retry this operation.`,
+      )
+    }
+  }
+
+  const externalWebAccess = request.settings?.external_web_access
+  const liveAccess =
+    externalWebAccess === undefined
+    || externalWebAccess === true
+    || externalWebAccess === "live"
+
+  if (remoteOperations.length > 0 && !liveAccess) {
+    warnings.push(
+      `GitHub Copilot alpha search supports live retrieval only; external_web_access=${JSON.stringify(externalWebAccess)} is unsupported. Do not retry this request in this mode.`,
+    )
+  }
+
+  if (remoteOperations.length > 0 && liveAccess) {
+    const model = alphaSearchFallbackDependencies.resolveMappedModel(
+      request.model,
+    )
+    const selectedModel =
+      alphaSearchFallbackDependencies.findEndpointModel(model)
+    if (!selectedModel?.supported_endpoints?.includes("/responses")) {
+      return invalidRequest(
+        c,
+        `Model '${model}' does not support the Copilot Responses endpoint required for alpha search`,
+      )
+    }
+
+    const instruction = buildInstruction(
+      remoteOperations,
+      commands.response_length,
+    )
+    const sessionId = getUUID(request.id)
+    const requestId = generateRequestIdFromPayload(
+      { messages: `${turn.number}:${instruction}` },
+      sessionId,
+    )
+    const responsesPayload: ResponsesPayload = {
+      model,
+      input: instruction,
+      tools: [
+        buildResponsesWebSearchTool({
+          allowedDomains: request.settings?.filters?.allowed_domains,
+          blockedDomains: request.settings?.filters?.blocked_domains,
+          userLocation: request.settings?.user_location,
+          searchContextSize: request.settings?.search_context_size,
+        }),
+      ],
+      tool_choice: "required",
+      store: false,
+      stream: false,
+      include: ["web_search_call.action.sources"],
+      reasoning: request.reasoning as ResponsesPayload["reasoning"],
+      max_output_tokens: request.max_output_tokens,
+    }
+
+    debugJson(
+      logger,
+      "Alpha search Copilot Responses request:",
+      responsesPayload,
+    )
+    const result = (await alphaSearchFallbackDependencies.createResponses(
+      responsesPayload,
+      {
+        vision: false,
+        initiator: "agent",
+        transport: "http",
+        requestId,
+        sessionId,
+      },
+    )) as ResponsesResult
+    debugJson(logger, "Alpha search Copilot Responses result:", result)
+
+    alphaSearchFallbackDependencies.createUsageRecorder(
+      model,
+      sessionId,
+    )({
+      ...normalizeResponsesUsage(result.usage),
+      total_nano_aiu: normalizeOptionalToken(
+        result.copilot_usage?.total_nano_aiu,
+      ),
+    })
+
+    const extracted = extractWebSearchResult(result)
+    const citedSources = extracted.sources.filter(
+      (source) => source.snippet !== undefined,
+    )
+    const relevantSources =
+      citedSources.length > 0 ? citedSources : extracted.sources
+    consola.log(
+      `--> web search: operations=${[
+        ...new Set(remoteOperations.map((operation) => operation.type)),
+      ].join(
+        ",",
+      )} queries=${JSON.stringify(extracted.queries)} sources=${relevantSources.length}`,
+    )
+    const remoteReferences = relevantSources
+      .map((source) => addUrlReference(session, source, turn))
+      .filter((reference): reference is UrlReference => Boolean(reference))
+    const activeRemoteReferences = (): Array<UrlReference> =>
+      remoteReferences.filter(
+        (reference) =>
+          session.referencesById.get(reference.result.ref_id) === reference,
+      )
+    for (const reference of activeRemoteReferences()) includeResult(reference)
+
+    const answerText =
+      extracted.answerText || "GitHub Copilot web search returned no text."
+    const markdownReferences =
+      remotePages.length === 0 ?
+        []
+      : extractMarkdownSources(answerText)
+          .map((source) => addUrlReference(session, source, turn))
+          .filter((reference): reference is UrlReference => Boolean(reference))
+    for (const reference of markdownReferences) includeResult(reference)
+    if (remotePages.length === 0) output.push(answerText)
+
+    for (const [index, page] of remotePages.entries()) {
+      const target =
+        addUrlReference(
+          session,
+          {
+            url: page.source.result.url,
+            title: page.source.result.title,
+            snippet: answerText,
+          },
+          turn,
+        ) ?? page.source
+      includeResult(target)
+      const snapshotLinks = [
+        ...new Map(
+          [...markdownReferences, ...activeRemoteReferences()]
+            .filter(
+              (reference) =>
+                reference.result.url !== target.result.url
+                && session.referencesById.get(reference.result.ref_id)
+                  === reference,
+            )
+            .map((reference) => [reference.result.url, reference] as const),
+        ).values(),
+      ]
+
+      if (page.kind === "find") {
+        output.push(
+          `Find results for ${JSON.stringify(page.pattern ?? "")} in ${target.result.url}:\n${answerText}`,
+        )
+        if (!findSnapshotByUrl(session, target.result.url)) {
+          addSnapshot(
+            session,
+            target,
+            turn.number,
+            index,
+            answerText,
+            snapshotLinks,
+          )
+        }
+        continue
+      }
+
+      const snapshot = addSnapshot(
+        session,
+        target,
+        turn.number,
+        index,
+        answerText,
+        snapshotLinks,
+      )
+      output.push(renderSnapshot(snapshot, page.lineno))
+    }
+
+    const activeSources = activeRemoteReferences()
+    if (activeSources.length > 0) {
+      output.push(
+        [
+          "Sources:",
+          ...activeSources.map(
+            (reference) =>
+              `- [${reference.result.ref_id}] ${reference.result.title} — ${reference.result.url}`,
+          ),
+        ].join("\n"),
+      )
+    }
+  }
+
+  output.push(...warnings)
+  if (output.length === 0) {
+    output.push("No supported search operations were requested.")
+  }
+
+  const response: AlphaSearchResponse = {
+    encrypted_output: null,
+    output: output.join("\n\n"),
+    results: [...resultReferences.values()]
+      .filter(
+        (reference) =>
+          session.referencesById.get(reference.result.ref_id) === reference,
+      )
+      .map(({ result }) => result),
+  }
+  return c.json(response)
+}

--- a/src/routes/alpha-search/route.ts
+++ b/src/routes/alpha-search/route.ts
@@ -1,6 +1,10 @@
 import { Hono, type Context } from "hono"
 
-import type { ResolvedProviderConfig } from "~/lib/config"
+import {
+  isAlphaSearchResponsesFallbackEnabled,
+  isResponsesApiWebSearchEnabled,
+  type ResolvedProviderConfig,
+} from "~/lib/config"
 import { forwardError } from "~/lib/error"
 import { createHandlerLogger, debugJsonAsync } from "~/lib/logger"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
@@ -8,6 +12,7 @@ import type {
   AlphaSearchRequest,
   AlphaSearchResponse,
 } from "~/routes/alpha-search/alpha-search-types"
+import { handleCopilotAlphaSearch } from "~/routes/alpha-search/copilot-fallback"
 import { forwardCodexAlphaSearch } from "~/services/codex/alpha-search"
 import { createProviderProxyResponse } from "~/services/providers/provider-proxy"
 
@@ -34,6 +39,12 @@ export async function handleCodexAlphaSearch(
   const codexProviderConfig =
     resolvedProviderConfig ?? (await resolveProviderConfig("codex"))
   if (!codexProviderConfig) {
+    if (
+      isAlphaSearchResponsesFallbackEnabled()
+      && isResponsesApiWebSearchEnabled()
+    ) {
+      return await handleCopilotAlphaSearch(c)
+    }
     return c.json(
       {
         error: {

--- a/src/routes/messages/web-search/backend.ts
+++ b/src/routes/messages/web-search/backend.ts
@@ -6,13 +6,14 @@ import type {
 export interface WebSearchSource {
   url: string
   title: string
+  snippet?: string
   page_age?: string | null
 }
 
 export interface WebSearchExtract {
   /** The grounded answer text produced by the GPT backend (with inline cites). */
   answerText: string
-  /** Deduped sources extracted from url_citation annotations. */
+  /** Deduped citation and included action sources. */
   sources: Array<WebSearchSource>
   /** Search queries the backend actually ran. */
   queries: Array<string>
@@ -22,15 +23,18 @@ export interface WebSearchToolConfig {
   allowedDomains?: Array<string>
   blockedDomains?: Array<string>
   userLocation?: Record<string, unknown>
+  searchContextSize?: "low" | "medium" | "high"
 }
 
 interface UrlCitationAnnotation {
   type: "url_citation"
   url: string
   title?: string
+  start_index?: number
+  end_index?: number
 }
 
-/** Builds the Responses API web_search tool object from the Anthropic config. */
+/** Builds the Responses API web_search tool object from normalized config. */
 export const buildResponsesWebSearchTool = (
   config: WebSearchToolConfig,
 ): Record<string, unknown> => {
@@ -44,6 +48,9 @@ export const buildResponsesWebSearchTool = (
   }
   if (Object.keys(filters).length > 0) tool.filters = filters
   if (config.userLocation) tool.user_location = config.userLocation
+  if (config.searchContextSize) {
+    tool.search_context_size = config.searchContextSize
+  }
   return tool
 }
 
@@ -76,7 +83,16 @@ const collectTextParts = (
       if (!isValidUrlCitation(annotation, seenUrls)) continue
       const ann = annotation
       seenUrls.add(ann.url)
-      sources.push({ url: ann.url, title: ann.title ?? ann.url })
+      const start = Math.max(0, (ann.start_index ?? 0) - 120)
+      const end = Math.min(
+        block.text?.length ?? 0,
+        (ann.end_index ?? block.text?.length ?? 0) + 120,
+      )
+      sources.push({
+        url: ann.url,
+        title: ann.title ?? ann.url,
+        snippet: block.text?.slice(start, end).trim(),
+      })
     }
   }
   return { textParts, sources }
@@ -110,13 +126,26 @@ export const extractWebSearchResult = (
       const collected = collectTextParts(item.content, seenUrls)
       textParts.push(...collected.textParts)
       sources.push(...collected.sources)
-      continue
     }
+  }
+
+  for (const item of result.output) {
     if ((item as { type?: string }).type === "web_search_call") {
-      collectQuery(
-        item as { action?: { query?: string; queries?: Array<string> } },
-        queries,
-      )
+      const action = (
+        item as {
+          action?: {
+            query?: string
+            queries?: Array<string>
+            sources?: Array<{ url?: string }>
+          }
+        }
+      ).action
+      collectQuery({ action }, queries)
+      for (const source of action?.sources ?? []) {
+        if (!source.url || seenUrls.has(source.url)) continue
+        seenUrls.add(source.url)
+        sources.push({ url: source.url, title: source.url })
+      }
     }
   }
 

--- a/tests/alpha-search.test.ts
+++ b/tests/alpha-search.test.ts
@@ -2,12 +2,19 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 
 import type { ResolvedProviderConfig } from "../src/lib/config"
+import type {
+  ResponsesPayload,
+  ResponsesResult,
+} from "../src/services/copilot/create-responses"
 
 const actualConfigModule = await import("../src/lib/config")
 const actualTokenModule = await import("../src/lib/token")
 
 let codexProviderConfig: ResolvedProviderConfig | null = null
 let openrouterProviderConfig: ResolvedProviderConfig | null = null
+let alphaSearchResponsesFallbackEnabled = false
+let responsesApiWebSearchEnabled = true
+let modelMappings: Record<string, string> = {}
 
 await mock.module("~/lib/config", () => ({
   ...actualConfigModule,
@@ -21,6 +28,10 @@ await mock.module("~/lib/config", () => ({
     if (provider === "openrouter") return openrouterProviderConfig
     return null
   },
+  isAlphaSearchResponsesFallbackEnabled: () =>
+    alphaSearchResponsesFallbackEnabled,
+  isResponsesApiWebSearchEnabled: () => responsesApiWebSearchEnabled,
+  resolveMappedModel: (model: string) => modelMappings[model] ?? model,
 }))
 
 await mock.module("~/lib/token", () => ({
@@ -29,6 +40,7 @@ await mock.module("~/lib/token", () => ({
 }))
 
 const { state } = await import("../src/lib/state")
+const { HTTPError } = await import("../src/lib/error")
 const { forwardCodexAlphaSearch, resolveCodexAlphaSearchUrl } = await import(
   "../src/services/codex/alpha-search"
 )
@@ -36,11 +48,17 @@ const { forwardCodexModels, getModels, resolveCodexModelsUrl } = await import(
   "../src/services/codex/get-models"
 )
 const { alphaSearchRoutes } = await import("../src/routes/alpha-search/route")
+const { alphaSearchFallbackDependencies, resetAlphaSearchFallbackState } =
+  await import("../src/routes/alpha-search/copilot-fallback")
 const { providerAlphaSearchRoutes } = await import(
   "../src/routes/provider/alpha-search/route"
 )
 
 const originalFetch = globalThis.fetch
+const originalFallbackDependencies = { ...alphaSearchFallbackDependencies }
+const originalModels = state.models
+const originalCopilotToken = state.copilotToken
+const originalMacMachineId = state.macMachineId
 const alphaSearchPayload = {
   id: "search-request-id",
   model: "gpt-5.6-sol",
@@ -83,6 +101,100 @@ const alphaSearchPayload = {
   },
   max_output_tokens: 10_000,
 }
+
+function createFallbackPayload(
+  commands: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "fallback-session",
+    model: "gpt-5.6-sol",
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Use the search commands." }],
+      },
+    ],
+    commands,
+    settings: {
+      external_web_access: "live",
+    },
+    max_output_tokens: 4096,
+    ...overrides,
+  }
+}
+
+function createResponsesResult(
+  options: {
+    answer?: string
+    citations?: boolean
+    query?: string
+    sources?: Array<{ title?: string; url: string }>
+  } = {},
+): ResponsesResult {
+  const answer = options.answer ?? "Grounded search answer."
+  const sources = options.sources ?? [
+    { title: "Example", url: "https://example.com/result" },
+  ]
+  return {
+    id: "resp-alpha-search",
+    object: "response",
+    created_at: 0,
+    model: "gpt-5.6-sol",
+    output: [
+      {
+        type: "web_search_call",
+        id: "search-call",
+        status: "completed",
+        action: {
+          type: "search",
+          query: options.query ?? "search query",
+          sources: sources.map(({ url }) => ({ type: "url", url })),
+        },
+      },
+      {
+        id: "message-alpha-search",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [
+          {
+            type: "output_text",
+            text: answer,
+            annotations:
+              options.citations === false ?
+                []
+              : sources.map((source) => ({
+                  type: "url_citation",
+                  title: source.title,
+                  url: source.url,
+                  start_index: 0,
+                  end_index: answer.length,
+                })),
+          },
+        ],
+      },
+    ],
+    output_text: answer,
+    status: "completed",
+    usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    parallel_tool_calls: true,
+    temperature: null,
+    tool_choice: "required",
+    tools: [],
+    top_p: null,
+  }
+}
+
+const createResponsesMock = mock(
+  (_payload: ResponsesPayload, _options: unknown): Promise<ResponsesResult> =>
+    Promise.resolve(createResponsesResult()),
+)
 const fetchMock = mock(
   (_url: string | URL | Request, _init?: RequestInit): Promise<Response> =>
     Promise.resolve(
@@ -104,7 +216,25 @@ function createApp() {
   return app
 }
 
+function requestFallback(
+  body: unknown,
+  path = "/alpha/search",
+): Promise<Response> {
+  codexProviderConfig = null
+  alphaSearchResponsesFallbackEnabled = true
+  return Promise.resolve(
+    createApp().request(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
 beforeEach(() => {
+  alphaSearchResponsesFallbackEnabled = false
+  responsesApiWebSearchEnabled = true
+  modelMappings = {}
   codexProviderConfig = {
     apiKey: "unused-provider-key",
     authType: "oauth2",
@@ -121,8 +251,36 @@ beforeEach(() => {
   }
   state.codexAccessToken = "codex-access-token"
   state.codexAccountId = "account-123"
+  state.copilotToken = "copilot-token"
+  state.macMachineId = "machine-id"
+  state.models = {
+    object: "list",
+    data: [
+      {
+        capabilities: { limits: {} },
+        id: "gpt-5.6-sol",
+        supported_endpoints: ["/responses"],
+      },
+      {
+        capabilities: { limits: {} },
+        id: "gpt-search-mapped",
+        supported_endpoints: ["/responses"],
+      },
+    ],
+  } as typeof state.models
   state.verbose = false
   fetchMock.mockClear()
+  createResponsesMock.mockClear()
+  alphaSearchFallbackDependencies.createResponses = createResponsesMock as never
+  alphaSearchFallbackDependencies.findEndpointModel = (model) =>
+    state.models?.data.find((candidate) => candidate.id === model)
+  alphaSearchFallbackDependencies.createUsageRecorder = (() =>
+    () => {}) as never
+  alphaSearchFallbackDependencies.now = () =>
+    Date.parse("2026-08-03T12:00:00.000Z")
+  alphaSearchFallbackDependencies.resolveMappedModel = (model) =>
+    modelMappings[model] ?? model
+  resetAlphaSearchFallbackState()
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
     fetchMock as unknown as typeof fetch
 })
@@ -131,8 +289,13 @@ afterEach(() => {
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
   state.codexAccessToken = undefined
   state.codexAccountId = undefined
+  state.copilotToken = originalCopilotToken
+  state.macMachineId = originalMacMachineId
+  state.models = originalModels
   state.verbose = false
   openrouterProviderConfig = null
+  Object.assign(alphaSearchFallbackDependencies, originalFallbackDependencies)
+  resetAlphaSearchFallbackState()
 })
 
 describe("Codex alpha search URL", () => {
@@ -342,5 +505,619 @@ describe("Codex alpha search forwarding", () => {
       },
     })
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("Copilot alpha search fallback", () => {
+  test("requires both flags and never overrides an available Codex provider", async () => {
+    alphaSearchResponsesFallbackEnabled = true
+    responsesApiWebSearchEnabled = false
+    codexProviderConfig = null
+
+    const disabledResponse = await createApp().request("/alpha/search", {
+      method: "POST",
+      body: JSON.stringify(
+        createFallbackPayload({ search_query: [{ q: "disabled" }] }),
+      ),
+    })
+
+    expect(disabledResponse.status).toBe(404)
+    expect(createResponsesMock).not.toHaveBeenCalled()
+
+    responsesApiWebSearchEnabled = true
+    codexProviderConfig = {
+      apiKey: "codex-key",
+      authType: "oauth2",
+      baseUrl: "https://chatgpt.com/backend-api",
+      name: "codex",
+      type: "openai-responses",
+    }
+    const codexResponse = await createApp().request("/alpha/search", {
+      method: "POST",
+      body: JSON.stringify(
+        createFallbackPayload({ search_query: [{ q: "codex wins" }] }),
+      ),
+    })
+
+    expect(codexResponse.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(createResponsesMock).not.toHaveBeenCalled()
+  })
+
+  test("supports the v1 alias and translates the complete live request", async () => {
+    modelMappings = { "gpt-5.6-sol": "gpt-search-mapped" }
+    const response = await requestFallback(
+      createFallbackPayload(
+        {
+          search_query: [
+            {
+              q: "OpenAI news",
+              recency: 7,
+              domains: ["openai.com"],
+              future_query_field: "kept",
+            },
+          ],
+          finance: [{ ticker: "MSFT", type: "equity", market: "USA" }],
+          weather: [
+            {
+              location: "US, CA, San Francisco",
+              start: "2026-08-03",
+              duration: 3,
+            },
+          ],
+          sports: [
+            {
+              tool: "sports",
+              fn: "schedule",
+              league: "nba",
+              team: "GSW",
+              date_from: "2026-08-03",
+              date_to: "2026-08-10",
+              num_games: 2,
+              locale: "en-US",
+            },
+          ],
+          response_length: "long",
+        },
+        {
+          reasoning: { effort: "high", summary: "concise" },
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "Recent text" }],
+              future_input_field: "kept",
+            },
+          ],
+          settings: {
+            external_web_access: "live",
+            search_context_size: "high",
+            filters: {
+              allowed_domains: ["openai.com"],
+              blocked_domains: ["example.net"],
+            },
+            user_location: {
+              type: "approximate",
+              country: "US",
+              city: "San Francisco",
+            },
+          },
+          max_output_tokens: 2048,
+          future_request_field: "kept",
+        },
+      ),
+      "/v1/alpha/search",
+    )
+
+    expect(response.status).toBe(200)
+    expect(createResponsesMock).toHaveBeenCalledTimes(1)
+    const [payload, options] = createResponsesMock.mock.calls[0] ?? []
+    expect(payload?.model).toBe("gpt-search-mapped")
+    expect(payload?.tool_choice).toBe("required")
+    expect(payload?.store).toBe(false)
+    expect(payload?.stream).toBe(false)
+    expect(payload?.include).toEqual(["web_search_call.action.sources"])
+    expect(payload?.reasoning).toEqual({ effort: "high", summary: "concise" })
+    expect(payload?.max_output_tokens).toBe(2048)
+    expect(payload?.tools).toEqual([
+      {
+        type: "web_search",
+        filters: {
+          allowed_domains: ["openai.com"],
+          blocked_domains: ["example.net"],
+        },
+        user_location: {
+          type: "approximate",
+          country: "US",
+          city: "San Francisco",
+        },
+        search_context_size: "high",
+      },
+    ])
+    expect(options).toMatchObject({
+      initiator: "agent",
+      transport: "http",
+      vision: false,
+    })
+
+    const instruction = payload?.input as string
+    expect(instruction).not.toContain("Recent text")
+    expect(instruction).toContain('"recency": 7')
+    expect(instruction).toContain('"market": "USA"')
+    expect(instruction).toContain('"team": "GSW"')
+    expect(instruction).toContain("Requested response length: long")
+
+    const body = (await response.json()) as {
+      encrypted_output: string | null
+      output: string
+      results: Array<Record<string, string>>
+    }
+    expect(body.encrypted_output).toBeNull()
+    expect(body.output).toContain("Grounded search answer.")
+    expect(body.results).toHaveLength(1)
+    expect(body.results[0]).toEqual({
+      domain: "example.com",
+      ref_id: "turn0search0",
+      snippet: "Grounded search answer.",
+      title: "Example",
+      type: "text_result",
+      url: "https://example.com/result",
+    })
+  })
+
+  test("prefers cited sources and falls back to included action sources", async () => {
+    const resultWithUncitedSource = createResponsesResult({
+      sources: [
+        { title: "Cited", url: "https://example.com/cited" },
+        { title: "Uncited", url: "https://example.com/uncited" },
+      ],
+    })
+    const message = resultWithUncitedSource.output[1] as {
+      content: Array<{ annotations?: Array<unknown> }>
+    }
+    message.content[0].annotations = message.content[0].annotations?.slice(0, 1)
+    createResponsesMock.mockImplementationOnce(() =>
+      Promise.resolve(resultWithUncitedSource),
+    )
+    const citedResponse = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "cited source" }] }),
+    )
+    const citedBody = (await citedResponse.json()) as {
+      results: Array<Record<string, string>>
+    }
+    expect(citedBody.results.map(({ url }) => url)).toEqual([
+      "https://example.com/cited",
+    ])
+
+    createResponsesMock.mockImplementationOnce(() =>
+      Promise.resolve(
+        createResponsesResult({
+          citations: false,
+          sources: [{ url: "https://example.com/action-source" }],
+        }),
+      ),
+    )
+    const fallbackResponse = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "action source" }] }),
+    )
+    const fallbackBody = (await fallbackResponse.json()) as {
+      results: Array<Record<string, string>>
+    }
+
+    expect(fallbackBody.results).toEqual([
+      {
+        type: "text_result",
+        domain: "example.com",
+        ref_id: "turn1search0",
+        snippet: "https://example.com/action-source",
+        title: "https://example.com/action-source",
+        url: "https://example.com/action-source",
+      },
+    ])
+  })
+
+  test("rejects malformed fallback payloads without parsing native Codex traffic", async () => {
+    codexProviderConfig = null
+    alphaSearchResponsesFallbackEnabled = true
+    const invalidJson = await createApp().request("/alpha/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    })
+    expect(invalidJson.status).toBe(400)
+
+    const missingFields = await requestFallback({ commands: {} })
+    expect(missingFields.status).toBe(400)
+    const missingFieldsBody = (await missingFields.json()) as {
+      error: { message: string }
+    }
+    expect(missingFieldsBody.error.message).toContain(
+      "Invalid alpha search request",
+    )
+
+    const invalidOffset = await requestFallback(
+      createFallbackPayload({ time: [{ utc_offset: "UTC+3" }] }),
+    )
+    expect(invalidOffset.status).toBe(400)
+    expect(createResponsesMock).not.toHaveBeenCalled()
+  })
+
+  test("returns one no-retry warning per unsupported command type", async () => {
+    const mixedResponse = await requestFallback(
+      createFallbackPayload(
+        {
+          search_query: [{ q: "supported" }],
+          image_query: [{ q: "one" }, { q: "two" }],
+          screenshot: [
+            { ref_id: "https://example.com/a.pdf", pageno: 0 },
+            { ref_id: "https://example.com/a.pdf", pageno: 1 },
+          ],
+          future_visual_search: [{ q: "future" }],
+        },
+        {
+          input: "Run search_query, image_query, and screenshot.",
+        },
+      ),
+    )
+    const mixedBody = (await mixedResponse.json()) as { output: string }
+
+    expect(mixedResponse.status).toBe(200)
+    expect(createResponsesMock).toHaveBeenCalledTimes(1)
+    expect(mixedBody.output.match(/image_query/gu)).toHaveLength(1)
+    expect(mixedBody.output.match(/screenshot/gu)).toHaveLength(1)
+    expect(mixedBody.output.match(/future_visual_search/gu)).toHaveLength(1)
+    expect(mixedBody.output).toContain("Do not retry")
+    const instruction = createResponsesMock.mock.calls[0]?.[0].input as string
+    expect(instruction).toContain("complete and exclusive")
+    expect(instruction).toContain('"type": "search_query"')
+    expect(instruction).not.toContain('"type": "image_query"')
+    expect(instruction).not.toContain('"type": "screenshot"')
+
+    const unsupportedOnly = await requestFallback(
+      createFallbackPayload(
+        {
+          image_query: [{ q: "images" }],
+          screenshot: [{ ref_id: "turn0view0", pageno: 0 }],
+        },
+        { id: "unsupported-only" },
+      ),
+    )
+    expect(unsupportedOnly.status).toBe(200)
+    expect(createResponsesMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("never turns explicit non-live modes into live retrieval", async () => {
+    for (const [index, mode] of [false, "cached", "indexed"].entries()) {
+      const response = await requestFallback(
+        createFallbackPayload(
+          { search_query: [{ q: "must not run" }] },
+          {
+            id: `non-live-${index}`,
+            settings: { external_web_access: mode },
+          },
+        ),
+      )
+      const body = (await response.json()) as { output: string }
+      expect(response.status).toBe(200)
+      expect(body.output).toContain("supports live retrieval only")
+      expect(body.output).toContain("Do not retry")
+    }
+    expect(createResponsesMock).not.toHaveBeenCalled()
+  })
+
+  test("computes time locally with the injected clock", async () => {
+    const response = await requestFallback(
+      createFallbackPayload({
+        time: [{ utc_offset: "+03:00" }, { utc_offset: "-04:30" }],
+      }),
+    )
+    const body = (await response.json()) as { output: string }
+
+    expect(response.status).toBe(200)
+    expect(body.output).toContain("Time at UTC+03:00: 2026-08-03 15:00:00")
+    expect(body.output).toContain("Time at UTC-04:30: 2026-08-03 07:30:00")
+    expect(createResponsesMock).not.toHaveBeenCalled()
+  })
+
+  test("requires a Responses-capable mapped Copilot model", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: { limits: {} },
+          id: "gpt-5.6-sol",
+          supported_endpoints: ["/chat/completions"],
+        },
+      ],
+    } as typeof state.models
+
+    const response = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "unsupported endpoint" }] }),
+    )
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: { message: string } }
+    expect(body.error.message).toContain(
+      "does not support the Copilot Responses endpoint",
+    )
+    expect(createResponsesMock).not.toHaveBeenCalled()
+  })
+
+  test("keeps stable deduplicated search references across turns", async () => {
+    createResponsesMock.mockImplementation(() =>
+      Promise.resolve(
+        createResponsesResult({
+          sources: [
+            { title: "First title", url: "https://example.com/same" },
+            { title: "Duplicate", url: "https://example.com/same" },
+          ],
+        }),
+      ),
+    )
+
+    const first = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "first" }] }),
+    )
+    const second = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "second" }] }),
+    )
+    const firstBody = (await first.json()) as {
+      results: Array<{ ref_id: string }>
+    }
+    const secondBody = (await second.json()) as {
+      results: Array<{ ref_id: string }>
+    }
+
+    expect(firstBody.results).toHaveLength(1)
+    expect(firstBody.results[0]?.ref_id).toBe("turn0search0")
+    expect(secondBody.results[0]?.ref_id).toBe("turn0search0")
+  })
+
+  test("opens, line-windows, finds, and clicks through bounded cached views", async () => {
+    const results = [
+      createResponsesResult({
+        answer: "Search answer",
+        sources: [{ title: "Page A", url: "https://example.com/a" }],
+      }),
+      createResponsesResult({
+        answer:
+          "zero\nneedle line\ntwo\n[Page B](https://example.com/b)\n([Page A](https://example.com/a))",
+        sources: [{ title: "Page A", url: "https://example.com/a" }],
+      }),
+      createResponsesResult({
+        answer: "Clicked page text",
+        sources: [{ title: "Page C", url: "https://example.com/c" }],
+      }),
+    ]
+    let responseIndex = 0
+    createResponsesMock.mockImplementation(() =>
+      Promise.resolve(results[responseIndex++] ?? results.at(-1)!),
+    )
+
+    const search = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "page a" }] }),
+    )
+    const searchBody = (await search.json()) as {
+      results: Array<{ ref_id: string }>
+    }
+    expect(searchBody.results[0]?.ref_id).toBe("turn0search0")
+
+    const opened = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn0search0" }] }),
+    )
+    const openedBody = (await opened.json()) as { output: string }
+    expect(openedBody.output).toContain("Open turn1view0")
+    expect(openedBody.output).toContain("L1: needle line")
+    expect(openedBody.output).toContain(
+      "[0] Page B — https://example.com/b (turn1search0)",
+    )
+    expect(openedBody.output).not.toContain("Page A — https://example.com/a)")
+
+    const windowed = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn1view0", lineno: 1 }] }),
+    )
+    expect(((await windowed.json()) as { output: string }).output).toContain(
+      "L1: needle line",
+    )
+
+    const found = await requestFallback(
+      createFallbackPayload({
+        find: [{ ref_id: "turn1view0", pattern: "needle" }],
+      }),
+    )
+    expect(((await found.json()) as { output: string }).output).toContain(
+      'Find results for "needle" in turn1view0',
+    )
+
+    const clicked = await requestFallback(
+      createFallbackPayload({ click: [{ ref_id: "turn1view0", id: 0 }] }),
+    )
+    expect(((await clicked.json()) as { output: string }).output).toContain(
+      "Clicked page text",
+    )
+    expect(createResponsesMock).toHaveBeenCalledTimes(3)
+
+    const cachedClick = await requestFallback(
+      createFallbackPayload({ click: [{ ref_id: "turn1view0", id: 0 }] }),
+    )
+    expect(((await cachedClick.json()) as { output: string }).output).toContain(
+      "Clicked page text",
+    )
+    expect(createResponsesMock).toHaveBeenCalledTimes(3)
+  })
+
+  test("uses Copilot find only when opened text cannot satisfy it locally", async () => {
+    const results = [
+      createResponsesResult({
+        answer: "Search answer",
+        sources: [{ title: "Find page", url: "https://example.com/find" }],
+      }),
+      createResponsesResult({
+        answer: "Remote matching context",
+        sources: [{ title: "Find page", url: "https://example.com/find" }],
+      }),
+    ]
+    let responseIndex = 0
+    createResponsesMock.mockImplementation(() =>
+      Promise.resolve(results[responseIndex++] ?? results.at(-1)!),
+    )
+
+    await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "find page" }] }),
+    )
+    const found = await requestFallback(
+      createFallbackPayload({
+        find: [{ ref_id: "turn0search0", pattern: "remote" }],
+      }),
+    )
+    expect(((await found.json()) as { output: string }).output).toContain(
+      "Remote matching context",
+    )
+    const payload = createResponsesMock.mock.calls[1]?.[0]
+    const instruction = payload?.input as string
+    expect(instruction).toContain('"type": "find"')
+
+    const cached = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn0search0" }] }),
+    )
+    expect(((await cached.json()) as { output: string }).output).toContain(
+      "Remote matching context",
+    )
+    expect(createResponsesMock).toHaveBeenCalledTimes(2)
+  })
+
+  test("isolates, expires, and evicts session references", async () => {
+    const search = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "session reference" }] }),
+    )
+    expect(search.status).toBe(200)
+
+    const crossSession = await requestFallback(
+      createFallbackPayload(
+        { open: [{ ref_id: "turn0search0" }] },
+        { id: "different-session" },
+      ),
+    )
+    expect(
+      ((await crossSession.json()) as { output: string }).output,
+    ).toContain("unavailable or expired")
+    expect(createResponsesMock).toHaveBeenCalledTimes(1)
+
+    alphaSearchFallbackDependencies.now = () =>
+      Date.parse("2026-08-03T13:00:00.000Z")
+    const expired = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn0search0" }] }),
+    )
+    expect(((await expired.json()) as { output: string }).output).toContain(
+      "unavailable or expired",
+    )
+
+    alphaSearchFallbackDependencies.now = () =>
+      Date.parse("2026-08-03T14:00:00.000Z")
+    await requestFallback(
+      createFallbackPayload(
+        { search_query: [{ q: "oldest" }] },
+        { id: "oldest-session" },
+      ),
+    )
+    for (let index = 0; index < 128; index += 1) {
+      await requestFallback(
+        createFallbackPayload(
+          { time: [{ utc_offset: "+00:00" }] },
+          { id: `new-session-${index}` },
+        ),
+      )
+    }
+    const evicted = await requestFallback(
+      createFallbackPayload(
+        { open: [{ ref_id: "turn0search0" }] },
+        { id: "oldest-session" },
+      ),
+    )
+    expect(((await evicted.json()) as { output: string }).output).toContain(
+      "unavailable or expired",
+    )
+  })
+
+  test("enforces URL-reference and opened-snapshot ceilings", async () => {
+    const manySources = Array.from({ length: 257 }, (_, index) => ({
+      title: `Source ${index}`,
+      url: `https://example.com/source-${index}`,
+    }))
+    createResponsesMock.mockImplementation(() =>
+      Promise.resolve(createResponsesResult({ sources: manySources })),
+    )
+    const manySourceResponse = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "many sources" }] }),
+    )
+    expect(
+      ((await manySourceResponse.json()) as { results: Array<unknown> })
+        .results,
+    ).toHaveLength(256)
+    const evictedReference = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn0search0" }] }),
+    )
+    expect(
+      ((await evictedReference.json()) as { output: string }).output,
+    ).toContain("unavailable or expired")
+
+    resetAlphaSearchFallbackState()
+    createResponsesMock.mockImplementation(() =>
+      Promise.resolve(
+        createResponsesResult({
+          answer: "Opened text",
+          sources: [],
+        }),
+      ),
+    )
+    for (let index = 0; index < 17; index += 1) {
+      await requestFallback(
+        createFallbackPayload({
+          open: [{ ref_id: `https://example.com/page-${index}` }],
+        }),
+      )
+    }
+    const evictedSnapshot = await requestFallback(
+      createFallbackPayload({ open: [{ ref_id: "turn0view0" }] }),
+    )
+    expect(
+      ((await evictedSnapshot.json()) as { output: string }).output,
+    ).toContain("unavailable or expired")
+  })
+
+  test("surfaces missing Copilot auth and upstream rate-limit headers", async () => {
+    createResponsesMock.mockImplementationOnce(() =>
+      Promise.reject(new Error("Copilot token not found")),
+    )
+    const missingAuth = await requestFallback(
+      createFallbackPayload({ search_query: [{ q: "auth" }] }),
+    )
+    expect(missingAuth.status).toBe(500)
+    const missingAuthBody = (await missingAuth.json()) as {
+      error: { message: string }
+    }
+    expect(missingAuthBody.error.message).toContain("Copilot token not found")
+
+    alphaSearchFallbackDependencies.createResponses = (() =>
+      Promise.reject(
+        new HTTPError(
+          "rate limited",
+          new Response('{"error":"rate limited"}', {
+            status: 429,
+            headers: {
+              "retry-after": "12",
+              "x-ratelimit-remaining": "0",
+            },
+          }),
+        ),
+      )) as never
+    const rateLimited = await requestFallback(
+      createFallbackPayload(
+        { search_query: [{ q: "rate limit" }] },
+        { id: "rate-limited-session" },
+      ),
+    )
+    expect(rateLimited.status).toBe(429)
+    expect(rateLimited.headers.get("retry-after")).toBe("12")
+    expect(rateLimited.headers.get("x-ratelimit-remaining")).toBe("0")
   })
 })

--- a/tests/web-search-fulfill.test.ts
+++ b/tests/web-search-fulfill.test.ts
@@ -19,6 +19,10 @@ import {
   stripWebSearchServerTool,
   webSearchFlowDependencies,
 } from "~/routes/messages/web-search/fulfill"
+import {
+  buildResponsesWebSearchTool,
+  extractWebSearchResult,
+} from "~/routes/messages/web-search/backend"
 
 const webSearchTool = {
   type: "web_search_20250305",
@@ -389,6 +393,51 @@ describe("resolveWebSearchRoute", () => {
         responsesWebSearchEnabled: false,
       }).kind,
     ).toBe("strip")
+  })
+})
+
+describe("Responses web search backend", () => {
+  it("passes supported search settings to the hosted tool", () => {
+    expect(
+      buildResponsesWebSearchTool({
+        allowedDomains: ["openai.com"],
+        blockedDomains: ["example.com"],
+        searchContextSize: "high",
+        userLocation: { type: "approximate", country: "US" },
+      }),
+    ).toEqual({
+      type: "web_search",
+      filters: {
+        allowed_domains: ["openai.com"],
+        blocked_domains: ["example.com"],
+      },
+      search_context_size: "high",
+      user_location: { type: "approximate", country: "US" },
+    })
+  })
+
+  it("keeps citation snippets and uncited included sources", () => {
+    const result = makeResponsesResult()
+    ;(
+      result.output[0] as unknown as {
+        action: { query: string; sources: Array<{ url: string }> }
+      }
+    ).action.sources = [
+      { url: "https://nodejs.org" },
+      { url: "https://example.com/included" },
+    ]
+
+    expect(extractWebSearchResult(result).sources).toEqual([
+      {
+        url: "https://nodejs.org",
+        title: "Node.js",
+        snippet: "Node.js 24 is the latest LTS.",
+      },
+      {
+        url: "https://example.com/included",
+        title: "https://example.com/included",
+      },
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

- add an opt-in GitHub Copilot Responses fallback for Codex's standalone `/alpha/search` protocol
- recognize every current Codex Search command, including stateful `open`, `click`, and `find`
- preserve authenticated Codex forwarding and provider-scoped route behavior
- return explicit no-retry output for unsupported visual operations and non-live retrieval modes
- add structured references, bounded session state, concise search logging, documentation, and comprehensive tests

## Problem

Codex Responses Lite exposes search as the standalone `web.run` tool and sends
its commands to `POST /alpha/search`. `copilot-api` currently forwards this
endpoint when an authenticated Codex provider is available, but Copilot-provider
users receive a 404.

The current Codex protocol includes search, open, click, find, finance, weather,
sports, time, image search, and PDF screenshots:

https://github.com/openai/codex/blob/57f42a81131ccf5933e7ec5dc659c381eeb5d72b/codex-rs/codex-api/src/search.rs#L8-L305

GitHub Copilot already supports hosted web search through `/responses`, and
`copilot-api` already has Responses search extraction from #273. This PR adapts
that existing path to the standalone Codex protocol without adding another
search service or crawler.

## Solution

When no authenticated Codex provider is available, top-level
`POST /alpha/search` and `POST /v1/alpha/search` can use an opt-in Copilot
fallback.

Routing precedence remains:

1. forward unchanged to an authenticated Codex provider
2. use the enabled Copilot Responses fallback
3. retain the existing 404

Provider-scoped alpha-search routes are unchanged.

The adapter:

- validates the current `SearchRequest` shape with the existing Zod dependency
- retains unknown request fields for forward compatibility
- treats the command payload as authoritative instead of replaying unrelated
  conversation text into the search prompt
- applies model mappings and requires the selected model to support `/responses`
- preserves reasoning, output-token limits, domain filters, approximate location,
  and search-context size
- sends at most one non-streaming Copilot Responses request per alpha-search request
- sets `tool_choice: "required"`, `store: false`, and requests action sources
- records normal Copilot usage and upstream rate-limit behavior
- returns `encrypted_output`, model-visible `output`, and opaque `text_result`
  records containing stable references, URLs, titles, domains, and citation snippets

### Command behavior

| Command | Behavior |
| --- | --- |
| `search_query` | Runs Copilot hosted search and assigns stable `turn{n}search{i}` references |
| `open` | Resolves a reference or literal URL, returns line-numbered grounded text, and stores a bounded view snapshot |
| `click` | Resolves a numbered link from an opened view and handles it as `open` |
| `find` | Searches cached view text locally first, then asks Copilot for matching page context |
| `finance` | Translates ticker, asset type, and market constraints to hosted search |
| `weather` | Translates location, start date, and duration to hosted search |
| `sports` | Translates league, schedule/standings, team, opponent, date, and locale constraints |
| `time` | Computes the requested UTC-offset time locally without invoking Copilot |
| `image_query` | Returns successful unsupported/no-retry output because Copilot web search has no image-search result protocol |
| `screenshot` | Returns successful unsupported/no-retry output because Copilot cannot return PDF page screenshots |
| unknown future commands | Return successful unsupported/no-retry output instead of causing retry loops |

Mixed requests execute supported commands and append one warning per unsupported
command type.

Explicit `external_web_access: false`, `cached`, or `indexed` requests are never
silently upgraded to live retrieval.

### Reference state

References use bounded process-local state keyed by `SearchRequest.id`:

- sliding one-hour session TTL
- maximum 128 sessions
- maximum 256 URL references per session
- maximum 16 opened-page snapshots per session
- maximum 20,000 characters per snapshot
- lazy expiry and oldest-entry eviction, with no background timer
- synchronous turn reservation to avoid duplicate IDs during concurrent requests
- URL deduplication with stable references

Restarting the proxy intentionally invalidates this ephemeral state. Missing or
expired references return recoverable output instructing Codex to search or open
the URL again.

Copilot performs all remote retrieval. The proxy does not fetch arbitrary URLs,
which avoids adding a crawler, HTML parser, dependency, or new SSRF boundary.

## Configuration

The fallback is disabled by default and requires Responses web search to remain
enabled:

```json
{
  "useResponsesApiWebSearch": true,
  "alphaSearchResponsesFallback": true
}
```

Codex must be configured to use standalone live search:

```toml
web_search = "live"

[model_providers.copilot_api]
supports_standalone_web_search = true
```

README documentation is included in English and Chinese.

## Observability

Completed remote searches emit one concise line containing the operation types,
queries Copilot actually executed, and the number of returned sources:

```text
--> web search: operations=search_query queries=["actual query"] sources=1
```

Answer text, snippets, and URLs are not written to the normal terminal log.

## Limitations

- the fallback supports live retrieval only
- `image_query` and `screenshot` are recognized but cannot be fulfilled by
  GitHub Copilot web search
- references are intentionally process-local and expire after one hour
- opened-page content is Copilot-grounded text, not locally fetched raw HTML
- the feature remains default-off while compatibility is evaluated

## Validation

Automated verification:

- `bun test tests/alpha-search.test.ts` — 28 passed
- `bun test tests/web-search-fulfill.test.ts` — 15 passed
- `bun run lint:all` — passed
- `bun run typecheck` — passed
- `bun test` — 491 passed, 0 failed
- `bun run build` — passed
- `git diff --check` — passed
- core changed search modules have 97.19–100% line coverage

Live verification with `gpt-5.6-sol`:

- direct `/alpha/search` returned cited structured references
- Codex invoked standalone Search successfully
- `search_query` produced stable source references
- `open` produced a numbered view with resolvable links
- cached `find` returned immediately without another Copilot request
- query text and source counts appeared in the new concise log output

No dependencies or version changes are included.

Fixes #311
