### PR TITLE
Harden Responses transport lifecycle and buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,14 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
     },
     "useMessagesApi": true,
     "useResponsesApiWebSocket": true,
+    "responsesTransport": {
+      "headersTimeoutMs": 30000,
+      "streamInactivityTimeoutMs": 300000,
+      "websocketOpenTimeoutMs": 30000,
+      "websocketPoolIdleTimeoutMs": 60000,
+      "websocketMaxBufferedBytes": 8388608,
+      "websocketMaxBufferedMessages": 1024
+    },
     "useResponsesApiWebSearch": true,
     "alphaSearchCodexPriority": true,
     "alphaSearchModel": "gpt-5-mini",
@@ -689,6 +697,7 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
   - **Configuration values:** `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.
 - **useMessagesApi:** When `true`, Claude-family models that support Copilot's native `/v1/messages` endpoint will use the Messages API; otherwise they fall back to `/chat/completions`. Set to `false` to disable Messages API routing and always use `/chat/completions`. Defaults to `true`.
 - **useResponsesApiWebSocket:** When `true`, Responses API requests use Copilot's websocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable websocket routing and use HTTP `/responses` whenever the selected model supports it. Defaults to `true`. If the Responses API WebSocket gets closed, it is usually caused by your own network. If you are using a VPN, try switching to a different node.
+- **responsesTransport:** Positive integer lifecycle and buffering limits for every upstream Responses transport. Invalid, zero, or negative values fall back to the defaults shown above. `headersTimeoutMs` covers connection setup through receipt of HTTP response headers; it is not a total generation deadline. `streamInactivityTimeoutMs` is reset by every HTTP body chunk or WebSocket message, allowing long generations to continue while they remain active. `websocketOpenTimeoutMs` limits the WebSocket handshake, while `websocketPoolIdleTimeoutMs` controls only completed, reusable pooled sockets. The byte and message limits bound queued WebSocket events; exceeding either limit fails that stream and invalidates its socket rather than dropping or reordering events.
 - **useResponsesApiWebSearch:** When `true`, the server keeps Responses API tools with `type: "web_search"` and forwards them upstream. Set to `false` to strip those tools from `/responses` payloads. Defaults to `true`.
 - **alphaSearchCodexPriority:** Defaults to `true`. Top-level alpha-search requests prefer the Codex alpha-search endpoint because it does not consume provider quota. If Codex is unavailable, or this setting is `false`, requests with a `provider/model` alias other than `codex/model` use that provider's `/v1/responses` endpoint, and requests without a provider prefix use GitHub Copilot Responses web search. The adapter recognizes every current Codex search command; unsupported `image_query` and `screenshot` operations return successful no-retry tool output.
 - **alphaSearchModel:** Native Responses search model used when a Messages-backed Responses Lite model cannot run Responses web search directly. Defaults to `gpt-5-mini`; it may be a regular Copilot model or an `openai-responses` `provider/model` alias. Set it to an empty string to disable this redirect, in which case alpha-search requests for those models return an invalid-request error.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -689,6 +689,14 @@ Copilot API 现在使用子命令结构，主要命令包括：
     },
     "useMessagesApi": true,
     "useResponsesApiWebSocket": true,
+    "responsesTransport": {
+      "headersTimeoutMs": 30000,
+      "streamInactivityTimeoutMs": 300000,
+      "websocketOpenTimeoutMs": 30000,
+      "websocketPoolIdleTimeoutMs": 60000,
+      "websocketMaxBufferedBytes": 8388608,
+      "websocketMaxBufferedMessages": 1024
+    },
     "useResponsesApiWebSearch": true,
     "alphaSearchCodexPriority": true,
     "alphaSearchModel": "gpt-5-mini",
@@ -729,6 +737,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
   - **配置可选值：** `none`、`minimal`、`low`、`medium`、`high`、`xhigh`、`max`。
 - **useMessagesApi：** 当为 `true` 时，支持 Copilot 原生 `/v1/messages` 的 Claude 系模型会走 Messages API；否则回退到 `/chat/completions`。设为 `false` 可禁用 Messages API 路由，始终使用 `/chat/completions`。默认值为 `true`。
 - **useResponsesApiWebSocket：** 当为 `true` 时，Responses API 请求会优先对声明了 `ws:/responses` 的模型使用 Copilot websocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用 websocket 路由，并在模型支持 `/responses` 时使用 HTTP `/responses`。默认值为 `true`。如果遇到 Responses API WebSocket closed，一般是自己的网络问题。如果使用了 VPN，建议切换节点。
+- **responsesTransport：** 所有上游 Responses transport 共用的生命周期与缓冲区正整数限制。无效值、零或负数会回退到上面列出的默认值。`headersTimeoutMs` 从连接建立开始计算，到收到 HTTP 响应头为止，并不是整个生成过程的总时限。每收到一个 HTTP body chunk 或 WebSocket message 都会重置 `streamInactivityTimeoutMs`，因此持续活跃的长推理任务不会被短总时限中断。`websocketOpenTimeoutMs` 限制 WebSocket 握手时间；`websocketPoolIdleTimeoutMs` 只控制已正常完成且可复用的空闲连接。WebSocket 队列同时受字节数和消息数上限约束；超过任一上限时会终止该 stream 并使 socket 失效，而不会丢弃或重排事件。
 - **useResponsesApiWebSearch：** 当为 `true` 时，服务端会保留 Responses API 中 `type: "web_search"` 的工具并透传到上游。设为 `false` 则会从 `/responses` payload 中移除这些工具。默认值为 `true`。
 - **alphaSearchCodexPriority：** 默认值为 `true`。顶层 alpha-search 请求优先使用 Codex alpha-search 端点，因为它不会消耗 provider 配额。若 Codex 不可用，或该配置设为 `false`，使用非 `codex/model` 的 `provider/model` 别名的请求会调用目标 provider 的 `/v1/responses` 端点，没有 provider 前缀的请求使用 GitHub Copilot Responses web search。该适配器会识别当前所有 Codex search command；不受支持的 `image_query` 和 `screenshot` 会返回成功且明确要求不要重试的 tool output。
 - **alphaSearchModel：** Messages-backed 的 Responses Lite 模型不能直接执行 Responses web search 时使用的原生 Responses 搜索模型，默认值为 `gpt-5-mini`。可以配置普通 Copilot 模型或 `openai-responses` 类型的 `provider/model`；设为空字符串可禁用，此时这类模型的 alpha-search 请求会返回参数错误。

--- a/desktop/tsconfig.node.json
+++ b/desktop/tsconfig.node.json
@@ -39,6 +39,7 @@
     "../src/services/copilot/get-models.ts",
     "../src/services/get-vscode-version.ts",
     "../src/services/github/**/*.ts",
+    "../src/services/responses-http.ts",
     "../src/services/responses-websocket-helpers.ts",
     "../src/services/responses-websocket.ts",
     "../src/lib/electron-fetch.ts"

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -23,6 +23,7 @@ export interface AppConfig {
   >
   useMessagesApi?: boolean
   useResponsesApiWebSocket?: boolean
+  responsesTransport?: ResponsesTransportConfig
   anthropicApiKey?: string
   useResponsesApiWebSearch?: boolean
   alphaSearchCodexPriority?: boolean
@@ -49,6 +50,24 @@ export interface ContextManagementConfig {
   messages?: boolean
   responses?: boolean
 }
+
+export interface ResponsesTransportConfig {
+  headersTimeoutMs?: number
+  streamInactivityTimeoutMs?: number
+  websocketMaxBufferedBytes?: number
+  websocketMaxBufferedMessages?: number
+  websocketOpenTimeoutMs?: number
+  websocketPoolIdleTimeoutMs?: number
+}
+
+export const defaultResponsesTransportConfig = {
+  headersTimeoutMs: 30_000,
+  streamInactivityTimeoutMs: 5 * 60 * 1000,
+  websocketMaxBufferedBytes: 8 * 1024 * 1024,
+  websocketMaxBufferedMessages: 1024,
+  websocketOpenTimeoutMs: 30_000,
+  websocketPoolIdleTimeoutMs: 60_000,
+} satisfies Required<ResponsesTransportConfig>
 
 export interface ModelConfig {
   temperature?: number
@@ -130,6 +149,7 @@ export const defaultConfig: AppConfig = {
   },
   useMessagesApi: true,
   useResponsesApiWebSocket: true,
+  responsesTransport: defaultResponsesTransportConfig,
   useResponsesApiWebSearch: true,
   alphaSearchCodexPriority: true,
   alphaSearchModel: "gpt-5-mini",
@@ -246,6 +266,9 @@ function mergeDefaultConfig(config: AppConfig): {
   const contextManagement = normalizeContextManagementConfig(
     config.contextManagement,
   )
+  const responsesTransport = normalizeResponsesTransportConfig(
+    config.responsesTransport,
+  )
   const defaultContextManagementConfig = defaultConfig.contextManagement ?? {}
 
   const missingExtraPromptModels = Object.keys(defaultExtraPrompts).filter(
@@ -267,12 +290,18 @@ function mergeDefaultConfig(config: AppConfig): {
   const hasResponsesApiCompactThresholdChanges =
     missingResponsesApiCompactThresholdModels.length > 0
   const hasContextManagementChanges = missingContextManagementKeys.length > 0
+  const hasResponsesTransportChanges = Object.entries(responsesTransport).some(
+    ([key, value]) =>
+      config.responsesTransport?.[key as keyof ResponsesTransportConfig]
+      !== value,
+  )
 
   if (
     !hasExtraPromptChanges
     && !hasReasoningEffortChanges
     && !hasResponsesApiCompactThresholdChanges
     && !hasContextManagementChanges
+    && !hasResponsesTransportChanges
   ) {
     return { mergedConfig: config, changed: false }
   }
@@ -296,6 +325,7 @@ function mergeDefaultConfig(config: AppConfig): {
         ...defaultModelReasoningEfforts,
         ...modelReasoningEfforts,
       },
+      responsesTransport,
     },
     changed: true,
   }
@@ -398,6 +428,44 @@ export function isResponsesApiWebSocketEnabled(): boolean {
   const config = getConfig()
   return config.useResponsesApiWebSocket ?? true
 }
+
+export function getResponsesTransportConfig(): Required<ResponsesTransportConfig> {
+  return normalizeResponsesTransportConfig(getConfig().responsesTransport)
+}
+
+export const normalizeResponsesTransportConfig = (
+  configured: ResponsesTransportConfig | undefined,
+): Required<ResponsesTransportConfig> => ({
+  headersTimeoutMs: positiveIntegerOrDefault(
+    configured?.headersTimeoutMs,
+    defaultResponsesTransportConfig.headersTimeoutMs,
+  ),
+  streamInactivityTimeoutMs: positiveIntegerOrDefault(
+    configured?.streamInactivityTimeoutMs,
+    defaultResponsesTransportConfig.streamInactivityTimeoutMs,
+  ),
+  websocketMaxBufferedBytes: positiveIntegerOrDefault(
+    configured?.websocketMaxBufferedBytes,
+    defaultResponsesTransportConfig.websocketMaxBufferedBytes,
+  ),
+  websocketMaxBufferedMessages: positiveIntegerOrDefault(
+    configured?.websocketMaxBufferedMessages,
+    defaultResponsesTransportConfig.websocketMaxBufferedMessages,
+  ),
+  websocketOpenTimeoutMs: positiveIntegerOrDefault(
+    configured?.websocketOpenTimeoutMs,
+    defaultResponsesTransportConfig.websocketOpenTimeoutMs,
+  ),
+  websocketPoolIdleTimeoutMs: positiveIntegerOrDefault(
+    configured?.websocketPoolIdleTimeoutMs,
+    defaultResponsesTransportConfig.websocketPoolIdleTimeoutMs,
+  ),
+})
+
+const positiveIntegerOrDefault = (value: unknown, fallback: number): number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ?
+    Math.floor(value)
+  : fallback
 
 export function getAnthropicApiKey(): string | undefined {
   const config = getConfig()

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -16,6 +16,13 @@ export async function forwardError(
   c: Context,
   error: unknown,
 ): Promise<Response> {
+  if (c.req.raw.signal.aborted || isAbortError(error)) {
+    return new Response(null, {
+      status: 499,
+      statusText: "Client Closed Request",
+    })
+  }
+
   consola.error("Error occurred:", error)
 
   if (error instanceof HTTPError) {
@@ -57,3 +64,6 @@ export async function forwardError(
     500,
   )
 }
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && error.name === "AbortError"

--- a/src/routes/alpha-search/alpha-search-responses.ts
+++ b/src/routes/alpha-search/alpha-search-responses.ts
@@ -131,6 +131,8 @@ export const alphaSearchResponsesDependencies = {
   findEndpointModel,
   now: (): number => Date.now(),
   resolveMappedModel,
+  resolveEffectiveProviderType,
+  resolveProviderConfig,
   createUsageRecorder: (
     model: string,
     sessionId: string,
@@ -616,7 +618,8 @@ async function resolveRemoteModel(
       request.model
     : alphaSearchResponsesDependencies.resolveMappedModel(request.model)
   if (provider) {
-    const providerConfig = await resolveProviderConfig(provider)
+    const providerConfig =
+      await alphaSearchResponsesDependencies.resolveProviderConfig(provider)
     if (!providerConfig) {
       return c.json(
         {
@@ -630,7 +633,10 @@ async function resolveRemoteModel(
     }
 
     if (
-      resolveEffectiveProviderType(providerConfig, model) !== "openai-responses"
+      alphaSearchResponsesDependencies.resolveEffectiveProviderType(
+        providerConfig,
+        model,
+      ) !== "openai-responses"
     ) {
       return invalidRequest(
         c,
@@ -692,6 +698,7 @@ async function requestProviderSearch(
     providerConfig,
     payload,
     c.req.raw.headers,
+    { signal: c.req.raw.signal },
   )
   if (!upstreamResponse.ok) {
     throw new HTTPError(
@@ -721,6 +728,7 @@ async function requestCopilotSearch(
   model: string,
   requestId: string,
   sessionId: string,
+  signal?: AbortSignal,
 ): Promise<ResponsesResult> {
   debugJson(logger, "Alpha search Copilot Responses request:", payload)
   const result = (await alphaSearchResponsesDependencies.createResponses(
@@ -731,6 +739,7 @@ async function requestCopilotSearch(
       transport: "http",
       requestId,
       sessionId,
+      signal,
     },
   )) as ResponsesResult
   debugJson(logger, "Alpha search Copilot Responses result:", result)
@@ -778,7 +787,13 @@ async function requestRemoteSearch(
     )
   }
 
-  return await requestCopilotSearch(payload, target.model, requestId, sessionId)
+  return await requestCopilotSearch(
+    payload,
+    target.model,
+    requestId,
+    sessionId,
+    c.req.raw.signal,
+  )
 }
 
 function getActiveRemoteReferences(

--- a/src/routes/alpha-search/route.ts
+++ b/src/routes/alpha-search/route.ts
@@ -25,6 +25,17 @@ const logger = createHandlerLogger("alpha-search-handler")
 
 export const alphaSearchRoutes = new Hono()
 
+export const alphaSearchRouteDependencies = {
+  findEndpointModel,
+  forwardCodexAlphaSearch,
+  getAlphaSearchModel,
+  handleAlphaSearchResponses,
+  isAlphaSearchCodexPriorityEnabled,
+  resolveEffectiveProviderType,
+  resolveMappedModel,
+  resolveProviderConfig,
+}
+
 function parseDebugBody<T>(body: string): T | string {
   try {
     return JSON.parse(body) as T
@@ -40,7 +51,8 @@ async function forwardCodexAlphaSearchRequest(
     body: parseDebugBody<AlphaSearchRequest>(await request.clone().text()),
   }))
 
-  const upstreamResponse = await forwardCodexAlphaSearch(request)
+  const upstreamResponse =
+    await alphaSearchRouteDependencies.forwardCodexAlphaSearch(request)
   await debugJsonAsync(logger, "alpha_search.codex.response", async () => ({
     body: parseDebugBody<AlphaSearchResponse>(
       await upstreamResponse.clone().text(),
@@ -72,7 +84,8 @@ async function handleCodexRequest(
   resolvedProviderConfig?: ResolvedProviderConfig,
 ): Promise<Response> {
   const codexProviderConfig =
-    resolvedProviderConfig ?? (await resolveProviderConfig("codex"))
+    resolvedProviderConfig
+    ?? (await alphaSearchRouteDependencies.resolveProviderConfig("codex"))
   if (!codexProviderConfig) {
     return c.json(
       {
@@ -138,7 +151,8 @@ export async function handleAlphaSearchRequest(
 
   const requestedModel = payload.model
 
-  payload.model = resolveMappedModel(requestedModel)
+  payload.model =
+    alphaSearchRouteDependencies.resolveMappedModel(requestedModel)
   if (payload.model !== requestedModel) {
     consola.debug(
       `Resolved model mapping: ${requestedModel} -> ${payload.model}`,
@@ -157,8 +171,9 @@ export async function handleAlphaSearchRequest(
     }
   }
 
-  if (isAlphaSearchCodexPriorityEnabled()) {
-    const codexProviderConfig = await resolveProviderConfig("codex")
+  if (alphaSearchRouteDependencies.isAlphaSearchCodexPriorityEnabled()) {
+    const codexProviderConfig =
+      await alphaSearchRouteDependencies.resolveProviderConfig("codex")
     if (codexProviderConfig) {
       if (!payload.model.startsWith("gpt")) {
         payload.model = "gpt-5.6-luna"
@@ -173,14 +188,15 @@ export async function handleAlphaSearchRequest(
     resolvedRequestedModel,
   )
   if (messagesBackedModel) {
-    const searchModel = getAlphaSearchModel()
+    const searchModel = alphaSearchRouteDependencies.getAlphaSearchModel()
     if (!searchModel) {
       return invalidRequest(
         c,
         "alphaSearchModel is disabled; Messages-backed Codex models require a native Responses search model",
       )
     }
-    const resolvedSearchModel = resolveMappedModel(searchModel)
+    const resolvedSearchModel =
+      alphaSearchRouteDependencies.resolveMappedModel(searchModel)
     if (!(await isNativeResponsesModel(resolvedSearchModel))) {
       return invalidRequest(
         c,
@@ -206,13 +222,13 @@ export async function handleAlphaSearchRequest(
     messagesBackedModel ? payload.model : requestedModel
 
   if (providerModelAlias) {
-    return await handleAlphaSearchResponses(c, {
+    return await alphaSearchRouteDependencies.handleAlphaSearchResponses(c, {
       provider: providerModelAlias.provider,
       request: payload,
     })
   }
 
-  return await handleAlphaSearchResponses(c, {
+  return await alphaSearchRouteDependencies.handleAlphaSearchResponses(c, {
     request: {
       ...payload,
       model: fallbackRequestedModel,
@@ -223,18 +239,24 @@ export async function handleAlphaSearchRequest(
 async function isMessagesBackedModel(model: string): Promise<boolean> {
   const providerAlias = parseProviderModelAlias(model)
   if (providerAlias) {
-    const providerConfig = await resolveProviderConfig(providerAlias.provider)
+    const providerConfig =
+      await alphaSearchRouteDependencies.resolveProviderConfig(
+        providerAlias.provider,
+      )
     if (!providerConfig) return false
-    const effectiveType = resolveEffectiveProviderType(
-      providerConfig,
-      providerAlias.model,
-    )
+    const effectiveType =
+      alphaSearchRouteDependencies.resolveEffectiveProviderType(
+        providerConfig,
+        providerAlias.model,
+      )
     return (
       effectiveType === "anthropic" || effectiveType === "openai-compatible"
     )
   }
 
-  const endpoints = findEndpointModel(model)?.supported_endpoints ?? []
+  const endpoints =
+    alphaSearchRouteDependencies.findEndpointModel(model)?.supported_endpoints
+    ?? []
   return (
     (endpoints.includes("/v1/messages")
       || endpoints.includes("/chat/completions"))
@@ -246,15 +268,22 @@ async function isMessagesBackedModel(model: string): Promise<boolean> {
 async function isNativeResponsesModel(model: string): Promise<boolean> {
   const providerAlias = parseProviderModelAlias(model)
   if (providerAlias) {
-    const providerConfig = await resolveProviderConfig(providerAlias.provider)
+    const providerConfig =
+      await alphaSearchRouteDependencies.resolveProviderConfig(
+        providerAlias.provider,
+      )
     return (
       providerConfig !== null
-      && resolveEffectiveProviderType(providerConfig, providerAlias.model)
-        === "openai-responses"
+      && alphaSearchRouteDependencies.resolveEffectiveProviderType(
+        providerConfig,
+        providerAlias.model,
+      ) === "openai-responses"
     )
   }
 
-  const endpoints = findEndpointModel(model)?.supported_endpoints ?? []
+  const endpoints =
+    alphaSearchRouteDependencies.findEndpointModel(model)?.supported_endpoints
+    ?? []
   return endpoints.includes("/responses") || endpoints.includes("ws:/responses")
 }
 

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -246,6 +246,7 @@ export const handleWithResponsesApi = async (
     {
       vision,
       initiator,
+      signal: c.req?.raw?.signal,
       transport,
       ...requestOptions,
     },

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -387,6 +387,7 @@ export const handleWebSearchViaResponses = async (
       subagentMarker: options.subagentMarker,
       requestId: options.requestId,
       sessionId: options.sessionId,
+      signal: c.req?.raw?.signal,
       compactType: options.compactType,
     },
   )

--- a/src/routes/provider/alpha-search/route.ts
+++ b/src/routes/provider/alpha-search/route.ts
@@ -13,11 +13,19 @@ const logger = createHandlerLogger("provider-alpha-search-handler")
 
 export const providerAlphaSearchRoutes = new Hono()
 
+export const providerAlphaSearchRouteDependencies = {
+  createProviderProxyResponse,
+  forwardProviderAlphaSearch,
+  handleAlphaSearchRequest,
+  resolveProviderConfig,
+}
+
 providerAlphaSearchRoutes.post("/", async (c) => {
   const provider = c.req.param("provider") ?? ""
 
   try {
-    const providerConfig = await resolveProviderConfig(provider)
+    const providerConfig =
+      await providerAlphaSearchRouteDependencies.resolveProviderConfig(provider)
     if (!providerConfig) {
       return c.json(
         {
@@ -31,7 +39,10 @@ providerAlphaSearchRoutes.post("/", async (c) => {
     }
 
     if (providerConfig.name === "codex") {
-      return await handleAlphaSearchRequest(c, providerConfig)
+      return await providerAlphaSearchRouteDependencies.handleAlphaSearchRequest(
+        c,
+        providerConfig,
+      )
     }
 
     await debugJsonAsync(logger, "provider.alpha_search.request", async () => ({
@@ -39,10 +50,11 @@ providerAlphaSearchRoutes.post("/", async (c) => {
       provider,
     }))
 
-    const upstreamResponse = await forwardProviderAlphaSearch(
-      providerConfig,
-      c.req.raw,
-    )
+    const upstreamResponse =
+      await providerAlphaSearchRouteDependencies.forwardProviderAlphaSearch(
+        providerConfig,
+        c.req.raw,
+      )
 
     await debugJsonAsync(
       logger,
@@ -54,7 +66,9 @@ providerAlphaSearchRoutes.post("/", async (c) => {
       }),
     )
 
-    return createProviderProxyResponse(upstreamResponse)
+    return providerAlphaSearchRouteDependencies.createProviderProxyResponse(
+      upstreamResponse,
+    )
   } catch (error) {
     logger.error("provider.alpha_search.error", { provider, error })
     return await forwardError(c, error)

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -273,6 +273,7 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
       responsesPayload,
       c.req.raw.headers,
       providerConfig.baseUrl,
+      { signal: c.req.raw.signal },
     )
 
     if (isResponsesStream(upstreamResponse)) {
@@ -307,6 +308,7 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
     providerConfig,
     responsesPayload,
     c.req.raw.headers,
+    { signal: c.req.raw.signal },
   )
 
   if (!upstreamResponse.ok) {
@@ -394,6 +396,7 @@ const handleOpenAIResponsesProviderMessages = async (
       responsesPayload,
       c.req.raw.headers,
       providerConfig.baseUrl,
+      { signal: c.req.raw.signal },
     )
 
     if (isResponsesStream(upstreamResponse)) {
@@ -443,6 +446,7 @@ const handleOpenAIResponsesProviderMessages = async (
     providerConfig,
     responsesPayload,
     c.req.raw.headers,
+    { signal: c.req.raw.signal },
   )
 
   if (!upstreamResponse.ok) {

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -96,6 +96,10 @@ import consola from "consola"
 
 const logger = createHandlerLogger("provider-messages-handler")
 
+export const providerMessagesHandlerDependencies = {
+  resolveProviderConfig,
+}
+
 export async function handleProviderMessages(
   c: Context<Env, "/:provider">,
 ): Promise<Response> {
@@ -125,7 +129,8 @@ export async function handleProviderMessagesForProvider(
   },
 ): Promise<Response> {
   const { payload, provider, usageEndpoint } = options
-  const providerConfig = await resolveProviderConfig(provider)
+  const providerConfig =
+    await providerMessagesHandlerDependencies.resolveProviderConfig(provider)
   if (!providerConfig) {
     return c.json(
       {

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -38,6 +38,10 @@ import type { ContentfulStatusCode } from "hono/utils/http-status"
 
 const logger = createHandlerLogger("provider-responses-handler")
 
+export const providerResponsesHandlerDependencies = {
+  resolveProviderConfig,
+}
+
 export async function handleProviderResponsesForProvider(
   c: Context,
   options: {
@@ -53,7 +57,8 @@ export async function handleProviderResponsesForProvider(
     provider,
   })
 
-  const providerConfig = await resolveProviderConfig(provider)
+  const providerConfig =
+    await providerResponsesHandlerDependencies.resolveProviderConfig(provider)
   if (!providerConfig) {
     return c.json(
       {

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -29,6 +29,7 @@ import type {
 } from "~/lib/types/responses"
 import { forwardCodexResponses } from "~/services/codex/create-responses"
 import { getModels as getCodexModels } from "~/services/codex/get-models"
+import { createResponsesSafeStream } from "~/services/responses-websocket-helpers"
 import {
   createProviderProxyResponse,
   forwardProviderResponses,
@@ -119,6 +120,7 @@ export async function handleProviderResponsesForProvider(
       payload,
       c.req.raw.headers,
       providerConfig.baseUrl,
+      { signal: c.req.raw.signal },
     )
     const recordUsage = createProviderResponsesUsageRecorder(
       payload,
@@ -144,6 +146,7 @@ export async function handleProviderResponsesForProvider(
     providerConfig,
     payload,
     c.req.raw.headers,
+    { signal: c.req.raw.signal },
   )
 
   if (!upstreamResponse.ok) {
@@ -161,11 +164,15 @@ export async function handleProviderResponsesForProvider(
   )
 
   if (payload.stream) {
-    return streamProviderResponses(c, getResponsesEvents(upstreamResponse), {
-      normalizeCodex: false,
-      provider,
-      recordUsage,
-    })
+    return streamProviderResponses(
+      c,
+      getResponsesEvents(upstreamResponse, c.req.raw.signal),
+      {
+        normalizeCodex: false,
+        provider,
+        recordUsage,
+      },
+    )
   }
 
   const responseBody = (await upstreamResponse
@@ -207,6 +214,7 @@ const streamProviderResponses = async (
   const iterator = upstreamResponse[Symbol.asyncIterator]()
   const firstResult = await iterator.next()
   if (firstResult.done) {
+    await iterator.return?.()
     throw new HTTPError(
       `Empty stream from ${options.provider} responses`,
       new Response("", { status: 502 }),
@@ -222,6 +230,7 @@ const streamProviderResponses = async (
     if (event?.type === "error") {
       const errorEvent = event
       const statusCode = errorEvent.status_code ?? 500
+      await iterator.return?.()
       return c.json(
         {
           error: {
@@ -279,6 +288,7 @@ const streamProviderResponses = async (
         await writeChunk(chunk)
       }
     } finally {
+      await iterator.return?.()
       options.recordUsage(usage)
     }
   })
@@ -321,5 +331,7 @@ const getResponsesStreamEventUsage = (
   return null
 }
 
-const getResponsesEvents = (response: Response): ResponsesStream =>
-  events(response)
+const getResponsesEvents = (
+  response: Response,
+  signal?: AbortSignal,
+): ResponsesStream => createResponsesSafeStream(events(response), { signal })

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -39,6 +39,7 @@ import {
   getResponsesTransportForModel,
   getResponsesRequestOptions,
   sanitizeOversizedInputImages,
+  sanitizeUnsupportedInputFields,
 } from "./utils"
 import consola from "consola"
 
@@ -130,6 +131,13 @@ export const handleResponses = async (c: Context) => {
     model: payload.model,
   })
 
+  const sanitizedUnsupportedFieldCount = sanitizeUnsupportedInputFields(payload)
+  if (sanitizedUnsupportedFieldCount > 0) {
+    logger.debug(
+      `Removed ${sanitizedUnsupportedFieldCount} unsupported input field(s) before forwarding to Copilot Responses`,
+    )
+  }
+
   removeUnsupportedTools(payload)
   fillEmptyNamespaceToolDescriptions(payload)
 
@@ -173,6 +181,7 @@ export const handleResponses = async (c: Context) => {
     subagentMarker,
     requestId,
     sessionId: fallbackSessionId,
+    signal: c.req.raw.signal,
     transport: responsesTransport,
   })
 
@@ -181,37 +190,43 @@ export const handleResponses = async (c: Context) => {
     return streamSSE(c, async (stream) => {
       const idTracker = createStreamIdTracker()
       let usage: UsageTokens = {}
+      const iterator = response[Symbol.asyncIterator]()
 
-      for await (const chunk of response) {
-        debugJson(logger, "Responses stream chunk:", chunk)
-        const parsedEvent = parseResponsesStreamEvent(chunk)
-        if (
-          parsedEvent?.type === "response.completed"
-          || parsedEvent?.type === "response.failed"
-          || parsedEvent?.type === "response.incomplete"
-        ) {
-          usage = {
-            ...normalizeResponsesUsage(parsedEvent.response.usage),
-            total_nano_aiu: normalizeOptionalToken(
-              parsedEvent.copilot_usage?.total_nano_aiu,
-            ),
+      try {
+        for await (const chunk of {
+          [Symbol.asyncIterator]: () => iterator,
+        }) {
+          debugJson(logger, "Responses stream chunk:", chunk)
+          const parsedEvent = parseResponsesStreamEvent(chunk)
+          if (
+            parsedEvent?.type === "response.completed"
+            || parsedEvent?.type === "response.failed"
+            || parsedEvent?.type === "response.incomplete"
+          ) {
+            usage = {
+              ...normalizeResponsesUsage(parsedEvent.response.usage),
+              total_nano_aiu: normalizeOptionalToken(
+                parsedEvent.copilot_usage?.total_nano_aiu,
+              ),
+            }
           }
+
+          const processedData = fixStreamIds(
+            (chunk as { data?: string }).data ?? "",
+            (chunk as { event?: string }).event,
+            idTracker,
+          )
+
+          await stream.writeSSE({
+            id: (chunk as { id?: string }).id,
+            event: (chunk as { event?: string }).event,
+            data: processedData,
+          })
         }
-
-        const processedData = fixStreamIds(
-          (chunk as { data?: string }).data ?? "",
-          (chunk as { event?: string }).event,
-          idTracker,
-        )
-
-        await stream.writeSSE({
-          id: (chunk as { id?: string }).id,
-          event: (chunk as { event?: string }).event,
-          data: processedData,
-        })
+      } finally {
+        await iterator.return?.()
+        recordUsage(usage)
       }
-
-      recordUsage(usage)
     })
   }
 

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -113,6 +113,37 @@ const REDACTED_IMAGE_PLACEHOLDER_DATA_URL =
     "OAuj2SEAAAAASUVORK5CYII=",
   ].join("")
 
+const COPILOT_UNSUPPORTED_INPUT_ITEM_FIELDS = [
+  "internal_chat_message_metadata_passthrough",
+] as const
+
+export const sanitizeUnsupportedInputFields = (
+  payload: ResponsesPayload,
+): number => {
+  if (!Array.isArray(payload.input)) {
+    return 0
+  }
+
+  let removedFieldCount = 0
+  for (const item of payload.input) {
+    if (typeof item !== "object" || item === null) {
+      continue
+    }
+
+    const record = item as Record<string, unknown>
+    for (const field of COPILOT_UNSUPPORTED_INPUT_ITEM_FIELDS) {
+      if (!Object.hasOwn(record, field)) {
+        continue
+      }
+
+      delete record[field]
+      removedFieldCount += 1
+    }
+  }
+
+  return removedFieldCount
+}
+
 export const sanitizeOversizedInputImages = (
   payload: ResponsesPayload,
   maxPromptImageSize?: number,

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -281,12 +281,52 @@ export async function forwardCodexResponses(
   }
 
   if (normalizedPayload.stream) {
-    return createResponsesSafeStream(events(response), {
-      signal: options.signal,
-    })
+    return createCodexResponsesHttpStream(response, options.signal)
   }
 
   return (await response.json()) as ResponsesResult
+}
+
+const createCodexResponsesHttpStream = async function* (
+  response: Response,
+  signal?: AbortSignal,
+): ResponsesStream {
+  const responseBody = response.body
+  if (!responseBody) {
+    return
+  }
+
+  const reader =
+    responseBody.getReader() as ReadableStreamDefaultReader<Uint8Array>
+  const readerBackedBody = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const result = await reader.read()
+      if (result.done) {
+        controller.close()
+        return
+      }
+
+      controller.enqueue(result.value)
+    },
+    async cancel(reason) {
+      await reader.cancel(reason)
+    },
+  })
+
+  try {
+    yield* createResponsesSafeStream(
+      events(new Response(readerBackedBody), signal),
+      { signal },
+    )
+  } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // The reader may already have failed or been cancelled downstream.
+    } finally {
+      reader.releaseLock()
+    }
+  }
 }
 
 const normalizeCodexResponsesPayload = (

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -13,7 +13,10 @@ import type {
   ResponsesTransport,
 } from "~/lib/types/responses"
 
-import { isResponsesApiWebSocketEnabled as isConfiguredResponsesApiWebSocketEnabled } from "~/lib/config"
+import {
+  getResponsesTransportConfig,
+  isResponsesApiWebSocketEnabled as isConfiguredResponsesApiWebSocketEnabled,
+} from "~/lib/config"
 import { HTTPError } from "~/lib/error"
 import { state } from "~/lib/state"
 import {
@@ -26,6 +29,7 @@ import {
   encodePoolKeyPart,
   isTerminalResponsesStreamChunk,
 } from "~/services/responses-websocket-helpers"
+import { fetchResponsesWithLifecycle } from "~/services/responses-http"
 import { requestContext } from "~/lib/request-context"
 import consola from "consola"
 
@@ -220,6 +224,7 @@ export function prepareCodexResponsesWebSocketRequest(
   payload: ResponsesPayload,
   requestHeaders: Headers,
   baseUrl: string = CODEX_API_BASE_URL,
+  signal?: AbortSignal,
 ): CodexResponsesWebSocketRequest {
   const headers = buildCodexResponsesWebSocketHeaders(requestHeaders)
 
@@ -227,6 +232,7 @@ export function prepareCodexResponsesWebSocketRequest(
     headers,
     payload: buildCodexResponsesWebSocketPayload(payload),
     poolKey: buildCodexResponsesWebSocketPoolKey(payload, headers, baseUrl),
+    signal,
     url: buildCodexResponsesWebSocketUrl(baseUrl),
   }
 }
@@ -236,31 +242,48 @@ export async function forwardCodexResponses(
   requestHeaders: Headers,
   baseUrl: string = CODEX_API_BASE_URL,
   options: {
+    signal?: AbortSignal
     transport?: ResponsesTransport
   } = {},
 ): Promise<CreateResponsesReturn> {
   consola.log(`<-- model: ${payload.model}`)
   const transport = resolveCodexResponsesTransport(options.transport)
   if (payload.stream && transport === "websocket") {
-    return forwardCodexResponsesOverWebSocket(payload, requestHeaders, baseUrl)
+    return forwardCodexResponsesOverWebSocket(
+      payload,
+      requestHeaders,
+      baseUrl,
+      options.signal,
+    )
   }
 
   const normalizedPayload = normalizeCodexResponsesPayload(payload)
 
-  const response = await fetch(resolveCodexResponsesUrl(baseUrl), {
-    method: "POST",
-    headers: buildCodexResponsesHeaders(requestHeaders, {
-      stream: normalizedPayload.stream,
-    }),
-    body: JSON.stringify(normalizedPayload),
-  })
+  const transportConfig = getResponsesTransportConfig()
+  const response = await fetchResponsesWithLifecycle(
+    resolveCodexResponsesUrl(baseUrl),
+    {
+      method: "POST",
+      headers: buildCodexResponsesHeaders(requestHeaders, {
+        stream: normalizedPayload.stream,
+      }),
+      body: JSON.stringify(normalizedPayload),
+    },
+    {
+      headersTimeoutMs: transportConfig.headersTimeoutMs,
+      signal: options.signal,
+      streamInactivityTimeoutMs: transportConfig.streamInactivityTimeoutMs,
+    },
+  )
 
   if (!response.ok) {
     throw new HTTPError("Failed to create codex responses", response)
   }
 
   if (normalizedPayload.stream) {
-    return events(response)
+    return createResponsesSafeStream(events(response), {
+      signal: options.signal,
+    })
   }
 
   return (await response.json()) as ResponsesResult
@@ -433,11 +456,13 @@ const forwardCodexResponsesOverWebSocket = (
   payload: ResponsesPayload,
   requestHeaders: Headers,
   baseUrl: string,
+  signal?: AbortSignal,
 ): ResponsesStream => {
   const websocketRequest = prepareCodexResponsesWebSocketRequest(
     payload,
     requestHeaders,
     baseUrl,
+    signal,
   )
 
   return createCodexResponsesWebSocketStream(websocketRequest)
@@ -445,17 +470,25 @@ const forwardCodexResponsesOverWebSocket = (
 
 const createCodexResponsesWebSocketStream = (
   request: CodexResponsesWebSocketRequest,
-): ResponsesStream =>
-  createResponsesSafeStream(
+): ResponsesStream => {
+  const transportConfig = getResponsesTransportConfig()
+  return createResponsesSafeStream(
     createPooledWebSocketStream(request, {
       createChunk: createCodexResponsesWebSocketStreamChunk,
+      maxBufferedBytes: transportConfig.websocketMaxBufferedBytes,
+      maxBufferedMessages: transportConfig.websocketMaxBufferedMessages,
       isTerminalChunk: isTerminalResponsesStreamChunk,
       openErrorMessage: "Failed to create codex responses websocket",
+      openTimeoutMs: transportConfig.websocketOpenTimeoutMs,
+      poolIdleTimeoutMs: transportConfig.websocketPoolIdleTimeoutMs,
+      streamInactivityTimeoutMs: transportConfig.streamInactivityTimeoutMs,
       streamErrorMessage: "Codex responses websocket stream error",
       terminalChunkMissingMessage:
         "Codex responses websocket ended without a terminal response",
     }),
+    { signal: request.signal },
   )
+}
 
 const createCodexResponsesWebSocketStreamChunk = (
   data: string,

--- a/src/services/codex/get-models.ts
+++ b/src/services/codex/get-models.ts
@@ -10,6 +10,7 @@ interface CodexModelDefinition {
   input: Array<"text" | "image">
   maxTokens: number
   name: string
+  reasoningEfforts: Array<string>
 }
 
 const CODEX_MODELS: Array<CodexModelDefinition> = [
@@ -19,6 +20,7 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
     input: ["text"],
     maxTokens: 32_000,
     name: "GPT-5.3 Codex Spark",
+    reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
   },
   {
     contextWindow: 400_000,
@@ -26,6 +28,7 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.4",
+    reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
   },
   {
     contextWindow: 400_000,
@@ -33,6 +36,7 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.4 mini",
+    reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
   },
   {
     contextWindow: 272_000,
@@ -40,27 +44,31 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.5",
+    reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
   },
   {
-    contextWindow: 372_000,
+    contextWindow: 1_050_000,
     id: "gpt-5.6-sol",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Sol",
+    reasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
   },
   {
-    contextWindow: 372_000,
+    contextWindow: 1_050_000,
     id: "gpt-5.6-terra",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Terra",
+    reasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
   },
   {
-    contextWindow: 372_000,
+    contextWindow: 1_050_000,
     id: "gpt-5.6-luna",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Luna",
+    reasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
   },
 ]
 
@@ -104,7 +112,7 @@ function normalizeCodexModel(model: CodexModelDefinition): Model {
       supports: {
         adaptive_thinking: true,
         parallel_tool_calls: true,
-        reasoning_effort: ["minimal", "low", "medium", "high", "xhigh"],
+        reasoning_effort: model.reasoningEfforts,
         streaming: true,
         tool_calls: true,
         vision: supportsVision,

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -20,6 +20,7 @@ import {
   prepareInteractionHeaders,
 } from "~/lib/api-config"
 import { COMPACT_REQUEST, type CompactType } from "~/lib/compact"
+import { getResponsesTransportConfig } from "~/lib/config"
 import {
   logCopilotQuotaSnapshots,
   logCopilotRateLimits,
@@ -36,6 +37,7 @@ import {
   encodePoolKeyPart,
   isTerminalResponsesStreamChunk,
 } from "~/services/responses-websocket-helpers"
+import { fetchResponsesWithLifecycle } from "~/services/responses-http"
 
 interface ResponsesRequestOptions {
   vision: boolean
@@ -45,6 +47,7 @@ interface ResponsesRequestOptions {
   sessionId?: string
   compactType?: CompactType
   transport?: ResponsesTransport
+  signal?: AbortSignal
 }
 
 export const createResponses = async (
@@ -57,6 +60,7 @@ export const createResponses = async (
     sessionId,
     compactType,
     transport = "http",
+    signal,
   }: ResponsesRequestOptions,
 ): Promise<CreateResponsesReturn> => {
   if (!state.copilotToken) throw new Error("Copilot token not found")
@@ -84,6 +88,7 @@ export const createResponses = async (
       headers,
       {
         requestId,
+        signal,
         subagentMarker,
       },
     )
@@ -91,18 +96,28 @@ export const createResponses = async (
     return stream
   }
 
-  return await createHttpResponses(payload, headers)
+  return await createHttpResponses(payload, headers, signal)
 }
 
 const createHttpResponses = async (
   payload: ResponsesPayload,
   headers: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<CreateResponsesReturn> => {
-  const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(payload),
-  })
+  const transportConfig = getResponsesTransportConfig()
+  const response = await fetchResponsesWithLifecycle(
+    `${copilotBaseUrl(state)}/responses`,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    },
+    {
+      headersTimeoutMs: transportConfig.headersTimeoutMs,
+      signal,
+      streamInactivityTimeoutMs: transportConfig.streamInactivityTimeoutMs,
+    },
+  )
 
   logCopilotRateLimits(response.headers)
 
@@ -112,7 +127,7 @@ const createHttpResponses = async (
   }
 
   if (payload.stream) {
-    return events(response)
+    return createResponsesSafeStream(events(response), { signal })
   }
 
   return (await response.json()) as ResponsesResult
@@ -131,6 +146,7 @@ export const prepareResponsesWebSocketRequest = (
   preparedHeaders: Record<string, string>,
   options: {
     requestId: string
+    signal?: AbortSignal
     subagentMarker?: SubagentMarker | null
   },
 ): ResponsesWebSocketRequest => {
@@ -140,6 +156,7 @@ export const prepareResponsesWebSocketRequest = (
     headers: copilotWebSocketHeaders(preparedHeaders),
     poolKey: buildResponsesWebSocketPoolKey(payload, options),
     payload: buildResponsesWebSocketPayload(payload, initiator),
+    signal: options.signal,
     url: buildResponsesWebSocketUrl(copilotBaseUrl(state)),
   }
 }
@@ -181,17 +198,25 @@ export const getResponsesWebSocketInitiator = (
 
 const createPooledResponsesWebSocketStream = (
   request: ResponsesWebSocketRequest,
-): ResponsesStream =>
-  createResponsesSafeStream(
+): ResponsesStream => {
+  const transportConfig = getResponsesTransportConfig()
+  return createResponsesSafeStream(
     createPooledWebSocketStream(request, {
       createChunk: createResponsesWebSocketStreamChunk,
+      maxBufferedBytes: transportConfig.websocketMaxBufferedBytes,
+      maxBufferedMessages: transportConfig.websocketMaxBufferedMessages,
       isTerminalChunk: isTerminalResponsesStreamChunk,
       openErrorMessage: "Failed to create responses websocket",
+      openTimeoutMs: transportConfig.websocketOpenTimeoutMs,
+      poolIdleTimeoutMs: transportConfig.websocketPoolIdleTimeoutMs,
+      streamInactivityTimeoutMs: transportConfig.streamInactivityTimeoutMs,
       streamErrorMessage: "Responses websocket stream error",
       terminalChunkMissingMessage:
         "Responses websocket ended without a terminal response",
     }),
+    { signal: request.signal },
   )
+}
 
 export const buildResponsesWebSocketPayload = (
   payload: ResponsesPayload,

--- a/src/services/providers/provider-proxy.ts
+++ b/src/services/providers/provider-proxy.ts
@@ -9,6 +9,8 @@ import { createTimeoutDispatcher } from "~/lib/timeout-dispatcher"
 import type { AnthropicMessagesPayload } from "~/lib/types/anthropic"
 import type { ChatCompletionsPayload } from "~/lib/types/chat-completions"
 import type { ResponsesPayload } from "~/lib/types/responses"
+import { getResponsesTransportConfig } from "~/lib/config"
+import { fetchResponsesWithLifecycle } from "~/services/responses-http"
 
 const SHARED_FORWARDABLE_HEADERS = ["accept", "user-agent"] as const
 
@@ -115,13 +117,23 @@ export async function forwardProviderResponses(
   providerConfig: ResolvedProviderConfig,
   payload: ResponsesPayload,
   requestHeaders: Headers,
+  options: { signal?: AbortSignal } = {},
 ): Promise<Response> {
   consola.log(`<-- model: ${payload.model}`)
-  return await fetch(`${providerConfig.baseUrl}/v1/responses`, {
-    method: "POST",
-    headers: buildProviderUpstreamHeaders(providerConfig, requestHeaders),
-    body: JSON.stringify(payload),
-  })
+  const transportConfig = getResponsesTransportConfig()
+  return await fetchResponsesWithLifecycle(
+    `${providerConfig.baseUrl}/v1/responses`,
+    {
+      method: "POST",
+      headers: buildProviderUpstreamHeaders(providerConfig, requestHeaders),
+      body: JSON.stringify(payload),
+    },
+    {
+      headersTimeoutMs: transportConfig.headersTimeoutMs,
+      signal: options.signal,
+      streamInactivityTimeoutMs: transportConfig.streamInactivityTimeoutMs,
+    },
+  )
 }
 
 const PROVIDER_MODELS_TIMEOUT_MS = 15_000

--- a/src/services/responses-http.ts
+++ b/src/services/responses-http.ts
@@ -128,11 +128,18 @@ const createManagedResponseBody = (
 ): ReadableStream<Uint8Array> => {
   const reader = body.getReader()
   let finished = false
+  let readerReleased = false
 
   const finish = () => {
     if (finished) return
     finished = true
     lifecycle.finish()
+  }
+
+  const releaseReader = () => {
+    if (readerReleased) return
+    readerReleased = true
+    reader.releaseLock()
   }
 
   return new ReadableStream<Uint8Array>({
@@ -141,6 +148,7 @@ const createManagedResponseBody = (
         const result = await readWithLifecycle(reader, lifecycle, options)
         if (result.done) {
           finish()
+          releaseReader()
           controller.close()
           return
         }
@@ -150,6 +158,7 @@ const createManagedResponseBody = (
         const reason = lifecycle.finishWithError(error)
         finish()
         await reader.cancel(reason).catch(() => {})
+        releaseReader()
         controller.error(reason)
       }
     },
@@ -158,6 +167,7 @@ const createManagedResponseBody = (
       lifecycle.abort(error)
       finish()
       await reader.cancel(error).catch(() => {})
+      releaseReader()
     },
   })
 }

--- a/src/services/responses-http.ts
+++ b/src/services/responses-http.ts
@@ -1,0 +1,232 @@
+export interface ResponsesHttpLifecycleOptions {
+  headersTimeoutMs: number
+  signal?: AbortSignal
+  streamInactivityTimeoutMs: number
+}
+
+export class ResponsesHeadersTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Responses upstream did not return headers within ${timeoutMs}ms`)
+    this.name = "ResponsesHeadersTimeoutError"
+  }
+}
+
+export class ResponsesStreamInactivityTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Responses upstream stream was inactive for ${timeoutMs}ms`)
+    this.name = "ResponsesStreamInactivityTimeoutError"
+  }
+}
+
+export async function fetchResponsesWithLifecycle(
+  input: string | URL | Request,
+  init: RequestInit,
+  options: ResponsesHttpLifecycleOptions,
+): Promise<Response> {
+  const lifecycle = createRequestLifecycle(options)
+
+  try {
+    const response = await fetch(input, {
+      ...init,
+      signal: lifecycle.signal,
+    })
+    lifecycle.headersReceived()
+    return createManagedResponse(response, lifecycle, options)
+  } catch (error) {
+    throw lifecycle.finishWithError(error)
+  }
+}
+
+interface RequestLifecycle {
+  abort: (reason: Error) => void
+  finish: () => void
+  finishWithError: (error: unknown) => Error
+  headersReceived: () => void
+  signal: AbortSignal
+}
+
+const createRequestLifecycle = (
+  options: ResponsesHttpLifecycleOptions,
+): RequestLifecycle => {
+  const controller = new AbortController()
+  const downstreamSignal = options.signal
+  let finished = false
+  let headersTimer: ReturnType<typeof setTimeout> | null = null
+
+  const abortFromDownstream = () => {
+    controller.abort(toAbortReason(downstreamSignal?.reason))
+  }
+
+  if (downstreamSignal?.aborted) {
+    abortFromDownstream()
+  } else {
+    downstreamSignal?.addEventListener("abort", abortFromDownstream, {
+      once: true,
+    })
+  }
+
+  if (!controller.signal.aborted) {
+    headersTimer = setTimeout(() => {
+      controller.abort(
+        new ResponsesHeadersTimeoutError(options.headersTimeoutMs),
+      )
+    }, options.headersTimeoutMs)
+    unrefTimer(headersTimer)
+  }
+
+  const clearHeadersTimer = () => {
+    if (headersTimer === null) return
+    clearTimeout(headersTimer)
+    headersTimer = null
+  }
+
+  const finish = () => {
+    if (finished) return
+    finished = true
+    clearHeadersTimer()
+    downstreamSignal?.removeEventListener("abort", abortFromDownstream)
+  }
+
+  return {
+    abort: (reason) => {
+      if (!controller.signal.aborted) controller.abort(reason)
+    },
+    finish,
+    finishWithError: (error) => {
+      clearHeadersTimer()
+      const reason = controller.signal.reason as unknown
+      finish()
+      return reason instanceof Error ? reason : toError(error)
+    },
+    headersReceived: clearHeadersTimer,
+    signal: controller.signal,
+  }
+}
+
+const createManagedResponse = (
+  response: Response,
+  lifecycle: RequestLifecycle,
+  options: ResponsesHttpLifecycleOptions,
+): Response => {
+  if (!response.body) {
+    lifecycle.finish()
+    return response
+  }
+
+  const body = createManagedResponseBody(response.body, lifecycle, options)
+  return new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
+
+const createManagedResponseBody = (
+  body: ReadableStream<Uint8Array>,
+  lifecycle: RequestLifecycle,
+  options: ResponsesHttpLifecycleOptions,
+): ReadableStream<Uint8Array> => {
+  const reader = body.getReader()
+  let finished = false
+
+  const finish = () => {
+    if (finished) return
+    finished = true
+    lifecycle.finish()
+  }
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const result = await readWithLifecycle(reader, lifecycle, options)
+        if (result.done) {
+          finish()
+          controller.close()
+          return
+        }
+
+        controller.enqueue(result.value)
+      } catch (error) {
+        const reason = lifecycle.finishWithError(error)
+        finish()
+        await reader.cancel(reason).catch(() => {})
+        controller.error(reason)
+      }
+    },
+    async cancel(reason) {
+      const error = toAbortReason(reason)
+      lifecycle.abort(error)
+      finish()
+      await reader.cancel(error).catch(() => {})
+    },
+  })
+}
+
+const readWithLifecycle = async (
+  reader: {
+    read: () => Promise<{ done: boolean; value?: Uint8Array }>
+  },
+  lifecycle: RequestLifecycle,
+  options: ResponsesHttpLifecycleOptions,
+): Promise<{ done: boolean; value?: Uint8Array }> =>
+  await new Promise((resolve, reject) => {
+    let settled = false
+    const signal = lifecycle.signal
+    const timer = setTimeout(() => {
+      const error = new ResponsesStreamInactivityTimeoutError(
+        options.streamInactivityTimeoutMs,
+      )
+      lifecycle.abort(error)
+      settle(() => reject(error))
+    }, options.streamInactivityTimeoutMs)
+    unrefTimer(timer)
+
+    const onAbort = () => {
+      settle(() => reject(toAbortReason(signal.reason)))
+    }
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      signal.removeEventListener("abort", onAbort)
+    }
+
+    const settle = (action: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      action()
+    }
+
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true })
+    reader.read().then(
+      (result) => settle(() => resolve(result)),
+      (error: unknown) => settle(() => reject(toError(error))),
+    )
+  })
+
+const toAbortReason = (reason: unknown): Error => {
+  if (reason instanceof Error) return reason
+  const error = new Error("The operation was aborted")
+  error.name = "AbortError"
+  return error
+}
+
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value
+  return new Error(String(value))
+}
+
+const unrefTimer = (timer: ReturnType<typeof setTimeout>): void => {
+  if (
+    typeof timer === "object"
+    && "unref" in timer
+    && typeof timer.unref === "function"
+  ) {
+    timer.unref()
+  }
+}

--- a/src/services/responses-websocket-helpers.ts
+++ b/src/services/responses-websocket-helpers.ts
@@ -55,10 +55,16 @@ export const isTerminalResponsesStreamChunk = (chunk: {
 
 export const createResponsesSafeStream = async function* <
   TChunk extends ResponsesStreamErrorChunk,
->(source: AsyncIterable<TChunk>): AsyncGenerator<TChunk, void, unknown> {
+>(
+  source: AsyncIterable<TChunk>,
+  options: { signal?: AbortSignal } = {},
+): AsyncGenerator<TChunk, void, unknown> {
   try {
     yield* source
   } catch (error) {
+    if (options.signal?.aborted || isAbortError(error)) {
+      return
+    }
     // The cast relies on TChunk staying shape-compatible with the error chunk
     // ({ data, event } only, no required extra fields). Keep new call sites
     // within that constraint.
@@ -67,3 +73,6 @@ export const createResponsesSafeStream = async function* <
     ) as TChunk
   }
 }
+
+const isAbortError = (error: unknown): boolean =>
+  error instanceof Error && error.name === "AbortError"

--- a/src/services/responses-websocket.ts
+++ b/src/services/responses-websocket.ts
@@ -6,38 +6,135 @@ export interface PooledWebSocketRequest<TPayload> {
   headers: Record<string, string>
   payload: TPayload
   poolKey: string
+  signal?: AbortSignal
   url: string
 }
 
 export interface PooledWebSocketStreamOptions<TChunk> {
   createChunk: (data: string) => TChunk
-  idleTimeoutMs?: number
   isTerminalChunk: (chunk: TChunk) => boolean
+  maxBufferedBytes: number
+  maxBufferedMessages: number
   openErrorMessage: string
+  openTimeoutMs: number
+  poolIdleTimeoutMs: number
   streamErrorMessage: string
+  streamInactivityTimeoutMs: number
   terminalChunkMissingMessage: string
   unavailableErrorMessage?: string
 }
 
+type WebSocketInstance = InstanceType<typeof WebSocket>
 type WebSocketErrorEvent = Parameters<
-  NonNullable<InstanceType<typeof WebSocket>["onerror"]>
+  NonNullable<WebSocketInstance["onerror"]>
 >[0]
-
-const DEFAULT_WEBSOCKET_IDLE_TIMEOUT_MS = 60_000
+type WebSocketMessageListener = (event: { data: unknown }) => void
 
 const websocketPool = new Map<string, PooledWebSocketEntry>()
 const websocketActiveRequests = new Map<string, number>()
 
 interface PooledWebSocketEntry {
   closed: boolean
+  idleMessageListener: WebSocketMessageListener | null
   idleTimer: ReturnType<typeof setTimeout> | null
+  poolIdleTimeoutMs: number
   requestCount: number
-  websocketPromise: Promise<InstanceType<typeof WebSocket>>
+  websocket: WebSocketInstance | null
+  websocketPromise: Promise<WebSocketInstance>
 }
 
 interface PooledWebSocketRequestTarget {
   entry: PooledWebSocketEntry
   pooled: boolean
+}
+
+interface BufferedWebSocketMessage {
+  data: Promise<string>
+  size: number
+}
+
+export class ResponsesWebSocketOpenTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Responses websocket did not open within ${timeoutMs}ms`)
+    this.name = "ResponsesWebSocketOpenTimeoutError"
+  }
+}
+
+export class ResponsesWebSocketInactivityTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Responses websocket stream was inactive for ${timeoutMs}ms`)
+    this.name = "ResponsesWebSocketInactivityTimeoutError"
+  }
+}
+
+export class ResponsesWebSocketBufferOverflowError extends Error {
+  constructor(maxBufferedBytes: number, maxBufferedMessages: number) {
+    super(
+      `Responses websocket buffer exceeded ${maxBufferedBytes} bytes or ${maxBufferedMessages} messages; downstream consumption is too slow`,
+    )
+    this.name = "ResponsesWebSocketBufferOverflowError"
+  }
+}
+
+export class WebSocketMessageBuffer {
+  private readonly entries: Array<BufferedWebSocketMessage | undefined> = []
+  private head = 0
+  private readonly maxBufferedBytes: number
+  private readonly maxBufferedMessages: number
+  private sizeBytes = 0
+
+  constructor(maxBufferedBytes: number, maxBufferedMessages: number) {
+    this.maxBufferedBytes = maxBufferedBytes
+    this.maxBufferedMessages = maxBufferedMessages
+  }
+
+  get bufferedBytes(): number {
+    return this.sizeBytes
+  }
+
+  get bufferedMessages(): number {
+    return this.entries.length - this.head
+  }
+
+  enqueue(data: unknown): boolean {
+    const size = getWebSocketMessageSize(data)
+    if (
+      this.sizeBytes + size > this.maxBufferedBytes
+      || this.bufferedMessages + 1 > this.maxBufferedMessages
+    ) {
+      return false
+    }
+
+    this.entries.push({
+      data: normalizeWebSocketMessageData(data),
+      size,
+    })
+    this.sizeBytes += size
+    return true
+  }
+
+  dequeue(): Promise<string> | undefined {
+    const entry = this.entries[this.head]
+    if (!entry) return undefined
+
+    this.entries[this.head] = undefined
+    this.head += 1
+    this.sizeBytes -= entry.size
+    this.compactIfNeeded()
+    return entry.data
+  }
+
+  clear(): void {
+    this.entries.length = 0
+    this.head = 0
+    this.sizeBytes = 0
+  }
+
+  private compactIfNeeded(): void {
+    if (this.head < 256 || this.head * 2 < this.entries.length) return
+    this.entries.splice(0, this.head)
+    this.head = 0
+  }
 }
 
 export const createWebSocketUrl = (url: string): string => {
@@ -62,12 +159,9 @@ const runPooledWebSocketRequest = async function* <TPayload, TChunk>(
   options: PooledWebSocketStreamOptions<TChunk>,
 ): AsyncIterable<TChunk> {
   const { entry, pooled } = getPooledWebSocketRequestTarget(request, options)
-  const release = acquirePooledWebSocketEntry(
-    request.poolKey,
-    entry,
-    pooled,
-    options,
-  )
+  const release = acquirePooledWebSocketEntry(request.poolKey, entry, pooled)
+  let messageStream: WebSocketMessageStream | null = null
+  let reusable = false
 
   try {
     const websocket = await getReadyPooledWebSocket(
@@ -76,24 +170,32 @@ const runPooledWebSocketRequest = async function* <TPayload, TChunk>(
       pooled,
       options,
     )
+    messageStream = createWebSocketMessageStream(
+      websocket,
+      request.signal,
+      options,
+    )
+    messageStream.start()
     websocket.send(JSON.stringify(request.payload))
 
-    for await (const data of createWebSocketMessageStream(websocket, options)) {
+    for await (const data of messageStream.iterable) {
       const chunk = options.createChunk(data)
       yield chunk
 
       if (options.isTerminalChunk(chunk)) {
+        messageStream.complete()
+        reusable = true
         return
       }
     }
 
-    removePooledWebSocketEntry(request.poolKey, entry)
     throw new Error(options.terminalChunkMissingMessage)
   } catch (error) {
-    removePooledWebSocketEntry(request.poolKey, entry)
     throw toError(error)
   } finally {
-    release()
+    messageStream?.dispose()
+    if (!reusable) removePooledWebSocketEntry(request.poolKey, entry)
+    release(reusable)
   }
 }
 
@@ -111,38 +213,39 @@ const getPooledWebSocketRequestTarget = <TPayload, TChunk>(
   const existing = websocketPool.get(request.poolKey)
   if (existing && !existing.closed) {
     consola.debug("websocket from pool")
-    clearPooledWebSocketIdleTimer(existing)
-    return {
-      entry: existing,
-      pooled: true,
-    }
+    clearPooledWebSocketIdleState(existing)
+    return { entry: existing, pooled: true }
   }
 
   const entry = createPooledWebSocketEntry(request, options)
   websocketPool.set(request.poolKey, entry)
-  return {
-    entry,
-    pooled: true,
-  }
+  return { entry, pooled: true }
 }
 
 const createPooledWebSocketEntry = <TPayload, TChunk>(
   request: PooledWebSocketRequest<TPayload>,
   options: PooledWebSocketStreamOptions<TChunk>,
 ): PooledWebSocketEntry => {
+  const websocketPromise = openWebSocket({
+    headers: request.headers,
+    openErrorMessage: options.openErrorMessage,
+    openTimeoutMs: options.openTimeoutMs,
+    signal: request.signal,
+    url: request.url,
+  })
   const entry: PooledWebSocketEntry = {
     closed: false,
+    idleMessageListener: null,
     idleTimer: null,
+    poolIdleTimeoutMs: options.poolIdleTimeoutMs,
     requestCount: 0,
-    websocketPromise: openWebSocket({
-      headers: request.headers,
-      openErrorMessage: options.openErrorMessage,
-      url: request.url,
-    }),
+    websocket: null,
+    websocketPromise,
   }
 
   entry.websocketPromise
     .then((websocket) => {
+      entry.websocket = websocket
       websocket.addEventListener("close", () => {
         removePooledWebSocketEntry(request.poolKey, entry)
       })
@@ -157,32 +260,30 @@ const createPooledWebSocketEntry = <TPayload, TChunk>(
   return entry
 }
 
-const acquirePooledWebSocketEntry = <TChunk>(
+const acquirePooledWebSocketEntry = (
   poolKey: string,
   entry: PooledWebSocketEntry,
   pooled: boolean,
-  options: PooledWebSocketStreamOptions<TChunk>,
-): (() => void) => {
-  clearPooledWebSocketIdleTimer(entry)
+): ((reusable: boolean) => void) => {
+  clearPooledWebSocketIdleState(entry)
   incrementPooledWebSocketActiveRequestCount(poolKey)
   entry.requestCount += 1
 
   let released = false
-  return () => {
-    if (released) {
-      return
-    }
-
+  return (reusable) => {
+    if (released) return
     released = true
     entry.requestCount -= 1
-
     decrementPooledWebSocketActiveRequestCount(poolKey)
-    if (entry.closed || entry.requestCount > 0) {
+
+    if (!reusable) {
+      removePooledWebSocketEntry(poolKey, entry)
       return
     }
+    if (entry.closed || entry.requestCount > 0) return
 
     if (pooled && websocketPool.get(poolKey) === entry) {
-      schedulePooledWebSocketIdleClose(poolKey, entry, options)
+      schedulePooledWebSocketIdleClose(poolKey, entry)
       return
     }
 
@@ -190,25 +291,22 @@ const acquirePooledWebSocketEntry = <TChunk>(
   }
 }
 
-const getReadyPooledWebSocket = async (
+const getReadyPooledWebSocket = async <TChunk>(
   poolKey: string,
   entry: PooledWebSocketEntry,
   pooled: boolean,
-  options?: { unavailableErrorMessage?: string },
-): Promise<InstanceType<typeof WebSocket>> => {
+  options: PooledWebSocketStreamOptions<TChunk>,
+): Promise<WebSocketInstance> => {
   const unavailableErrorMessage =
-    options?.unavailableErrorMessage
+    options.unavailableErrorMessage
     ?? "Websocket connection became unavailable before the request started"
 
-  if (entry.closed) {
-    throw new Error(unavailableErrorMessage)
-  }
+  if (entry.closed) throw new Error(unavailableErrorMessage)
 
   const websocket = await entry.websocketPromise
   if (entry.closed || (pooled && websocketPool.get(poolKey) !== entry)) {
     throw new Error(unavailableErrorMessage)
   }
-
   if (websocket.readyState !== WebSocket.OPEN) {
     removePooledWebSocketEntry(poolKey, entry)
     throw new Error(unavailableErrorMessage)
@@ -217,22 +315,36 @@ const getReadyPooledWebSocket = async (
   return websocket
 }
 
-const schedulePooledWebSocketIdleClose = <TChunk>(
+const schedulePooledWebSocketIdleClose = (
   poolKey: string,
   entry: PooledWebSocketEntry,
-  options: PooledWebSocketStreamOptions<TChunk>,
 ): void => {
-  clearPooledWebSocketIdleTimer(entry)
+  clearPooledWebSocketIdleState(entry)
+  const websocket = entry.websocket
+  if (!websocket || websocket.readyState !== WebSocket.OPEN) {
+    removePooledWebSocketEntry(poolKey, entry)
+    return
+  }
+
+  entry.idleMessageListener = () => {
+    removePooledWebSocketEntry(poolKey, entry)
+  }
+  websocket.addEventListener("message", entry.idleMessageListener)
+
   entry.idleTimer = setTimeout(() => {
     removePooledWebSocketEntry(poolKey, entry)
-  }, options.idleTimeoutMs ?? DEFAULT_WEBSOCKET_IDLE_TIMEOUT_MS)
+  }, entry.poolIdleTimeoutMs)
   unrefTimer(entry.idleTimer)
 }
 
-const clearPooledWebSocketIdleTimer = (entry: PooledWebSocketEntry): void => {
+const clearPooledWebSocketIdleState = (entry: PooledWebSocketEntry): void => {
   if (entry.idleTimer) {
     clearTimeout(entry.idleTimer)
     entry.idleTimer = null
+  }
+  if (entry.websocket && entry.idleMessageListener) {
+    entry.websocket.removeEventListener("message", entry.idleMessageListener)
+    entry.idleMessageListener = null
   }
 }
 
@@ -250,28 +362,297 @@ const decrementPooledWebSocketActiveRequestCount = (poolKey: string): void => {
   const nextCount = getPooledWebSocketActiveRequestCount(poolKey) - 1
   if (nextCount <= 0) {
     websocketActiveRequests.delete(poolKey)
-    return
+  } else {
+    websocketActiveRequests.set(poolKey, nextCount)
   }
-
-  websocketActiveRequests.set(poolKey, nextCount)
 }
 
 const removePooledWebSocketEntry = (
   poolKey: string,
   entry: PooledWebSocketEntry,
 ): void => {
-  if (websocketPool.get(poolKey) === entry) {
-    websocketPool.delete(poolKey)
-  }
-
-  if (entry.closed) {
-    return
-  }
+  if (websocketPool.get(poolKey) === entry) websocketPool.delete(poolKey)
+  if (entry.closed) return
 
   entry.closed = true
-  clearPooledWebSocketIdleTimer(entry)
+  clearPooledWebSocketIdleState(entry)
   entry.websocketPromise.then(closeWebSocket).catch(() => {})
 }
+
+const createWebSocketError = (
+  message: string,
+  event?: Pick<WebSocketErrorEvent, "error" | "message">,
+): Error => {
+  const reason = event?.error ?? event?.message
+  if (reason === undefined || reason === "") return new Error(message)
+
+  const cause = toError(reason)
+  return new Error(`${message}: ${cause.message}`, { cause })
+}
+
+const openWebSocket = async ({
+  headers,
+  openErrorMessage,
+  openTimeoutMs,
+  signal,
+  url,
+}: {
+  headers: Record<string, string>
+  openErrorMessage: string
+  openTimeoutMs: number
+  signal?: AbortSignal
+  url: string
+}): Promise<WebSocketInstance> =>
+  await new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(toAbortReason(signal.reason))
+      return
+    }
+
+    const proxy = typeof Bun === "undefined" ? undefined : getProxyUrl(url)
+    const init = { headers, ...(proxy ? { proxy } : {}) }
+    const websocket = new WebSocket(url, init)
+    let settled = false
+    const timer = setTimeout(() => {
+      fail(new ResponsesWebSocketOpenTimeoutError(openTimeoutMs))
+    }, openTimeoutMs)
+    unrefTimer(timer)
+
+    const cleanup = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener("abort", onAbort)
+      websocket.removeEventListener("open", onOpen)
+      websocket.removeEventListener("close", onClose)
+      websocket.removeEventListener("error", onError)
+    }
+
+    const fail = (error: Error) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      closeWebSocket(websocket)
+      reject(error)
+    }
+
+    const onAbort = () => fail(toAbortReason(signal?.reason))
+    const onOpen = () => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(websocket)
+    }
+    const onClose = () => fail(new Error(openErrorMessage))
+    const onError = (event: WebSocketErrorEvent) => {
+      fail(createWebSocketError(openErrorMessage, event))
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true })
+    websocket.addEventListener("open", onOpen)
+    websocket.addEventListener("close", onClose)
+    websocket.addEventListener("error", onError)
+  })
+
+interface WebSocketMessageStream {
+  complete: () => void
+  dispose: () => void
+  iterable: AsyncIterable<string>
+  start: () => void
+}
+
+const createWebSocketMessageStream = <TChunk>(
+  websocket: WebSocketInstance,
+  signal: AbortSignal | undefined,
+  options: PooledWebSocketStreamOptions<TChunk>,
+): WebSocketMessageStream => {
+  const buffer = new WebSocketMessageBuffer(
+    options.maxBufferedBytes,
+    options.maxBufferedMessages,
+  )
+  let closed = false
+  let disposed = false
+  let error: Error | null = null
+  let inactivityTimer: ReturnType<typeof setTimeout> | null = null
+  let notify: (() => void) | null = null
+
+  const wake = () => {
+    notify?.()
+    notify = null
+  }
+
+  const clearInactivityTimer = () => {
+    if (!inactivityTimer) return
+    clearTimeout(inactivityTimer)
+    inactivityTimer = null
+  }
+
+  const fail = (nextError: Error, close = true) => {
+    if (error || disposed) return
+    error = nextError
+    clearInactivityTimer()
+    buffer.clear()
+    if (close) closeWebSocket(websocket)
+    wake()
+  }
+
+  const resetInactivityTimer = () => {
+    clearInactivityTimer()
+    if (disposed || closed || error) return
+    inactivityTimer = setTimeout(() => {
+      fail(
+        new ResponsesWebSocketInactivityTimeoutError(
+          options.streamInactivityTimeoutMs,
+        ),
+      )
+    }, options.streamInactivityTimeoutMs)
+    unrefTimer(inactivityTimer)
+  }
+
+  const onMessage = (event: { data: unknown }) => {
+    resetInactivityTimer()
+    if (!buffer.enqueue(event.data)) {
+      fail(
+        new ResponsesWebSocketBufferOverflowError(
+          options.maxBufferedBytes,
+          options.maxBufferedMessages,
+        ),
+      )
+      return
+    }
+    wake()
+  }
+
+  const onClose = () => {
+    consola.debug("WebSocket closed")
+    closed = true
+    clearInactivityTimer()
+    wake()
+  }
+
+  const onError = (event: WebSocketErrorEvent) => {
+    consola.error("WebSocket error:", event, event.error)
+    fail(createWebSocketError(options.streamErrorMessage, event), false)
+  }
+
+  const onAbort = () => fail(toAbortReason(signal?.reason))
+
+  websocket.addEventListener("message", onMessage)
+  websocket.addEventListener("close", onClose)
+  websocket.addEventListener("error", onError)
+  signal?.addEventListener("abort", onAbort, { once: true })
+
+  const dispose = () => {
+    if (disposed) return
+    disposed = true
+    clearInactivityTimer()
+    buffer.clear()
+    websocket.removeEventListener("message", onMessage)
+    websocket.removeEventListener("close", onClose)
+    websocket.removeEventListener("error", onError)
+    signal?.removeEventListener("abort", onAbort)
+    wake()
+  }
+
+  const iterable = (async function* (): AsyncIterable<string> {
+    try {
+      while (true) {
+        const item = buffer.dequeue()
+        if (item) {
+          yield await item
+          continue
+        }
+        if (error) throw toError(error)
+        if (closed) return
+
+        await new Promise<void>((resolve) => {
+          notify = resolve
+        })
+      }
+    } finally {
+      dispose()
+    }
+  })()
+
+  return {
+    complete: clearInactivityTimer,
+    dispose,
+    iterable,
+    start: resetInactivityTimer,
+  }
+}
+
+const normalizeWebSocketMessageData = async (
+  data: unknown,
+): Promise<string> => {
+  if (typeof data === "string") return data
+  if (data instanceof ArrayBuffer) return new TextDecoder().decode(data)
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(
+      new Uint8Array(
+        data.buffer as ArrayBuffer,
+        data.byteOffset,
+        data.byteLength,
+      ),
+    )
+  }
+  if (isTextReadable(data)) return await data.text()
+  return String(data)
+}
+
+const getWebSocketMessageSize = (data: unknown): number => {
+  if (typeof data === "string") return new TextEncoder().encode(data).byteLength
+  if (data instanceof ArrayBuffer) return data.byteLength
+  if (ArrayBuffer.isView(data)) return data.byteLength
+  if (isSized(data)) return data.size
+  return new TextEncoder().encode(String(data)).byteLength
+}
+
+const isTextReadable = (
+  value: unknown,
+): value is { text: () => Promise<string> } =>
+  Boolean(
+    value
+      && typeof value === "object"
+      && "text" in value
+      && typeof (value as { text?: unknown }).text === "function",
+  )
+
+const isSized = (value: unknown): value is { size: number } =>
+  Boolean(
+    value
+      && typeof value === "object"
+      && "size" in value
+      && typeof (value as { size?: unknown }).size === "number",
+  )
+
+const toAbortReason = (reason: unknown): Error => {
+  if (reason instanceof Error) return reason
+  const error = new Error("The operation was aborted")
+  error.name = "AbortError"
+  return error
+}
+
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) return value
+  return new Error(String(value))
+}
+
+const closeWebSocket = (websocket: WebSocketInstance): void => {
+  if (
+    websocket.readyState !== WebSocket.CONNECTING
+    && websocket.readyState !== WebSocket.OPEN
+  ) {
+    return
+  }
+  try {
+    websocket.close()
+  } catch {
+    // Some implementations reject close() while CONNECTING. The open
+    // listeners have already been detached, so the socket cannot be reused.
+  }
+}
+
+const getProxyUrl = (url: string): string =>
+  getProxyForUrl(url.replace(/^wss:/u, "https:").replace(/^ws:/u, "http:"))
 
 const unrefTimer = (timer: ReturnType<typeof setTimeout>): void => {
   if (
@@ -281,172 +662,4 @@ const unrefTimer = (timer: ReturnType<typeof setTimeout>): void => {
   ) {
     timer.unref()
   }
-}
-
-const createWebSocketError = (
-  message: string,
-  event?: Pick<WebSocketErrorEvent, "error" | "message">,
-): Error => {
-  const reason = event?.error ?? event?.message
-  if (reason === undefined || reason === "") {
-    return new Error(message)
-  }
-
-  const cause = toError(reason)
-  return new Error(`${message}: ${cause.message}`, { cause })
-}
-
-const openWebSocket = async ({
-  headers,
-  openErrorMessage,
-  url,
-}: {
-  headers: Record<string, string>
-  openErrorMessage: string
-  url: string
-}): Promise<InstanceType<typeof WebSocket>> =>
-  await new Promise((resolve, reject) => {
-    const proxy = typeof Bun === "undefined" ? undefined : getProxyUrl(url)
-    const init = { headers, ...(proxy ? { proxy } : {}) }
-    const websocket = new WebSocket(url, init)
-
-    const cleanup = () => {
-      websocket.removeEventListener("open", onOpen)
-      websocket.removeEventListener("error", onError)
-    }
-
-    const onOpen = () => {
-      cleanup()
-      resolve(websocket)
-    }
-
-    const onError = (event: WebSocketErrorEvent) => {
-      cleanup()
-      reject(createWebSocketError(openErrorMessage, event))
-    }
-
-    websocket.addEventListener("open", onOpen)
-    websocket.addEventListener("error", onError)
-  })
-
-const createWebSocketMessageStream = async function* <TChunk>(
-  websocket: InstanceType<typeof WebSocket>,
-  options: PooledWebSocketStreamOptions<TChunk>,
-): AsyncIterable<string> {
-  const queue: Array<Promise<string>> = []
-  let closed = false
-  let error: Error | null = null
-  let notify: (() => void) | null = null
-
-  const wake = () => {
-    notify?.()
-    notify = null
-  }
-
-  const onMessage = (event: { data: unknown }) => {
-    queue.push(normalizeWebSocketMessageData(event.data))
-    wake()
-  }
-
-  const onClose = () => {
-    consola.debug("WebSocket closed")
-    closed = true
-    wake()
-  }
-
-  const onError = (event: WebSocketErrorEvent) => {
-    consola.error("WebSocket error:", event, event.error)
-    error = createWebSocketError(options.streamErrorMessage, event)
-    wake()
-  }
-
-  websocket.addEventListener("message", onMessage)
-  websocket.addEventListener("close", onClose)
-  websocket.addEventListener("error", onError)
-
-  try {
-    while (true) {
-      const item = queue.shift()
-      if (item) {
-        yield await item
-        continue
-      }
-
-      if (error) {
-        throw toError(error)
-      }
-
-      if (closed) {
-        break
-      }
-
-      await new Promise<void>((resolve) => {
-        notify = resolve
-      })
-    }
-  } finally {
-    websocket.removeEventListener("message", onMessage)
-    websocket.removeEventListener("close", onClose)
-    websocket.removeEventListener("error", onError)
-  }
-}
-
-const normalizeWebSocketMessageData = async (
-  data: unknown,
-): Promise<string> => {
-  if (typeof data === "string") {
-    return data
-  }
-
-  if (data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(data)
-  }
-
-  if (ArrayBuffer.isView(data)) {
-    const view = data
-    return new TextDecoder().decode(
-      new Uint8Array(
-        view.buffer as ArrayBuffer,
-        view.byteOffset,
-        view.byteLength,
-      ),
-    )
-  }
-
-  if (isTextReadable(data)) {
-    return await data.text()
-  }
-
-  return String(data)
-}
-
-const isTextReadable = (
-  value: unknown,
-): value is { text: () => Promise<string> } => {
-  if (!value || typeof value !== "object" || !("text" in value)) {
-    return false
-  }
-
-  return typeof (value as { text?: unknown }).text === "function"
-}
-
-const toError = (value: unknown): Error => {
-  if (value instanceof Error) {
-    return value
-  }
-
-  return new Error(String(value))
-}
-
-const closeWebSocket = (websocket: InstanceType<typeof WebSocket>): void => {
-  if (
-    websocket.readyState === WebSocket.CONNECTING
-    || websocket.readyState === WebSocket.OPEN
-  ) {
-    websocket.close()
-  }
-}
-
-const getProxyUrl = (url: string): string => {
-  return getProxyForUrl(url.replace(/^wss:/, "https:").replace(/^ws:/, "http:"))
 }

--- a/tests/alpha-search.test.ts
+++ b/tests/alpha-search.test.ts
@@ -4,34 +4,10 @@ import { Hono } from "hono"
 import type { ResolvedProviderConfig } from "~/lib/config"
 import type { ResponsesPayload, ResponsesResult } from "~/lib/types/responses"
 
-const actualConfigModule = await import("~/lib/config")
-const actualTokenModule = await import("~/lib/token")
-
 let codexProviderConfig: ResolvedProviderConfig | null = null
 let openrouterProviderConfig: ResolvedProviderConfig | null = null
 let alphaSearchCodexPriorityEnabled = true
 let modelMappings: Record<string, string> = {}
-
-await mock.module("~/lib/config", () => ({
-  ...actualConfigModule,
-  getProviderConfig: (provider: string) => {
-    if (provider === "codex") return codexProviderConfig
-    if (provider === "openrouter") return openrouterProviderConfig
-    return null
-  },
-  getRawProviderConfig: (provider: string) => {
-    if (provider === "codex") return codexProviderConfig
-    if (provider === "openrouter") return openrouterProviderConfig
-    return null
-  },
-  isAlphaSearchCodexPriorityEnabled: () => alphaSearchCodexPriorityEnabled,
-  resolveMappedModel: (model: string) => modelMappings[model] ?? model,
-}))
-
-await mock.module("~/lib/token", () => ({
-  ...actualTokenModule,
-  setupCodexToken: async () => {},
-}))
 
 const { state } = await import("~/lib/state")
 const { HTTPError } = await import("~/lib/error")
@@ -42,17 +18,22 @@ const { forwardCodexAlphaSearch, resolveCodexAlphaSearchUrl } = await import(
 const { forwardCodexModels, getModels, resolveCodexModelsUrl } = await import(
   "~/services/codex/get-models"
 )
-const { alphaSearchRoutes } = await import("~/routes/alpha-search/route")
+const { alphaSearchRouteDependencies, alphaSearchRoutes } = await import(
+  "~/routes/alpha-search/route"
+)
 const { alphaSearchResponsesDependencies, resetAlphaSearchState } =
   await import("~/routes/alpha-search/alpha-search-responses")
-const { providerAlphaSearchRoutes } = await import(
-  "~/routes/provider/alpha-search/route"
-)
+const { providerAlphaSearchRouteDependencies, providerAlphaSearchRoutes } =
+  await import("~/routes/provider/alpha-search/route")
 
 const DB_PATH_ENV = "COPILOT_API_SQLITE_DB_PATH"
 
 const originalFetch = globalThis.fetch
 const originalResponsesDependencies = { ...alphaSearchResponsesDependencies }
+const originalRouteDependencies = { ...alphaSearchRouteDependencies }
+const originalProviderRouteDependencies = {
+  ...providerAlphaSearchRouteDependencies,
+}
 const originalModels = state.models
 const originalCopilotToken = state.copilotToken
 const originalMacMachineId = state.macMachineId
@@ -227,6 +208,20 @@ function requestFallback(
   )
 }
 
+const resolveTestProviderConfig = (
+  provider: string,
+): Promise<ResolvedProviderConfig | null> => {
+  if (provider === "codex") return Promise.resolve(codexProviderConfig)
+  if (provider === "openrouter")
+    return Promise.resolve(openrouterProviderConfig)
+  return Promise.resolve(null)
+}
+
+const resolveTestProviderType = (
+  providerConfig: ResolvedProviderConfig,
+  model: string,
+) => providerConfig.models?.[model]?.type ?? providerConfig.type
+
 beforeEach(async () => {
   process.env[DB_PATH_ENV] = ":memory:"
   await closeUsageStore()
@@ -279,6 +274,22 @@ beforeEach(async () => {
     Date.parse("2026-08-03T12:00:00.000Z")
   alphaSearchResponsesDependencies.resolveMappedModel = (model) =>
     modelMappings[model] ?? model
+  alphaSearchResponsesDependencies.resolveEffectiveProviderType =
+    resolveTestProviderType
+  alphaSearchResponsesDependencies.resolveProviderConfig =
+    resolveTestProviderConfig
+  alphaSearchRouteDependencies.findEndpointModel = (model) =>
+    state.models?.data.find((candidate) => candidate.id === model)
+  alphaSearchRouteDependencies.getAlphaSearchModel = () => "gpt-5-mini"
+  alphaSearchRouteDependencies.isAlphaSearchCodexPriorityEnabled = () =>
+    alphaSearchCodexPriorityEnabled
+  alphaSearchRouteDependencies.resolveEffectiveProviderType =
+    resolveTestProviderType
+  alphaSearchRouteDependencies.resolveMappedModel = (model) =>
+    modelMappings[model] ?? model
+  alphaSearchRouteDependencies.resolveProviderConfig = resolveTestProviderConfig
+  providerAlphaSearchRouteDependencies.resolveProviderConfig =
+    resolveTestProviderConfig
   resetAlphaSearchState()
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
     fetchMock as unknown as typeof fetch
@@ -296,6 +307,11 @@ afterEach(async () => {
   state.verbose = false
   openrouterProviderConfig = null
   Object.assign(alphaSearchResponsesDependencies, originalResponsesDependencies)
+  Object.assign(alphaSearchRouteDependencies, originalRouteDependencies)
+  Object.assign(
+    providerAlphaSearchRouteDependencies,
+    originalProviderRouteDependencies,
+  )
   resetAlphaSearchState()
 })
 

--- a/tests/codex-create-responses.test.ts
+++ b/tests/codex-create-responses.test.ts
@@ -224,5 +224,32 @@ describe("codex api helpers", () => {
         (model) => !model.supported_endpoints?.includes("/v1/embeddings"),
       ),
     ).toBe(true)
+
+    const gpt56Models = models.data.filter((model) =>
+      model.id.startsWith("gpt-5.6-"),
+    )
+    expect(gpt56Models).toHaveLength(3)
+    for (const model of gpt56Models) {
+      expect(model.capabilities.supports.reasoning_effort).toEqual([
+        "none",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+      ])
+      expect(model.capabilities.supports.reasoning_effort).not.toContain(
+        "ultra",
+      )
+      expect(model.capabilities.limits.max_context_window_tokens).toBe(
+        1_050_000,
+      )
+      expect(model.capabilities.limits.max_output_tokens).toBe(128_000)
+    }
+
+    expect(
+      models.data.find((model) => model.id === "gpt-5.5")?.capabilities.supports
+        .reasoning_effort,
+    ).not.toContain("max")
   })
 })

--- a/tests/codex-websocket.test.ts
+++ b/tests/codex-websocket.test.ts
@@ -198,6 +198,7 @@ afterEach(() => {
 
 test("forwardCodexResponses falls back to HTTP for non-streaming responses", async () => {
   mockFetchJsonResponse(createResponsesResult("gpt-5.4", "resp-http"))
+  const downstream = new AbortController()
 
   const response = await forwardCodexResponses(
     {
@@ -209,6 +210,7 @@ test("forwardCodexResponses falls back to HTTP for non-streaming responses", asy
     }),
     undefined,
     {
+      signal: downstream.signal,
       transport: "websocket",
     },
   )
@@ -232,6 +234,8 @@ test("forwardCodexResponses falls back to HTTP for non-streaming responses", asy
 
   expect(request).toBe("https://chatgpt.com/backend-api/codex/responses")
   expect(requestInit?.method).toBe("POST")
+  expect(requestInit?.signal).toBeInstanceOf(AbortSignal)
+  expect(requestInit?.signal?.aborted).toBe(false)
 
   const payload = JSON.parse(requestInit.body) as {
     model?: string
@@ -251,6 +255,8 @@ test("forwardCodexResponses falls back to HTTP for non-streaming responses", asy
     model: "gpt-5.4",
     status: "completed",
   })
+  downstream.abort()
+  expect(requestInit?.signal?.aborted).toBe(false)
 })
 
 test("forwardCodexResponses moves system input messages into instructions for HTTP requests", async () => {
@@ -390,6 +396,24 @@ test("forwardCodexResponses emits an error event when the websocket closes witho
   expect(chunks[0]?.data).toContain(
     '"message":"Codex responses websocket ended without a terminal response"',
   )
+})
+
+test("forwardCodexResponses propagates cancellation to an active websocket", async () => {
+  MockWebSocket.autoComplete = false
+  const controller = new AbortController()
+  const response = await forwardCodexResponses(
+    { input: "hello", model: "gpt-5.4", stream: true },
+    new Headers(),
+    undefined,
+    { signal: controller.signal, transport: "websocket" },
+  )
+  const chunksPromise = collectStreamChunks(response as AsyncIterable<unknown>)
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  controller.abort()
+
+  expect(await chunksPromise).toEqual([])
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
 })
 
 const collectStreamChunks = async (

--- a/tests/codex-websocket.test.ts
+++ b/tests/codex-websocket.test.ts
@@ -342,6 +342,66 @@ test("forwardCodexResponses returns HTTP event streams when stream=true", async 
   expect(chunks[0]?.data).toContain('"type":"response.completed"')
 })
 
+test("forwardCodexResponses cancels and unlocks an HTTP body after a terminal event", async () => {
+  let cancelledBodies = 0
+  const upstreamBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          [
+            "event: response.completed",
+            `data: ${JSON.stringify({
+              response: createResponsesResult("gpt-5.4", "resp-http-terminal"),
+              sequence_number: 1,
+              type: "response.completed",
+            })}`,
+            "",
+            "",
+          ].join("\n"),
+        ),
+      )
+    },
+    cancel() {
+      cancelledBodies += 1
+    },
+  })
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(
+      new Response(upstreamBody, {
+        headers: {
+          "content-type": "text/event-stream; charset=utf-8",
+        },
+        status: 200,
+      }),
+    ),
+  )
+
+  const response = await forwardCodexResponses(
+    {
+      input: "hello",
+      model: "gpt-5.4",
+      stream: true,
+    },
+    new Headers({ accept: "text/event-stream" }),
+    undefined,
+    { transport: "http" },
+  )
+
+  const chunks: Array<{ data?: string; event?: string }> = []
+  for await (const chunk of response as AsyncIterable<{
+    data?: string
+    event?: string
+  }>) {
+    chunks.push(chunk)
+    break
+  }
+
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0]?.event).toBe("response.completed")
+  expect(cancelledBodies).toBe(1)
+  expect(upstreamBody.locked).toBe(false)
+})
+
 test("forwardCodexResponses preserves response.completed while using websocket", async () => {
   const response = await forwardCodexResponses(
     {

--- a/tests/create-responses-websocket-pool.test.ts
+++ b/tests/create-responses-websocket-pool.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, expect, mock, test } from "bun:test"
 import type { ResponsesResult } from "~/lib/types/responses"
 
 type ListenerEvent = {
-  data?: string
+  data?: unknown
   error?: unknown
   message?: string
 }
@@ -47,6 +47,8 @@ class MockWebSocket {
   static closeAfterComplete = false
   static failOpen = false
   static failOpenEvent: ListenerEvent | null = null
+  static neverOpen = false
+  static openDelayMs = 0
   static instances: Array<MockWebSocket> = []
 
   readonly sent: Array<string> = []
@@ -61,6 +63,7 @@ class MockWebSocket {
     this.url = url
     MockWebSocket.instances.push(this)
     originalSetTimeout(() => {
+      if (MockWebSocket.neverOpen) return
       if (MockWebSocket.failOpen) {
         this.readyState = MockWebSocket.CLOSED
         this.emit("error", MockWebSocket.failOpenEvent ?? {})
@@ -69,7 +72,7 @@ class MockWebSocket {
 
       this.readyState = MockWebSocket.OPEN
       this.emit("open", {})
-    }, 0)
+    }, MockWebSocket.openDelayMs)
   }
 
   addEventListener(event: string, listener: Listener): void {
@@ -103,6 +106,14 @@ class MockWebSocket {
 
   emitError(payload: ListenerEvent): void {
     this.emit("error", payload)
+  }
+
+  emitMessage(data: unknown): void {
+    this.emit("message", { data })
+  }
+
+  listenerCount(event: string): number {
+    return this.listeners.get(event)?.size ?? 0
   }
 
   completeLatestResponse(): void {
@@ -167,6 +178,15 @@ await mock.module("undici", () => ({
 
 const { state } = await import("~/lib/state")
 const { createResponses } = await import("~/services/copilot/create-responses")
+const {
+  createPooledWebSocketStream,
+  ResponsesWebSocketInactivityTimeoutError,
+  ResponsesWebSocketOpenTimeoutError,
+  WebSocketMessageBuffer,
+} = await import("~/services/responses-websocket")
+const { createResponsesSafeStream } = await import(
+  "~/services/responses-websocket-helpers"
+)
 
 const originalState = {
   accountType: state.accountType,
@@ -204,6 +224,8 @@ beforeEach(() => {
   MockWebSocket.closeAfterComplete = false
   MockWebSocket.failOpen = false
   MockWebSocket.failOpenEvent = null
+  MockWebSocket.neverOpen = false
+  MockWebSocket.openDelayMs = 0
   MockWebSocket.instances = []
   state.accountType = "individual"
   state.copilotApiUrl = "https://api.githubcopilot.com"
@@ -217,6 +239,8 @@ afterEach(() => {
   MockWebSocket.closeAfterComplete = false
   MockWebSocket.failOpen = false
   MockWebSocket.failOpenEvent = null
+  MockWebSocket.neverOpen = false
+  MockWebSocket.openDelayMs = 0
   for (const websocket of MockWebSocket.instances) {
     websocket.close()
   }
@@ -605,6 +629,238 @@ test("Responses websocket honors NO_PROXY when resolving Bun websocket proxy", a
     restoreProxyEnv(proxyEnv)
   }
 })
+
+test("Responses websocket opening has a real deadline", async () => {
+  MockWebSocket.neverOpen = true
+  const stream = createTestPooledStream("never-opens", {
+    openTimeoutMs: 5,
+  })
+
+  expect(await getRejectedError(collectStreamChunks(stream))).toBeInstanceOf(
+    ResponsesWebSocketOpenTimeoutError,
+  )
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+})
+
+test("Responses websocket can open just before its deadline", async () => {
+  MockWebSocket.openDelayMs = 5
+  const stream = createTestPooledStream("opens-in-time", {
+    openTimeoutMs: 25,
+  })
+
+  const chunksPromise = collectStreamChunks(stream)
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+  MockWebSocket.instances[0]?.completeLatestResponse()
+
+  const chunks = await chunksPromise
+  expect(chunks).toHaveLength(1)
+})
+
+test("Responses websocket active streams time out independently", async () => {
+  MockWebSocket.autoComplete = false
+  const stalled = createTestPooledStream("stalled", {
+    streamInactivityTimeoutMs: 5,
+  })
+  const healthy = createTestPooledStream("healthy", {
+    streamInactivityTimeoutMs: 100,
+  })
+  const stalledResult = collectStreamChunks(stalled)
+  const healthyResult = collectStreamChunks(healthy)
+
+  await waitFor(
+    () =>
+      MockWebSocket.instances.length === 2
+      && MockWebSocket.instances.every(
+        (websocket) => websocket.sent.length > 0,
+      ),
+  )
+  MockWebSocket.instances[1]?.completeLatestResponse()
+
+  expect(await getRejectedError(stalledResult)).toBeInstanceOf(
+    ResponsesWebSocketInactivityTimeoutError,
+  )
+  expect(await healthyResult).toHaveLength(1)
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+  expect(MockWebSocket.instances[1]?.readyState).toBe(MockWebSocket.OPEN)
+})
+
+test("Responses websocket messages reset the active-stream deadline", async () => {
+  MockWebSocket.autoComplete = false
+  const chunksPromise = collectStreamChunks(
+    createTestPooledStream("periodic", { streamInactivityTimeoutMs: 15 }),
+  )
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  MockWebSocket.instances[0]?.emitMessage(
+    '{"type":"response.output_text.delta"}',
+  )
+  await delay(8)
+  MockWebSocket.instances[0]?.emitMessage(
+    '{"type":"response.output_text.delta"}',
+  )
+  await delay(8)
+  MockWebSocket.instances[0]?.completeLatestResponse()
+
+  expect(await chunksPromise).toHaveLength(3)
+})
+
+test("Responses websocket terminal events clear active timers", async () => {
+  MockWebSocket.autoComplete = false
+  const chunksPromise = collectStreamChunks(
+    createTestPooledStream("terminal-clears", {
+      streamInactivityTimeoutMs: 5,
+    }),
+  )
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+  MockWebSocket.instances[0]?.completeLatestResponse()
+
+  expect(await chunksPromise).toHaveLength(1)
+  await delay(10)
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN)
+})
+
+test("Responses websocket late idle events invalidate pooled connections", async () => {
+  await collectStreamChunks(createTestPooledStream("late-event"))
+  expect(MockWebSocket.instances).toHaveLength(1)
+  expect(MockWebSocket.instances[0]?.listenerCount("message")).toBe(1)
+
+  MockWebSocket.instances[0]?.emitMessage(
+    '{"type":"response.output_text.delta"}',
+  )
+  await Promise.resolve()
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+
+  await collectStreamChunks(createTestPooledStream("late-event"))
+  expect(MockWebSocket.instances).toHaveLength(2)
+})
+
+test("Responses websocket cancellation is quiet when wrapped as a Responses stream", async () => {
+  MockWebSocket.autoComplete = false
+  const controller = new AbortController()
+  const source = createTestPooledStream("cancelled", {
+    signal: controller.signal,
+  })
+  const chunksPromise = collectStreamChunks(
+    createResponsesSafeStream(source, { signal: controller.signal }),
+  )
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  controller.abort()
+
+  expect(await chunksPromise).toEqual([])
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+})
+
+test("Responses websocket cancellation while connecting closes the socket", async () => {
+  MockWebSocket.neverOpen = true
+  const controller = new AbortController()
+  const chunksPromise = collectStreamChunks(
+    createResponsesSafeStream(
+      createTestPooledStream("cancel-connect", {
+        signal: controller.signal,
+      }),
+      { signal: controller.signal },
+    ),
+  )
+  await waitFor(() => MockWebSocket.instances.length === 1)
+
+  controller.abort()
+
+  expect(await chunksPromise).toEqual([])
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+})
+
+test("Responses websocket buffer tracks bytes, binary data, and dequeue order", async () => {
+  const buffer = new WebSocketMessageBuffer(32, 4)
+  const binary = new TextEncoder().encode("bc")
+
+  expect(buffer.enqueue("a")).toBe(true)
+  expect(buffer.enqueue(binary)).toBe(true)
+  expect(buffer.bufferedBytes).toBe(3)
+  expect(buffer.bufferedMessages).toBe(2)
+  expect(await buffer.dequeue()).toBe("a")
+  expect(buffer.bufferedBytes).toBe(2)
+  expect(await buffer.dequeue()).toBe("bc")
+  expect(buffer.bufferedBytes).toBe(0)
+  expect(buffer.bufferedMessages).toBe(0)
+})
+
+test("Responses websocket buffer overflow emits one error and invalidates the socket", async () => {
+  MockWebSocket.autoComplete = false
+  const source = createTestPooledStream("overflow", {
+    maxBufferedBytes: 8,
+    maxBufferedMessages: 2,
+  })
+  const chunksPromise = collectStreamChunks(createResponsesSafeStream(source))
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  MockWebSocket.instances[0]?.emitMessage("1234")
+  MockWebSocket.instances[0]?.emitMessage("5678")
+  MockWebSocket.instances[0]?.emitMessage("overflow")
+
+  const chunks = await chunksPromise
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0]?.event).toBe("error")
+  expect(chunks[0]?.data).toContain("websocket buffer exceeded")
+  expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.CLOSED)
+
+  const nextChunksPromise = collectStreamChunks(
+    createTestPooledStream("overflow"),
+  )
+  await waitFor(() => MockWebSocket.instances[1]?.sent.length === 1)
+  MockWebSocket.instances[1]?.completeLatestResponse()
+  await nextChunksPromise
+  expect(MockWebSocket.instances).toHaveLength(2)
+})
+
+const createTestPooledStream = (
+  poolKey: string,
+  overrides: {
+    maxBufferedBytes?: number
+    maxBufferedMessages?: number
+    openTimeoutMs?: number
+    signal?: AbortSignal
+    streamInactivityTimeoutMs?: number
+  } = {},
+): AsyncIterable<{ data?: string; event?: string }> =>
+  createPooledWebSocketStream(
+    {
+      headers: {},
+      payload: { model: "gpt-test" },
+      poolKey: `test-${poolKey}`,
+      signal: overrides.signal,
+      url: "wss://api.githubcopilot.com/responses",
+    },
+    {
+      createChunk: (data) => {
+        const parsed = JSON.parse(data) as { type?: string }
+        return { data, event: parsed.type }
+      },
+      isTerminalChunk: (chunk) => chunk.event === "response.completed",
+      maxBufferedBytes: overrides.maxBufferedBytes ?? 1024,
+      maxBufferedMessages: overrides.maxBufferedMessages ?? 32,
+      openErrorMessage: "open failed",
+      openTimeoutMs: overrides.openTimeoutMs ?? 100,
+      poolIdleTimeoutMs: 1000,
+      streamErrorMessage: "stream failed",
+      streamInactivityTimeoutMs: overrides.streamInactivityTimeoutMs ?? 100,
+      terminalChunkMissingMessage: "terminal missing",
+    },
+  )
+
+const delay = async (milliseconds: number): Promise<void> =>
+  await new Promise<void>((resolve) => {
+    originalSetTimeout(resolve, milliseconds)
+  })
+
+const getRejectedError = async (promise: Promise<unknown>): Promise<Error> => {
+  try {
+    await promise
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+  throw new Error("Expected promise to reject")
+}
 
 const collectResponsesStream = async (requestId: string): Promise<void> => {
   const response = await createResponses(

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -168,6 +168,45 @@ describe("createResponses", () => {
     expect(response).toEqual(createResponsesResult("gpt-test"))
   })
 
+  test("keeps cache-relevant HTTP payloads deterministic", async () => {
+    const payload: ResponsesPayload = {
+      input: [
+        { role: "user", content: "hello" },
+        {
+          encrypted_content: "encrypted-reasoning",
+          id: "reasoning-1",
+          summary: [],
+          type: "reasoning",
+        },
+      ],
+      instructions: "stable instructions",
+      model: "gpt-test",
+      prompt_cache_key: "stable-cache-key",
+      stream: false,
+    }
+
+    await createResponses(structuredClone(payload), {
+      initiator: "user",
+      requestId: "request-1",
+      vision: false,
+    })
+    await createResponses(structuredClone(payload), {
+      initiator: "user",
+      requestId: "request-1",
+      vision: false,
+    })
+
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(
+      fetchMock.mock.calls[1]?.[1]?.body,
+    )
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toContain(
+      '"prompt_cache_key":"stable-cache-key"',
+    )
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toContain(
+      '"encrypted_content":"encrypted-reasoning"',
+    )
+  })
+
   test("builds the first websocket frame as response.create", () => {
     const payload = {
       background: true,

--- a/tests/models-route.test.ts
+++ b/tests/models-route.test.ts
@@ -613,10 +613,12 @@ describe("model routes", () => {
       description: "Sol catalog description",
       base_instructions: "Sol catalog instructions",
       context_window: 372_000,
+      default_reasoning_level: "max",
       priority: 11,
       supported_reasoning_levels: [
         { effort: "high", description: "High reasoning" },
         { effort: "xhigh", description: "Extra high reasoning" },
+        { effort: "max", description: "Maximum reasoning" },
       ],
       use_responses_lite: false,
       custom_catalog_field: { source: "sol" },

--- a/tests/provider-responses-context-management.test.ts
+++ b/tests/provider-responses-context-management.test.ts
@@ -5,30 +5,30 @@ import type { ResolvedProviderConfig } from "~/lib/config"
 import { state } from "~/lib/state"
 import type { ResponsesResult } from "~/lib/types/responses"
 
-const actualConfigModule = await import("~/lib/config")
-const actualTokenUsageModule = await import("~/lib/token-usage")
-
 let providerConfig: ResolvedProviderConfig | null = null
-
-const noopTokenUsageRecorder = () => {}
-
-await mock.module("~/lib/config", () => ({
-  ...actualConfigModule,
-  getProviderConfig: () => providerConfig,
-  resolveMappedModel: (model: string) => model,
-}))
-
-await mock.module("~/lib/token-usage", () => ({
-  ...actualTokenUsageModule,
-  createProviderTokenUsageRecorder: () => noopTokenUsageRecorder,
-}))
 
 const { responsesRoutes } = await import("~/routes/responses/route")
 const { providerResponsesRoutes } = await import(
   "~/routes/provider/responses/route"
 )
+const { providerMessagesHandlerDependencies } = await import(
+  "~/routes/provider/messages/handler"
+)
+const { providerResponsesHandlerDependencies } = await import(
+  "~/routes/provider/responses/handler"
+)
+const { responsesHandlerDependencies } = await import(
+  "~/routes/responses/handler"
+)
 const { responsesUtilsDependencies } = await import("~/routes/responses/utils")
 
+const defaultProviderMessagesHandlerDependencies = {
+  ...providerMessagesHandlerDependencies,
+}
+const defaultProviderResponsesHandlerDependencies = {
+  ...providerResponsesHandlerDependencies,
+}
+const defaultResponsesHandlerDependencies = { ...responsesHandlerDependencies }
 const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
 const originalFetch = globalThis.fetch
 
@@ -95,6 +95,12 @@ beforeEach(() => {
     type: "openai-responses",
   }
 
+  const resolveProviderConfig = () => Promise.resolve(providerConfig)
+  providerMessagesHandlerDependencies.resolveProviderConfig =
+    resolveProviderConfig
+  providerResponsesHandlerDependencies.resolveProviderConfig =
+    resolveProviderConfig
+  responsesHandlerDependencies.resolveMappedModel = (model) => model
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
     undefined
   responsesUtilsDependencies.isContextManagementEnabledForMessages = () => true
@@ -109,6 +115,18 @@ beforeEach(() => {
 afterEach(() => {
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
   providerConfig = null
+  Object.assign(
+    providerMessagesHandlerDependencies,
+    defaultProviderMessagesHandlerDependencies,
+  )
+  Object.assign(
+    providerResponsesHandlerDependencies,
+    defaultProviderResponsesHandlerDependencies,
+  )
+  Object.assign(
+    responsesHandlerDependencies,
+    defaultResponsesHandlerDependencies,
+  )
   Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
 })
 

--- a/tests/provider-responses-context-management.test.ts
+++ b/tests/provider-responses-context-management.test.ts
@@ -326,12 +326,14 @@ describe("provider Responses context management", () => {
 
   test("propagates provider-scoped client cancellation upstream without a 500", async () => {
     let upstreamSignal: AbortSignal | undefined
+    const upstreamStarted = createDeferred()
     fetchMock.mockImplementation((_url, init) => {
       const signal = init?.signal
       if (!(signal instanceof AbortSignal)) {
         throw new Error("Expected upstream abort signal")
       }
       upstreamSignal = signal
+      upstreamStarted.resolve()
       return new Promise<Response>((_resolve, reject) => {
         if (signal.aborted) {
           reject(
@@ -362,7 +364,7 @@ describe("provider Responses context management", () => {
         signal: controller.signal,
       }),
     )
-    await waitFor(() => upstreamSignal !== undefined)
+    await upstreamStarted.promise
 
     controller.abort()
 
@@ -375,6 +377,7 @@ describe("provider Responses context management", () => {
     const originalCodexAccessToken = state.codexAccessToken
     const originalCodexAccountId = state.codexAccountId
     let upstreamSignal: AbortSignal | undefined
+    const upstreamStarted = createDeferred()
     providerConfig = {
       apiKey: "",
       authType: "oauth2",
@@ -392,6 +395,7 @@ describe("provider Responses context management", () => {
         throw new Error("Expected upstream abort signal")
       }
       upstreamSignal = signal
+      upstreamStarted.resolve()
       return new Promise<Response>((_resolve, reject) => {
         signal.addEventListener(
           "abort",
@@ -416,7 +420,7 @@ describe("provider Responses context management", () => {
           signal: controller.signal,
         }),
       )
-      await waitFor(() => upstreamSignal !== undefined)
+      await upstreamStarted.promise
 
       controller.abort()
 
@@ -620,10 +624,13 @@ describe("provider Responses context management", () => {
   })
 })
 
-const waitFor = async (predicate: () => boolean): Promise<void> => {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    if (predicate()) return
-    await new Promise<void>((resolve) => setTimeout(resolve, 0))
-  }
-  throw new Error("Timed out waiting for condition")
+const createDeferred = (): {
+  promise: Promise<void>
+  resolve: () => void
+} => {
+  let resolve!: () => void
+  const promise = new Promise<void>((deferredResolve) => {
+    resolve = deferredResolve
+  })
+  return { promise, resolve }
 }

--- a/tests/provider-responses-context-management.test.ts
+++ b/tests/provider-responses-context-management.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 
 import type { ResolvedProviderConfig } from "~/lib/config"
+import { state } from "~/lib/state"
 import type { ResponsesResult } from "~/lib/types/responses"
 
 const actualConfigModule = await import("~/lib/config")
@@ -320,6 +321,112 @@ describe("provider Responses context management", () => {
       model: string
     }
     expect(body.model).toBe("gpt-test")
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  test("propagates provider-scoped client cancellation upstream without a 500", async () => {
+    let upstreamSignal: AbortSignal | undefined
+    fetchMock.mockImplementation((_url, init) => {
+      const signal = init?.signal
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("Expected upstream abort signal")
+      }
+      upstreamSignal = signal
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(
+            signal.reason instanceof Error ?
+              signal.reason
+            : new Error("Provider request aborted"),
+          )
+          return
+        }
+        signal.addEventListener(
+          "abort",
+          () =>
+            reject(
+              signal.reason instanceof Error ?
+                signal.reason
+              : new Error("Provider request aborted"),
+            ),
+          { once: true },
+        )
+      })
+    })
+    const controller = new AbortController()
+    const responsePromise = createApp().fetch(
+      new Request("http://localhost/openai/v1/responses", {
+        body: JSON.stringify({ input: "hello", model: "gpt-test" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+        signal: controller.signal,
+      }),
+    )
+    await waitFor(() => upstreamSignal !== undefined)
+
+    controller.abort()
+
+    const response = await responsePromise
+    expect(upstreamSignal?.aborted).toBe(true)
+    expect(response.status).toBe(499)
+  })
+
+  test("propagates provider-prefixed Codex cancellation upstream", async () => {
+    const originalCodexAccessToken = state.codexAccessToken
+    const originalCodexAccountId = state.codexAccountId
+    let upstreamSignal: AbortSignal | undefined
+    providerConfig = {
+      apiKey: "",
+      authType: "oauth2",
+      baseUrl: "https://chatgpt.example/backend-api",
+      models: { "gpt-test": {} },
+      name: "codex",
+      type: "openai-responses",
+    }
+    state.codexAccessToken = "synthetic-codex-token"
+    state.codexAccountId = "synthetic-account"
+    fetchMock.mockImplementation((url, init) => {
+      expect(url).toBe("https://chatgpt.example/backend-api/codex/responses")
+      const signal = init?.signal
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("Expected upstream abort signal")
+      }
+      upstreamSignal = signal
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener(
+          "abort",
+          () =>
+            reject(
+              signal.reason instanceof Error ?
+                signal.reason
+              : new Error("Codex request aborted"),
+            ),
+          { once: true },
+        )
+      })
+    })
+
+    try {
+      const controller = new AbortController()
+      const responsePromise = createApp().fetch(
+        new Request("http://localhost/codex/v1/responses", {
+          body: JSON.stringify({ input: "hello", model: "gpt-test" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+          signal: controller.signal,
+        }),
+      )
+      await waitFor(() => upstreamSignal !== undefined)
+
+      controller.abort()
+
+      const response = await responsePromise
+      expect(upstreamSignal?.aborted).toBe(true)
+      expect(response.status).toBe(499)
+    } finally {
+      state.codexAccessToken = originalCodexAccessToken
+      state.codexAccountId = originalCodexAccountId
+    }
   })
 
   test("adapts Responses Lite through Messages to Chat Completions", async () => {
@@ -512,3 +619,11 @@ describe("provider Responses context management", () => {
     })
   })
 })
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) return
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error("Timed out waiting for condition")
+}

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -623,6 +623,54 @@ describe("responses handler token usage", () => {
     expect(createResponses.mock.calls[0][1]?.transport).toBe("http")
   })
 
+  for (const [transport, supportedEndpoints] of [
+    ["http", ["/responses"]],
+    ["websocket", ["/responses", "ws:/responses"]],
+  ] as const) {
+    test(`sanitizes unsupported Copilot input fields before the ${transport} transport`, async () => {
+      state.models = {
+        object: "list",
+        data: [
+          {
+            capabilities: { limits: { max_prompt_tokens: 128000 } },
+            id: "gpt-test",
+            supported_endpoints: [...supportedEndpoints],
+          },
+        ],
+      } as typeof state.models
+      createResponses.mockImplementation((payload) =>
+        Promise.resolve(createResponsesResult(payload.model)),
+      )
+
+      const response = await createApp().request("/v1/responses", {
+        body: JSON.stringify({
+          input: [
+            {
+              content: "hello",
+              internal_chat_message_metadata_passthrough: {
+                private: "must-not-be-forwarded",
+              },
+              role: "user",
+            },
+          ],
+          model: "gpt-test",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      })
+
+      expect(response.status).toBe(200)
+      expect(createResponses).toHaveBeenCalledTimes(1)
+      expect(createResponses.mock.calls[0][1]?.transport).toBe(transport)
+      expect(createResponses.mock.calls[0][1]?.signal).toBeInstanceOf(
+        AbortSignal,
+      )
+      expect(createResponses.mock.calls[0][0].input).toEqual([
+        { content: "hello", role: "user" },
+      ])
+    })
+  }
+
   test("does not add context management to native Responses API by default", async () => {
     createResponses.mockImplementation((payload) =>
       Promise.resolve(createResponsesResult(payload.model)),

--- a/tests/responses-http-lifecycle.test.ts
+++ b/tests/responses-http-lifecycle.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, expect, mock, test } from "bun:test"
+
+import {
+  defaultResponsesTransportConfig,
+  normalizeResponsesTransportConfig,
+} from "~/lib/config"
+import {
+  fetchResponsesWithLifecycle,
+  ResponsesHeadersTimeoutError,
+  ResponsesStreamInactivityTimeoutError,
+} from "~/services/responses-http"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
+})
+
+test("Responses transport configuration validates positive integer limits", () => {
+  expect(
+    normalizeResponsesTransportConfig({
+      headersTimeoutMs: 12.8,
+      streamInactivityTimeoutMs: 0,
+      websocketMaxBufferedBytes: -1,
+      websocketMaxBufferedMessages: Number.NaN,
+      websocketOpenTimeoutMs: 45,
+    }),
+  ).toEqual({
+    ...defaultResponsesTransportConfig,
+    headersTimeoutMs: 12,
+    websocketOpenTimeoutMs: 45,
+  })
+})
+
+test("downstream cancellation aborts only its upstream HTTP request", async () => {
+  const upstreamSignals: Array<AbortSignal> = []
+  let cancelledBodies = 0
+  const fetchMock = mock(
+    (_input: string | URL | Request, init?: RequestInit) => {
+      upstreamSignals.push(init?.signal as AbortSignal)
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("event"))
+            },
+            cancel() {
+              cancelledBodies += 1
+            },
+          }),
+        ),
+      )
+    },
+  )
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
+    fetchMock as unknown as typeof fetch
+
+  const firstController = new AbortController()
+  const secondController = new AbortController()
+  const firstResponse = await fetchResponsesWithLifecycle(
+    "https://first.example/responses",
+    { method: "POST" },
+    lifecycleOptions(firstController.signal),
+  )
+  const secondResponse = await fetchResponsesWithLifecycle(
+    "https://second.example/responses",
+    { method: "POST" },
+    lifecycleOptions(secondController.signal),
+  )
+  const firstReader = firstResponse.body!.getReader()
+  const secondReader = secondResponse.body!.getReader()
+
+  await firstReader.read()
+  await secondReader.read()
+  firstController.abort(new Error("client disconnected"))
+
+  expect(await getRejectedError(firstReader.read())).toHaveProperty(
+    "message",
+    "client disconnected",
+  )
+  expect(cancelledBodies).toBe(1)
+  expect(upstreamSignals[0]?.aborted).toBe(true)
+  expect(upstreamSignals[1]?.aborted).toBe(false)
+
+  secondController.abort(new Error("test cleanup"))
+  expect(await getRejectedError(secondReader.read())).toHaveProperty(
+    "message",
+    "test cleanup",
+  )
+  expect(cancelledBodies).toBe(2)
+})
+
+test("normal HTTP body completion removes downstream cancellation linkage", async () => {
+  let upstreamSignal: AbortSignal | undefined
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = mock(
+    (_input: string | URL | Request, init?: RequestInit) => {
+      upstreamSignal = init?.signal as AbortSignal
+      return Promise.resolve(Response.json({ ok: true }))
+    },
+  ) as unknown as typeof fetch
+
+  const downstream = new AbortController()
+  const response = await fetchResponsesWithLifecycle(
+    "https://upstream.example/responses",
+    { method: "POST" },
+    lifecycleOptions(downstream.signal),
+  )
+
+  expect(await response.json()).toEqual({ ok: true })
+  expect(upstreamSignal?.aborted).toBe(false)
+  downstream.abort(new Error("too late"))
+  expect(upstreamSignal?.aborted).toBe(false)
+})
+
+test("HTTP headers deadline aborts a stalled fetch with an actionable error", async () => {
+  let upstreamSignal: AbortSignal | undefined
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = mock(
+    (_input: string | URL | Request, init?: RequestInit) => {
+      upstreamSignal = init?.signal as AbortSignal
+      return new Promise<Response>((_resolve, reject) => {
+        upstreamSignal?.addEventListener(
+          "abort",
+          () =>
+            reject(
+              upstreamSignal?.reason instanceof Error ?
+                upstreamSignal.reason
+              : new Error("HTTP request aborted"),
+            ),
+          { once: true },
+        )
+      })
+    },
+  ) as unknown as typeof fetch
+
+  expect(
+    await getRejectedError(
+      fetchResponsesWithLifecycle(
+        "https://upstream.example/responses",
+        { method: "POST" },
+        {
+          headersTimeoutMs: 5,
+          streamInactivityTimeoutMs: 100,
+        },
+      ),
+    ),
+  ).toBeInstanceOf(ResponsesHeadersTimeoutError)
+  expect(upstreamSignal?.aborted).toBe(true)
+})
+
+test("HTTP stream inactivity aborts stalled body consumption", async () => {
+  let upstreamSignal: AbortSignal | undefined
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = mock(
+    (_input: string | URL | Request, init?: RequestInit) => {
+      upstreamSignal = init?.signal as AbortSignal
+      return Promise.resolve(
+        new Response(new ReadableStream<Uint8Array>({ start() {} })),
+      )
+    },
+  ) as unknown as typeof fetch
+
+  const response = await fetchResponsesWithLifecycle(
+    "https://upstream.example/responses",
+    { method: "POST" },
+    {
+      headersTimeoutMs: 100,
+      streamInactivityTimeoutMs: 5,
+    },
+  )
+
+  expect(
+    await getRejectedError(response.body!.getReader().read()),
+  ).toBeInstanceOf(ResponsesStreamInactivityTimeoutError)
+  expect(upstreamSignal?.aborted).toBe(true)
+})
+
+const lifecycleOptions = (
+  signal: AbortSignal,
+): {
+  headersTimeoutMs: number
+  signal: AbortSignal
+  streamInactivityTimeoutMs: number
+} => ({
+  headersTimeoutMs: 1000,
+  signal,
+  streamInactivityTimeoutMs: 1000,
+})
+
+const getRejectedError = async (promise: Promise<unknown>): Promise<Error> => {
+  try {
+    await promise
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+  throw new Error("Expected promise to reject")
+}

--- a/tests/responses-input-sanitizer.test.ts
+++ b/tests/responses-input-sanitizer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+
+import type { ResponsesPayload } from "~/services/copilot/create-responses"
+
+import { sanitizeUnsupportedInputFields } from "~/routes/responses/utils"
+
+describe("sanitizeUnsupportedInputFields", () => {
+  test("removes Codex internal_chat_message_metadata_passthrough from input items", () => {
+    const payload = {
+      input: [
+        {
+          content: [{ text: "hello", type: "input_text" }],
+          internal_chat_message_metadata_passthrough: {
+            turn_id: "turn-1",
+          },
+          role: "user",
+        },
+        {
+          content: [{ text: "world", type: "input_text" }],
+          role: "assistant",
+        },
+      ],
+      model: "gpt-5.5",
+    } as unknown as ResponsesPayload
+
+    expect(sanitizeUnsupportedInputFields(payload)).toBe(1)
+    expect(
+      (payload.input as Array<Record<string, unknown>>)[0]
+        .internal_chat_message_metadata_passthrough,
+    ).toBeUndefined()
+  })
+
+  test("returns zero when input is missing or unsupported fields are absent", () => {
+    expect(
+      sanitizeUnsupportedInputFields({ model: "gpt-5.5" } as ResponsesPayload),
+    ).toBe(0)
+    expect(
+      sanitizeUnsupportedInputFields({
+        input: [{ content: "hello", role: "user" }],
+        model: "gpt-5.5",
+      } as ResponsesPayload),
+    ).toBe(0)
+  })
+})

--- a/tests/responses-input-sanitizer.test.ts
+++ b/tests/responses-input-sanitizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import type { ResponsesPayload } from "~/services/copilot/create-responses"
+import type { ResponsesPayload } from "~/lib/types/responses"
 
 import { sanitizeUnsupportedInputFields } from "~/routes/responses/utils"
 


### PR DESCRIPTION
## Why

I use `copilot-api` every day and have been experiencing several reliability issues around cancelled or stalled Responses requests, especially with long-running streams and the pooled WebSocket transport. In practice, client disconnects could leave upstream generations running, active streams could hang indefinitely, and slow consumers could grow the in-memory WebSocket queue without a bound.

This PR is my attempt to fix those issues comprehensively. I would appreciate a review even if you would prefer to reimplement some or all of the approach in a different shape.

## What changed

- propagate each downstream request's `AbortSignal` through the native GitHub Copilot, ChatGPT Codex-provider, and generic provider Responses paths
- return a quiet 499 for client cancellation and deterministically release body readers, stream iterators, timers, listeners, and request-specific sockets
- add distinct configurable HTTP headers, stream inactivity, WebSocket open, active-stream inactivity, and reusable-pool idle timeouts; there is no short total-generation deadline
- bound ordered WebSocket buffering by both bytes and message count, failing and invalidating the affected socket rather than dropping deltas
- prevent concurrent or late WebSocket events from crossing request boundaries, while preserving reuse after a clean terminal response
- invoke the existing unsupported-input sanitizer on the actual GitHub Copilot HTTP and WebSocket path, without applying Copilot-specific stripping to the separate ChatGPT Codex backend or generic providers
- correct the built-in GPT-5.6 Sol/Terra/Luna reasoning metadata (`none` through `max`, with raw `ultra` kept separate) and context/output limits
- remove order-dependent alpha-search tests caused by process-wide Bun module mocks, replacing them with scoped dependency overrides that are restored after each test
- preserve cache-relevant payload ordering, reasoning/encrypted content, tool IDs, `prompt_cache_key`, and backend-specific request behavior

The default limits are conservative and backward compatible:

- HTTP headers: 30 seconds
- active HTTP/WebSocket inactivity: 5 minutes
- WebSocket open: 30 seconds
- reusable WebSocket pool idle: 60 seconds
- WebSocket buffer: 8 MiB or 1,024 messages

All values are configurable under `responsesTransport` and documented in both READMEs.

## Validation

- `bun run typecheck`
- `bun run lint:all`
- `bun run build`
- targeted HTTP, WebSocket, handler, provider, sanitizer, model, cache-stability, and alpha-search tests
- repeated full-suite runs; final result: 597 passed, 0 failed across 61 files
- changed executable source-line coverage: 93.29% (709/760)

All upstream behavior was exercised with mocks and local fixtures; no live GitHub Copilot, ChatGPT backend, or paid OpenAI request was made during validation.
