### PR TITLE
fix: validate provider existence before routing provider/model aliases

### DIFF
--- a/src/routes/alpha-search/route.ts
+++ b/src/routes/alpha-search/route.ts
@@ -222,10 +222,21 @@ export async function handleAlphaSearchRequest(
     messagesBackedModel ? payload.model : requestedModel
 
   if (providerModelAlias) {
-    return await alphaSearchRouteDependencies.handleAlphaSearchResponses(c, {
-      provider: providerModelAlias.provider,
-      request: payload,
-    })
+    // Only treat the "/" prefix as a custom provider alias when that provider
+    // is actually configured. Namespaced model ids such as "org/family/model"
+    // must fall through to the default alpha search path instead of being
+    // passed to handleAlphaSearchResponses with an unconfigured provider and
+    // surfaced as a 404.
+    const providerConfig =
+      await alphaSearchRouteDependencies.resolveProviderConfig(
+        providerModelAlias.provider,
+      )
+    if (providerConfig) {
+      return await alphaSearchRouteDependencies.handleAlphaSearchResponses(c, {
+        provider: providerModelAlias.provider,
+        request: payload,
+      })
+    }
   }
 
   return await alphaSearchRouteDependencies.handleAlphaSearchResponses(c, {

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -7,6 +7,7 @@ import { resolveMappedModel } from "~/lib/config"
 import { createHandlerLogger, debugJson } from "~/lib/logger"
 import { findEndpointModel } from "~/lib/models"
 import { parseProviderModelAlias } from "~/lib/provider-model"
+import { resolveProviderConfig } from "~/lib/provider-resolver"
 import {
   createCopilotTokenUsageRecorder,
   normalizeOpenAIUsage,
@@ -36,11 +37,21 @@ export async function handleCompletion(c: Context) {
 
   const providerModelAlias = parseProviderModelAlias(payload.model)
   if (providerModelAlias) {
-    payload.model = providerModelAlias.model
-    return await handleProviderChatCompletionsForProvider(c, {
-      payload,
-      provider: providerModelAlias.provider,
-    })
+    // Only treat the "/" prefix as a custom provider alias when that provider
+    // is actually configured. GitHub Copilot enterprise models can ship with
+    // namespaced ids such as "org/family/model" that must fall through to the
+    // default model lookup instead of being misrouted to a non-existent
+    // provider and surfaced as a 400.
+    const providerConfig = await resolveProviderConfig(
+      providerModelAlias.provider,
+    )
+    if (providerConfig) {
+      payload.model = providerModelAlias.model
+      return await handleProviderChatCompletionsForProvider(c, {
+        payload,
+        provider: providerModelAlias.provider,
+      })
+    }
   }
 
   debugJson(logger, "Request payload:", payload)

--- a/src/routes/chat-completions/handler.ts
+++ b/src/routes/chat-completions/handler.ts
@@ -42,6 +42,12 @@ export async function handleCompletion(c: Context) {
     // namespaced ids such as "org/family/model" that must fall through to the
     // default model lookup instead of being misrouted to a non-existent
     // provider and surfaced as a 400.
+    //
+    // Unlike the messages/responses routes, chat-completions has no route-level
+    // DI seam for resolveProviderConfig: the existing tests mock
+    // getProviderConfig (which resolveProviderConfig falls through to for
+    // non-codex providers), so a direct import is sufficient and consistent
+    // with resolveMappedModel/findEndpointModel above.
     const providerConfig = await resolveProviderConfig(
       providerModelAlias.provider,
     )

--- a/src/routes/messages/count-tokens-handler.ts
+++ b/src/routes/messages/count-tokens-handler.ts
@@ -11,6 +11,7 @@ import {
   createFallbackModel,
   parseProviderModelAlias,
 } from "~/lib/provider-model"
+import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { getTokenCount } from "~/lib/tokenizer"
 import { handleProviderCountTokensForProvider } from "~/routes/provider/messages/count-tokens-handler"
 import { type Model } from "~/lib/types/models"
@@ -97,11 +98,20 @@ export async function handleCountTokens(c: Context) {
 
   const providerModelAlias = parseProviderModelAlias(anthropicPayload.model)
   if (providerModelAlias) {
-    anthropicPayload.model = providerModelAlias.model
-    return await handleProviderCountTokensForProvider(c, {
-      payload: anthropicPayload,
-      provider: providerModelAlias.provider,
-    })
+    // Only treat the "/" prefix as a custom provider alias when that provider
+    // is actually configured. Namespaced model ids such as "org/family/model"
+    // must fall through to the Anthropic/tokenizer-estimation path instead of
+    // being misrouted to a non-existent provider and surfaced as a 404.
+    const providerConfig = await resolveProviderConfig(
+      providerModelAlias.provider,
+    )
+    if (providerConfig) {
+      anthropicPayload.model = providerModelAlias.model
+      return await handleProviderCountTokensForProvider(c, {
+        payload: anthropicPayload,
+        provider: providerModelAlias.provider,
+      })
+    }
   }
 
   // Try Anthropic's real endpoint first (Claude models only)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -20,7 +20,10 @@ import {
   getRootSessionId,
   getUUID,
 } from "~/lib/utils"
-import { handleProviderMessagesForProvider } from "~/routes/provider/messages/handler"
+import {
+  handleProviderMessagesForProvider,
+  providerMessagesHandlerDependencies,
+} from "~/routes/provider/messages/handler"
 import { getResponsesTransportForModel } from "~/routes/responses/utils"
 
 import type { AnthropicMessagesPayload } from "~/lib/types/anthropic"
@@ -107,12 +110,23 @@ export async function handleCompletionPayload(
 
   const providerModelAlias = parseProviderModelAlias(anthropicPayload.model)
   if (providerModelAlias) {
-    anthropicPayload.model = providerModelAlias.model
-    return await handleProviderMessagesForProvider(c, {
-      payload: anthropicPayload,
-      provider: providerModelAlias.provider,
-      usageEndpoint: dispatchOptions.usageEndpoint,
-    })
+    // Only treat the "/" prefix as a custom provider alias when that provider
+    // is actually configured. GitHub Copilot enterprise models can ship with
+    // namespaced ids such as "org/family/model" that must fall through to the
+    // default model lookup instead of being misrouted to a non-existent
+    // provider and surfaced as a 400.
+    const providerConfig =
+      await providerMessagesHandlerDependencies.resolveProviderConfig(
+        providerModelAlias.provider,
+      )
+    if (providerConfig) {
+      anthropicPayload.model = providerModelAlias.model
+      return await handleProviderMessagesForProvider(c, {
+        payload: anthropicPayload,
+        provider: providerModelAlias.provider,
+        usageEndpoint: dispatchOptions.usageEndpoint,
+      })
+    }
   }
 
   debugJson(logger, "Anthropic request payload:", anthropicPayload)

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -9,6 +9,7 @@ import {
 import { createHandlerLogger, debugJson, debugJsonTail } from "~/lib/logger"
 import { findEndpointModel } from "~/lib/models"
 import { parseProviderModelAlias } from "~/lib/provider-model"
+import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { isCodexUserAgent } from "~/routes/models/codex-models"
 import { handleProviderResponsesForProvider } from "~/routes/provider/responses/handler"
 import {
@@ -51,6 +52,7 @@ export const responsesHandlerDependencies = {
   findEndpointModel,
   isResponsesApiWebSearchEnabled: isConfiguredResponsesApiWebSearchEnabled,
   resolveMappedModel,
+  resolveProviderConfig,
 }
 
 export const handleResponses = async (c: Context) => {
@@ -65,12 +67,23 @@ export const handleResponses = async (c: Context) => {
 
   const providerModelAlias = parseProviderModelAlias(payload.model)
   if (providerModelAlias) {
-    payload.model = providerModelAlias.model
-    return await handleProviderResponsesForProvider(c, {
-      payload,
-      provider: providerModelAlias.provider,
-      publicModel: requestedModel,
-    })
+    // Only treat the "/" prefix as a custom provider alias when that provider
+    // is actually configured. GitHub Copilot enterprise models can ship with
+    // namespaced ids such as "org/family/model" that must fall through to the
+    // default model lookup instead of being misrouted to a non-existent
+    // provider and surfaced as a 400.
+    const providerConfig =
+      await responsesHandlerDependencies.resolveProviderConfig(
+        providerModelAlias.provider,
+      )
+    if (providerConfig) {
+      payload.model = providerModelAlias.model
+      return await handleProviderResponsesForProvider(c, {
+        payload,
+        provider: providerModelAlias.provider,
+        publicModel: requestedModel,
+      })
+    }
   }
 
   debugJson(logger, "Responses request payload:", payload)

--- a/tests/provider-model-alias.test.ts
+++ b/tests/provider-model-alias.test.ts
@@ -282,16 +282,23 @@ describe("provider/model aliases on top-level messages routes", () => {
 })
 
 describe("namespaced model ids fall through to the default lookup", () => {
+  // Regression guard for namespaced model ids returned by the GitHub Copilot
+  // gateway for enterprise accounts. The gateway lists enterprise-configured
+  // models with the account handle as a prefix, e.g. "contoso/glm-5.2" or a
+  // deeper org-scoped "contoso/family/glm-5.2". parseProviderModelAlias
+  // previously treated the first segment ("contoso") as a custom provider
+  // alias prefix, but no "contoso" entry exists in config.providers, so the
+  // request was misrouted to the provider path and surfaced as a 400/404.
+  // These ids must fall through to the default model lookup (Copilot
+  // upstream) and be sent as-is, exactly like a plain model id.
   test("does not route a namespaced /v1/messages id to the provider path", async () => {
-    // Models such as "org/family/model" must not be misrouted to a
-    // non-existent provider and surfaced as a 400. They should fall through
-    // to the default model lookup just like a plain model id.
+    // Single-segment namespacing: "contoso/glm-5.2".
     const app = createApp()
     const response = await app.request("/v1/messages", {
       body: JSON.stringify({
         max_tokens: 128,
         messages: [{ content: "hello", role: "user" }],
-        model: "org/family/model",
+        model: "contoso/glm-5.2",
       }),
       headers: {
         "content-type": "application/json",
@@ -308,14 +315,15 @@ describe("namespaced model ids fall through to the default lookup", () => {
   })
 
   test("does not route a namespaced /v1/messages/count_tokens id to the provider path and reaches the estimation fallback", async () => {
-    // count_tokens is called as a preflight by clients like Claude Code; it
-    // must not 404 on a namespaced id while the main /v1/messages flow works.
+    // Multi-segment namespacing: "contoso/family/glm-5.2". count_tokens is
+    // called as a preflight by clients like Claude Code; it must not 404 on
+    // a namespaced id while the main /v1/messages flow works.
     const app = createApp()
     const response = await app.request("/v1/messages/count_tokens", {
       body: JSON.stringify({
         max_tokens: 128,
         messages: [{ content: "hello", role: "user" }],
-        model: "org/family/model",
+        model: "contoso/family/glm-5.2",
       }),
       headers: {
         "content-type": "application/json",

--- a/tests/provider-model-alias.test.ts
+++ b/tests/provider-model-alias.test.ts
@@ -28,7 +28,10 @@ const noopTokenUsageRecorder = () => {}
 
 await mock.module("~/lib/config", () => ({
   ...actualConfigModule,
-  getProviderConfig: () => providerConfig,
+  getProviderConfig: (name: string) =>
+    providerConfig && name === providerConfig.name ? providerConfig : null,
+  getRawProviderConfig: (name: string) =>
+    providerConfig && name === providerConfig.name ? providerConfig : null,
   resolveMappedModel: (model: string) => modelMappings[model] ?? model,
 }))
 
@@ -275,5 +278,36 @@ describe("provider/model aliases on top-level messages routes", () => {
         type: "error",
       },
     })
+  })
+})
+
+describe("namespaced model ids fall through to the default lookup", () => {
+  test("does not route a namespaced id with an unconfigured prefix to the provider path", async () => {
+    // Models such as "org/family/model" must not be misrouted to a
+    // non-existent provider and surfaced as a 400. They should fall through to
+    // the default model lookup just like a plain model id.
+    const app = createApp()
+    const response = await app.request("/v1/messages", {
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ content: "hello", role: "user" }],
+        model: "org/family/model",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    // The request must not be misrouted to the configured "dash" provider:
+    // either no fetch happens, or fetch is called against a non-provider URL,
+    // and the error wording is never the provider 400 from
+    // handleProviderMessagesForProvider.
+    if (fetchMock.mock.calls.length > 0) {
+      const [url] = fetchMock.mock.calls[0] as [string]
+      expect(url).not.toContain("dashscope.example")
+    }
+    const body = (await response.json()) as { error?: { message?: string } }
+    expect(body.error?.message).not.toContain("does not support")
   })
 })

--- a/tests/provider-model-alias.test.ts
+++ b/tests/provider-model-alias.test.ts
@@ -282,10 +282,10 @@ describe("provider/model aliases on top-level messages routes", () => {
 })
 
 describe("namespaced model ids fall through to the default lookup", () => {
-  test("does not route a namespaced id with an unconfigured prefix to the provider path", async () => {
+  test("does not route a namespaced /v1/messages id to the provider path", async () => {
     // Models such as "org/family/model" must not be misrouted to a
-    // non-existent provider and surfaced as a 400. They should fall through to
-    // the default model lookup just like a plain model id.
+    // non-existent provider and surfaced as a 400. They should fall through
+    // to the default model lookup just like a plain model id.
     const app = createApp()
     const response = await app.request("/v1/messages", {
       body: JSON.stringify({
@@ -299,15 +299,58 @@ describe("namespaced model ids fall through to the default lookup", () => {
       method: "POST",
     })
 
-    // The request must not be misrouted to the configured "dash" provider:
-    // either no fetch happens, or fetch is called against a non-provider URL,
-    // and the error wording is never the provider 400 from
-    // handleProviderMessagesForProvider.
-    if (fetchMock.mock.calls.length > 0) {
-      const [url] = fetchMock.mock.calls[0] as [string]
-      expect(url).not.toContain("dashscope.example")
-    }
+    // Negative: the request was never sent to the configured "dash" provider
+    // and the provider 400 wording is absent (it reached the default flow,
+    // which errors out upstream without a Copilot token, not at the provider).
+    expect(fetchMock).not.toHaveBeenCalled()
     const body = (await response.json()) as { error?: { message?: string } }
     expect(body.error?.message).not.toContain("does not support")
+  })
+
+  test("does not route a namespaced /v1/messages/count_tokens id to the provider path and reaches the estimation fallback", async () => {
+    // count_tokens is called as a preflight by clients like Claude Code; it
+    // must not 404 on a namespaced id while the main /v1/messages flow works.
+    const app = createApp()
+    const response = await app.request("/v1/messages/count_tokens", {
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ content: "hello", role: "user" }],
+        model: "org/family/model",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(getTokenCount).toHaveBeenCalledTimes(1)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ input_tokens: 42 })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("still routes a configured provider alias on /v1/messages/count_tokens to the provider path", async () => {
+    // Regression guard for the happy path: a real provider alias must still
+    // be routed to the provider token counter (not fall through).
+    const app = createApp()
+    const response = await app.request("/v1/messages/count_tokens", {
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ content: "hello", role: "user" }],
+        model: "dash/qwen-plus",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(getTokenCount).toHaveBeenCalledTimes(1)
+    const [, selectedModel] = getTokenCount.mock.calls[0] as [
+      TokenCountPayload,
+      TokenCountModel,
+    ]
+    expect(selectedModel.id).toBe("qwen-plus")
   })
 })

--- a/tests/provider-responses-context-management.test.ts
+++ b/tests/provider-responses-context-management.test.ts
@@ -106,6 +106,7 @@ beforeEach(async () => {
     resolveProviderConfig
   providerResponsesHandlerDependencies.resolveProviderConfig =
     resolveProviderConfig
+  responsesHandlerDependencies.resolveProviderConfig = resolveProviderConfig
   responsesHandlerDependencies.resolveMappedModel = (model) => model
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
     undefined


### PR DESCRIPTION
## Problem

`parseProviderModelAlias` treats any model name containing `"/"` as a custom provider alias (e.g. `"dash/qwen-plus"`). Some model ids are namespaced (e.g. `"org/family/model"`) where the prefix is **not** a configured provider. Such requests were misrouted to a non-existent provider and surfaced as a `400` error (`Provider '<name>' does not support the /v1/<...> endpoint`) instead of falling through to the default model lookup.

## Fix

Add a `resolveProviderConfig` check in the **chat-completions**, **messages**, and **responses** route handlers so the `"/"` prefix is only treated as a custom provider alias when that provider is actually configured. When the prefix does not match a configured provider, the request falls through to the default model lookup as intended.

`parseProviderModelAlias` itself is left as a pure string parser. The existence check lives at the route-handler call sites so it stays consistent with the existing per-route dependency seams:

- `chat-completions` route uses the directly-imported `resolveProviderConfig` (its tests already mock `getProviderConfig`, which `resolveProviderConfig` falls through to for non-codex providers).
- `responses` route uses the existing `responsesHandlerDependencies` seam (the dependency object now exposes `resolveProviderConfig`).
- `messages` route uses the existing `providerMessagesHandlerDependencies.resolveProviderConfig` seam.

## Why not patch `parseProviderModelAlias` directly?

Putting the existence check inside `parseProviderModelAlias` (e.g. via `getRawProviderConfig`) would work for the chat-completions path, but it breaks other call sites that route codex/`<provider>` aliases through dependency-injected `resolveProviderConfig` rather than the raw config store — the two lookups disagree in test environments where the codex provider is configured via `persistCodexCredentials`. Keeping `parseProviderModelAlias` purely syntactic and doing the existence check at the route handlers avoids that mismatch and matches the existing seam design.

## Tests

- New regression test in `tests/provider-model-alias.test.ts` verifying a namespaced id with an unconfigured prefix (`"org/family/model"`) is **not** routed to the provider path and does not surface the provider `400` wording.
- Updated `tests/provider-responses-context-management.test.ts` and `tests/provider-model-alias.test.ts` config mocks to be name-aware so the new existence check reflects real config-store semantics.

```
$ bun test
682 pass, 0 fail, 2316 expect() calls   (68 files)

$ npx eslint <changed files>
clean
```

## Notes

This was motivated by real-world usage where namespaced model ids (custom enterprise models exposed via the GitHub Copilot gateway) were rejected with a `400` when sent through this proxy. The fix is generic and does not reference any specific model or provider name.