### PR TITLE
fix: normalize client model id in chat completions handler

### DIFF
--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -5,8 +5,8 @@ import { streamSSE, type SSEMessage } from "hono/streaming"
 
 import { resolveMappedModel } from "~/lib/config"
 import { createHandlerLogger, debugJson } from "~/lib/logger"
+import { findEndpointModel } from "~/lib/models"
 import { parseProviderModelAlias } from "~/lib/provider-model"
-import { state } from "~/lib/state"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
@@ -45,10 +45,8 @@ export async function handleCompletion(c: Context) {
 
   debugJson(logger, "Request payload:", payload)
 
-  // Find the selected model
-  const selectedModel = state.models?.data.find(
-    (model) => model.id === payload.model,
-  )
+  const selectedModel = findEndpointModel(payload.model)
+  payload.model = selectedModel?.id ?? payload.model
 
   if (
     isNullish(payload.max_tokens)


### PR DESCRIPTION
 - /v1/models returns client-friendly ids with hyphens (e.g. claude-opus-4-7), but the /v1/chat/completions handler looked up the model by strict equality against upstream ids (which use dots, e.g. claude-opus-4.7). The match failed, so payload.model was forwarded to Copilot unchanged and upstream rejected the request.
 - Switched to findEndpointModel, matching the pattern already used in src/routes/messages/handler.ts and src/routes/responses/handler.ts.

 Test plan

 - bun run typecheck
 - bun test tests/create-chat-completions.test.ts
 - bun test tests/provider-chat-completions-alias.test.ts