### PR TITLE
fix: route native Responses compaction over HTTP

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -1,7 +1,9 @@
 import type { Context } from "hono"
 
+import consola from "consola"
 import { streamSSE } from "hono/streaming"
 
+import { COMPACT_REQUEST } from "~/lib/compact"
 import {
   isResponsesApiWebSearchEnabled as isConfiguredResponsesApiWebSearchEnabled,
   resolveMappedModel,
@@ -39,12 +41,12 @@ import {
   compactInputByLatestCompaction,
   getResponsesTransportForModel,
   getResponsesRequestOptions,
+  hasTerminalCompactionTrigger,
   normalizeInputImageDetails,
   normalizeResponsesReasoningEffort,
   sanitizeOversizedInputImages,
   sanitizeUnsupportedInputFields,
 } from "./utils"
-import consola from "consola"
 
 const logger = createHandlerLogger("responses-handler")
 
@@ -117,7 +119,11 @@ export const handleResponses = async (c: Context) => {
       `Normalized reasoning effort from ${normalizedReasoningEffort.from} to ${normalizedReasoningEffort.to} based on the selected model capabilities`,
     )
   }
-  const responsesTransport = getResponsesTransportForModel(selectedModel)
+  const compactType =
+    hasTerminalCompactionTrigger(payload) ? COMPACT_REQUEST : undefined
+  const responsesTransport = getResponsesTransportForModel(selectedModel, {
+    compactType,
+  })
 
   const useMessagesFallback = shouldFallbackToMessages(
     c,
@@ -213,6 +219,7 @@ export const handleResponses = async (c: Context) => {
     requestId,
     sessionId: fallbackSessionId,
     signal: c.req.raw.signal,
+    compactType,
     transport: responsesTransport,
   })
 

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -437,7 +437,9 @@ const isContextManagementEnabledForSource = (
   return responsesUtilsDependencies.isContextManagementEnabledForResponses()
 }
 
-const hasTerminalCompactionTrigger = (payload: ResponsesPayload): boolean => {
+export const hasTerminalCompactionTrigger = (
+  payload: ResponsesPayload,
+): boolean => {
   const { input } = payload
   if (!Array.isArray(input) || input.length === 0) {
     return false

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono, type Context } from "hono"
 
+import { COMPACT_REQUEST } from "~/lib/compact"
 import type { AnthropicMessagesPayload } from "~/lib/types/anthropic"
 import type { CompletionPayloadOptions } from "~/routes/messages/handler"
 import { MESSAGES_TOOL_CALL_TIPS } from "~/routes/responses/messages-translation"
@@ -1137,6 +1138,40 @@ describe("responses handler token usage", () => {
       latestInput,
       compactionTrigger,
     ])
+  })
+
+  test("marks native Responses compaction triggers as compact HTTP requests", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: { limits: { max_prompt_tokens: 272000 } },
+          id: "gpt-5.6-sol",
+          supported_endpoints: ["/responses", "ws:/responses"],
+        },
+      ],
+    } as typeof state.models
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const response = await createApp().request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          { content: "history", role: "user" },
+          { type: "compaction_trigger" },
+        ],
+        model: "gpt-5.6-sol",
+        stream: true,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][1]?.compactType).toBe(COMPACT_REQUEST)
+    expect(createResponses.mock.calls[0][1]?.transport).toBe("http")
   })
 
   test("does not compact input ending with compaction trigger when context management is disabled", async () => {


### PR DESCRIPTION
## Summary

- recognize native Responses requests whose final input item is `compaction_trigger`
- mark them as `COMPACT_REQUEST` before selecting the upstream transport
- route those requests through the existing HTTP compaction path and headers
- add a regression test for dual-endpoint models that would otherwise choose pooled WebSocket transport

## Problem

Native `/v1/responses` compaction requests were treated like ordinary streamed conversations. For models advertising both `/responses` and `ws:/responses`, the handler selected the pooled WebSocket transport and did not pass a compact request type to `createResponses`.

This can leave Codex with a compaction carrier that GitHub Copilot rejects on replay. The client-facing symptom is:

```text
stream disconnected before completion: stream closed before response.completed
```

Retries then fail consistently because the rejected carrier remains in the session replacement history.

## Root cause

The Responses utilities already detect a terminal `compaction_trigger`, and the Copilot Responses service already has the required `COMPACT_REQUEST` behavior:

- force HTTP instead of WebSocket
- set `x-initiator: agent`
- set `x-interaction-type: conversation-compaction`
- set `openai-intent: conversation-agent`

However, the native Responses handler only used terminal-trigger detection for context-management decisions. It never passed `compactType` into transport selection or `createResponses`, so the existing compaction-specific path was unreachable for native Responses traffic.

## Fix

Detect the terminal compaction trigger after model resolution, then:

1. pass `COMPACT_REQUEST` to `getResponsesTransportForModel`, which selects HTTP for compaction even when the model also supports WebSocket
2. pass the same `compactType` to `createResponses`, which applies the existing compaction headers

Normal Responses requests keep their existing transport behavior.

## Evidence

Live reproduction with `gpt-5.6-sol` showed:

- an earlier historical compaction carrier completed when replayed directly against GitHub Copilot
- the carrier associated with the failing session was rejected directly upstream with HTTP 400 `invalid_request_body`
- a reconstructed approximately 3.28 MB history successfully compacted, ruling out request size alone
- the ordinary pooled WebSocket path could return an upstream error for a compaction request, while the existing HTTP `COMPACT_REQUEST` path completed and produced replayable carriers

No credentials, encrypted carriers, or session fixtures are included in this PR.

## Validation

- `bun run lint:all`
- `bun run typecheck`
- `bun run build`
- `bun test tests/responses-handler.test.ts tests/create-responses.test.ts` — 46 passed
- `bun test` — 712 passed, 0 failed across 69 files
- `git diff --check`
