### PR TITLE
Use provider-specific model context limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,6 @@ Add the following `[model_providers.copilot_api]` section to your Codex `~/.code
 ```toml
 model_provider = "copilot_api"
 model_reasoning_summary = "auto"
-model_context_window = 272000
-model_auto_compact_token_limit = 244800
 web_search = "live"
 
 [model_providers.copilot_api]
@@ -409,6 +407,11 @@ apps = false
 [analytics]
 enabled = false
 ```
+
+Context and auto-compaction limits are discovered from the gateway's model
+catalog. Avoid setting `model_context_window` or
+`model_auto_compact_token_limit` globally, because those overrides apply the
+same fixed limit to every selected model.
 
 > [!NOTE]
 > `name` must be set to `"OpenAI"`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -414,8 +414,6 @@ npx @jeffreycao/copilot-api@latest start
 ```toml
 model_provider = "copilot_api"
 model_reasoning_summary = "auto"
-model_context_window = 272000
-model_auto_compact_token_limit = 244800
 web_search = "live"
 
 [model_providers.copilot_api]
@@ -437,6 +435,9 @@ apps = false
 [analytics]
 enabled = false
 ```
+
+上下文与自动压缩限制会从 gateway 的模型目录中自动获取。请避免全局设置
+`model_context_window` 或 `model_auto_compact_token_limit`，因为这些覆盖项会对每个所选模型应用相同的固定限制。
 
 > [!NOTE]
 > `name` 一定要配置为 `"OpenAI"`。

--- a/src/routes/models/codex-models-types.ts
+++ b/src/routes/models/codex-models-types.ts
@@ -151,6 +151,7 @@ export interface SyntheticCodexModelCandidate {
   displayName: string
   description: string
   contextWindow: number
+  maxPromptTokens?: number
   maxOutputTokens: number
   inputModalities: Array<CodexInputModality>
   reasoningEfforts: Array<CodexReasoningEffort>

--- a/src/routes/models/codex-models.ts
+++ b/src/routes/models/codex-models.ts
@@ -344,6 +344,15 @@ export async function handleMergedCodexModels(
   const catalogModelsBySlug = new Map(
     upstreamModels.map((model) => [model.slug, model]),
   )
+  const candidatesBySlug = new Map(
+    candidates.map((candidate) => [candidate.slug, candidate]),
+  )
+  // A matching unprefixed model routes through Copilot, while the codex/
+  // alias below routes through ChatGPT Codex. Keep each route's own limits.
+  const routedUpstreamModels = upstreamModels.map((model) => {
+    const candidate = candidatesBySlug.get(model.slug)
+    return candidate ? applyCandidateLimits(model, candidate) : model
+  })
   const seenSlugs = new Set(upstreamModels.map((model) => model.slug))
   const codexProviderAliases =
     options.includeCodexProviderAliases ?
@@ -387,7 +396,7 @@ export async function handleMergedCodexModels(
     })
 
   const models = [
-    ...upstreamModels,
+    ...routedUpstreamModels,
     ...codexProviderAliases,
     ...syntheticModels,
   ].sort((a, b) => getModelPriority(a) - getModelPriority(b))
@@ -403,6 +412,29 @@ export async function handleMergedCodexModels(
     models: response,
   })
   return c.json(response)
+}
+
+function applyCandidateLimits(
+  model: CodexModel,
+  candidate: SyntheticCodexModelCandidate,
+): CodexModel {
+  return {
+    ...model,
+    context_window: candidate.contextWindow,
+    max_context_window: candidate.contextWindow,
+    max_output_tokens: candidate.maxOutputTokens,
+    auto_compact_token_limit: getCandidateAutoCompactTokenLimit(candidate),
+  }
+}
+
+function getCandidateAutoCompactTokenLimit(
+  candidate: SyntheticCodexModelCandidate,
+): number | null {
+  if (candidate.maxPromptTokens === undefined) return null
+  return Math.min(
+    candidate.maxPromptTokens,
+    Math.floor(candidate.contextWindow * 0.9),
+  )
 }
 
 function createCatalogAlias(
@@ -468,7 +500,7 @@ export function createSyntheticCodexModel(
     context_window: candidate.contextWindow,
     max_context_window: candidate.contextWindow,
     max_output_tokens: candidate.maxOutputTokens,
-    auto_compact_token_limit: null,
+    auto_compact_token_limit: getCandidateAutoCompactTokenLimit(candidate),
     comp_hash: null,
     effective_context_window_percent: 95,
     default_reasoning_level: defaultReasoningEffort,

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -303,6 +303,9 @@ function createCopilotCodexCandidate(
       model.capabilities.limits.max_context_window_tokens,
       256_000,
     ),
+    maxPromptTokens: optionalPositiveNumber(
+      model.capabilities.limits.max_prompt_tokens,
+    ),
     maxOutputTokens: positiveNumber(
       model.capabilities.limits.max_output_tokens,
       32_000,
@@ -516,6 +519,12 @@ function positiveNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ?
       Math.floor(value)
     : fallback
+}
+
+function optionalPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ?
+      Math.floor(value)
+    : undefined
 }
 
 function getFirstPositiveNumber(

--- a/tests/codex-create-responses.test.ts
+++ b/tests/codex-create-responses.test.ts
@@ -248,6 +248,15 @@ describe("codex api helpers", () => {
     }
 
     expect(
+      models.data.find((model) => model.id === "gpt-5.4")?.capabilities.limits
+        .max_context_window_tokens,
+    ).toBe(400_000)
+    expect(
+      models.data.find((model) => model.id === "gpt-5.5")?.capabilities.limits
+        .max_context_window_tokens,
+    ).toBe(272_000)
+
+    expect(
       models.data.find((model) => model.id === "gpt-5.5")?.capabilities.supports
         .reasoning_effort,
     ).not.toContain("max")

--- a/tests/models-route.test.ts
+++ b/tests/models-route.test.ts
@@ -711,6 +711,65 @@ describe("model routes", () => {
     )
   })
 
+  test("uses Copilot limits for matching unprefixed Codex catalog models", async () => {
+    codexCatalogModels = [
+      {
+        slug: "gpt-5.6-sol",
+        display_name: "GPT-5.6 Sol",
+        context_window: 372_000,
+        max_context_window: 372_000,
+        max_output_tokens: 128_000,
+        auto_compact_token_limit: 334_800,
+        priority: 11,
+      },
+    ]
+    const copilotModels = createCopilotModels(["gpt-5.6-sol"])
+    copilotModels.data[0].capabilities.limits = {
+      max_context_window_tokens: 1_050_000,
+      max_output_tokens: 128_000,
+      max_prompt_tokens: 922_000,
+    }
+    copilotModels.data[0].capabilities.supports.tool_calls = true
+    copilotModels.data[0].supported_endpoints = ["/responses"]
+    state.models = copilotModels
+    state.codexAccessToken = "codex-access-token"
+    state.codexAccountId = "account-123"
+    enabledProviders = ["codex"]
+    providerConfigs = {
+      codex: {
+        apiKey: "codex-token",
+        authType: "oauth2",
+        baseUrl: "https://chatgpt.com/backend-api",
+        name: "codex",
+        type: "openai-responses",
+      },
+    }
+
+    const response = await createApp().request("/v1/models", {
+      headers: { "user-agent": "codex-cli/1.0.0" },
+    })
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      models: Array<Record<string, unknown> & { slug: string }>
+    }
+    expect(
+      body.models.find((model) => model.slug === "gpt-5.6-sol"),
+    ).toMatchObject({
+      context_window: 1_050_000,
+      max_context_window: 1_050_000,
+      max_output_tokens: 128_000,
+      auto_compact_token_limit: 922_000,
+    })
+    expect(
+      body.models.find((model) => model.slug === "codex/gpt-5.6-sol"),
+    ).toMatchObject({
+      context_window: 372_000,
+      max_context_window: 372_000,
+      auto_compact_token_limit: 334_800,
+    })
+  })
+
   test("orders merged Codex models as catalog, codex, copilot, opencode-go, then providers", async () => {
     const copilotModels = createCopilotModels(["claude-sonnet-4.6"])
     copilotModels.data[0].supported_endpoints = ["/v1/messages"]


### PR DESCRIPTION
## Summary

- use GitHub Copilot's discovered context and output limits for unprefixed models routed through Copilot
- preserve the upstream ChatGPT Codex limits on `codex/` aliases
- cap Codex auto-compaction at the provider's advertised maximum prompt size
- remove global Codex context overrides from the English and Chinese setup examples

## Root cause

Matching models from the ChatGPT Codex catalog kept that catalog's smaller context window even when the unprefixed route was served by GitHub Copilot. Applying the larger Copilot context without its separate prompt ceiling would also make Codex derive a 945k compaction threshold, exceeding Copilot's advertised 922k maximum prompt.

## Impact

GPT models routed through Copilot can use their full discovered context window without crossing the upstream prompt limit. Explicit `codex/` routes continue to advertise the limits of the ChatGPT Codex backend they actually use.

## Validation

- `bun test` — 610 tests passed
- `bun run typecheck`
- targeted ESLint with repository formatting
- `bun run build`
- targeted coverage: 94%+ line coverage for the changed model-route files
