### PR TITLE
fix(messages): keep signature-only thinking blocks on replay

### DIFF
--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -883,9 +883,16 @@ const filterAssistantThinkingBlocks = (
     if (msg.role === "assistant" && Array.isArray(msg.content)) {
       msg.content = msg.content.filter((block) => {
         if (block.type !== "thinking") return true
+        // Keep signature-only blocks (empty `thinking` text). On the Anthropic
+        // Messages API it is the signature, not the summary text, that carries
+        // reasoning continuity across turns, and Copilot's upstream frequently
+        // returns thinking blocks with an empty summary. Requiring non-empty
+        // text here silently drops those blocks — and their signatures — so the
+        // reasoning chain breaks on exactly those turns. The `"Thinking..."`
+        // placeholder is still excluded: it is a synthetic value this project
+        // adds for clients that filter empty text, never real model output.
         return (
-          block.thinking
-          && block.thinking !== "Thinking..."
+          block.thinking !== "Thinking..."
           && block.signature
           && !block.signature.includes("@")
         )

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1137,6 +1137,56 @@ describe("prepareMessagesApiPayload", () => {
     expect(payload.output_config).toEqual({ effort: "xhigh" })
   })
 
+  test("keeps signature-only thinking blocks", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-5",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "",
+              signature: "sig-only",
+            },
+            {
+              type: "text",
+              text: "Visible text",
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: "hello",
+        },
+      ],
+    }
+
+    prepareMessagesApiPayload(payload, {
+      capabilities: {
+        supports: {
+          adaptive_thinking: true,
+        },
+      },
+    } as never)
+
+    expect(payload.messages[0]).toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "",
+          signature: "sig-only",
+        },
+        {
+          type: "text",
+          text: "Visible text",
+        },
+      ],
+    })
+  })
+
   test("sets summarized display for Claude versions at least 4.7", () => {
     const models = [
       "claude-opus-4.7",


### PR DESCRIPTION
## Summary

`filterAssistantThinkingBlocks` requires a non-empty `thinking` string. Any assistant thinking block whose **summary text is empty** is therefore removed before the payload reaches the Copilot Messages API — **and its `signature` is removed with it**.

On the Anthropic Messages API the **signature**, not the summary text, is what carries reasoning continuity across turns. Copilot's upstream returns summary-less thinking blocks a large fraction of the time, so a client that faithfully replays the assistant turn still loses the reasoning chain on those turns — **silently, with no error**.

```ts
// src/routes/messages/preprocess.ts
return (
  block.thinking            // <-- empty summary => whole block (incl. signature) dropped
  && block.thinking !== "Thinking..."
  && block.signature
  && !block.signature.includes("@")
)
```

## Evidence

Environment: built from source, GitHub Copilot enterprise seat, `claude-opus-5`, non-streaming `/v1/messages`.

**1. Summary-less thinking blocks are common, and they originate upstream.**

Calling the Copilot endpoint **directly** (gateway bypassed), replicating exactly what this project sends, shows the summary text is returned only when *both* `thinking.display: "summarized"` **and** `output_config.effort` are present — and even then only intermittently:

| direct request | non-empty summary |
|---|---|
| no `thinking`, no `output_config` | 0/6 |
| `display: "summarized"` only | 0/3 |
| `output_config.effort: "high"` only | 0/2 |
| **both** (what this project sends) | **2/4** |

The `signature` was present in **every** response, and `usage.output_tokens_details.thinking_tokens` was always > 0 — the model reasons and is billed for it every time; only the human-readable summary is intermittent.

**2. Wire-level proof of the drop**, from this project's own `--verbose` `messages-handler` log, comparing `Anthropic request payload` (what the client sent) with `Translated Messages payload` (what is forwarded upstream). Values are `(thinking text length, signature length)`:

| client sent | forwarded upstream | result |
|---|---|---|
| `[(0, 336)]` | `[]` | **dropped** |
| `[(0, 336)]` | `[]` | **dropped** |
| `[(293, 2856)]` | `[(293, 2856)]` | kept |

The client replayed the assistant turn verbatim in every case. Only the summary-less blocks were lost.

**3. Upstream accepts signature-only blocks.** With this patch applied:

| client sent | forwarded upstream | upstream response |
|---|---|---|
| `[(0, 420)]` | `[(0, 420)]` | **200**, `stop_reason: end_turn` |

So the block being discarded locally is one the upstream is happy to accept. Multi-turn tool loops (4 turns each) on `claude-opus-5` and `gpt-5.6-sol` completed with **0 errors** after the change.

## Why this is safe

- The `"Thinking..."` placeholder stays excluded. It is synthetic — added by this project in `getAnthropicThinkBlocks` for clients that filter empty text — and is never real model output.
- Signature validity checks (`block.signature`, no `@`) are unchanged, so GPT-format signatures are still rejected on the Claude path.
- The existing test `"strips cache_control scope, filters thinking blocks, and enables adaptive thinking"` covers the placeholder case, the normal case, and the `@`-signature case; all three behave identically and it passes unmodified.

## Testing

- `bun test` — **554 pass, 0 fail** (58 files)
- `bun run typecheck` — clean
- New regression test: `keeps signature-only thinking blocks`

## Note for maintainer (not changed here)

`src/routes/messages/non-stream-translation.ts` carries the same predicate on the chat-completions path:

```ts
thinkingBlocks = thinkingBlocks.filter(
  (b) => b.thinking && b.thinking !== THINKING_TEXT && b.signature && !b.signature.includes("@"),
)
...
const signature = thinkingBlocks.find((b) => b.signature)?.signature
```

Because `signature` is derived *after* that filter, a summary-less block loses `reasoning_opaque` there too. A separate `.filter` already guards `thinkingContents`, so dropping `b.thinking &&` would preserve the signature while still leaving `allThinkingContent` undefined. I have not measured that path, so I left it untouched — happy to extend this PR if you'd like it covered.
