### PR TITLE
fix: relocate tool result images out of Copilot chat/completions tool messages

### DIFF
--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -36,9 +36,19 @@ import { parseUserIdMetadata } from "~/lib/utils"
 export const THINKING_TEXT = "Thinking..."
 export const RICH_TOOL_RESULT_MOVED_TEXT =
   "Rich tool result content was moved to a user message because this upstream does not support it in tool messages."
+// Copilot's /chat/completions upstream accepts an array-shaped tool content, but
+// silently discards any image parts inside a `role: "tool"` message: the image is
+// neither billed as prompt tokens nor visible to the model. Verified against
+// gemini-3.7-flash, gpt-5.4 and kimi-k3 -- all three answer as if no image were
+// present (gpt-5.4 replies "NO_IMAGE" outright) and prompt_tokens stays at the
+// text-only count. Omitting "image" here routes tool result images through
+// createToolResultUserMessage, which re-attaches them to a following user
+// message where the upstream does read them.
+// Models that also expose /responses (gpt-5.4, ...) are unaffected in practice
+// because handleWithResponsesApi wins the dispatch in handler.ts; models limited
+// to /chat/completions (the whole gemini family) only ever take this path.
 const COPILOT_TOOL_CONTENT_SUPPORT_TYPE: Array<ToolContentSupportType> = [
   "array",
-  "image",
 ]
 
 interface TranslationCapabilities {

--- a/tests/anthropic-request.test.ts
+++ b/tests/anthropic-request.test.ts
@@ -432,7 +432,7 @@ describe("Anthropic to OpenAI translation logic", () => {
 })
 
 describe("tool content support translation", () => {
-  test("keeps Copilot chat translation compatible with array and image tool results", () => {
+  test("moves Copilot tool result images into a following user message", () => {
     const anthropicPayload: AnthropicMessagesPayload = {
       model: "gpt-4o",
       messages: [
@@ -465,11 +465,21 @@ describe("tool content support translation", () => {
 
     const openAIPayload = translateToOpenAI(anthropicPayload)
 
+    // The Copilot /chat/completions upstream drops image parts inside a
+    // `role: "tool"` message, so the image has to ride along on a user message.
     expect(openAIPayload.messages).toEqual([
       {
         role: "tool",
         tool_call_id: "tool_image",
+        content: "screenshot",
+      },
+      {
+        role: "user",
         content: [
+          {
+            type: "text",
+            text: "Tool result for tool_image:",
+          },
           {
             type: "text",
             text: "screenshot",
@@ -485,7 +495,84 @@ describe("tool content support translation", () => {
     ])
   })
 
-  test("keeps Copilot image tool content while downgrading unsupported PDFs", () => {
+  test("keeps the tool call protocol intact when relocating a tool result image", () => {
+    // Regression: a Read/screenshot tool returning an image is how images
+    // usually reach the model from Claude Code. The image must leave the tool
+    // message, but `tool_use -> tool_result -> user` ordering must survive.
+    const anthropicPayload: AnthropicMessagesPayload = {
+      model: "gemini-3.7-flash",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "read /tmp/shot.png" }],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_shot",
+              name: "Read",
+              input: { path: "/tmp/shot.png" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool_shot",
+              content: [
+                {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: "image-data",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      max_tokens: 100,
+    }
+
+    const openAIPayload = translateToOpenAI(anthropicPayload)
+
+    expect(openAIPayload.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "tool",
+      "user",
+    ])
+
+    const toolMessage = openAIPayload.messages[2]
+    expect(toolMessage.tool_call_id).toBe("tool_shot")
+    // No image left behind in the tool message -- the upstream would drop it.
+    expect(JSON.stringify(toolMessage)).not.toContain("image_url")
+    expect(toolMessage.content).toBe(RICH_TOOL_RESULT_MOVED_TEXT)
+
+    expect(openAIPayload.messages[3]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Tool result for tool_shot:",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: "data:image/png;base64,image-data",
+          },
+        },
+      ],
+    })
+  })
+
+  test("moves Copilot tool result images to a user message while downgrading unsupported PDFs", () => {
     const anthropicPayload: AnthropicMessagesPayload = {
       model: "gpt-4o",
       messages: [
@@ -536,6 +623,18 @@ describe("tool content support translation", () => {
         role: "tool",
         tool_call_id: "tool_pdf",
         content: [
+          "screenshot",
+          "PDF file read: report.pdf",
+          "PDF/document content is not supported by this Chat Completions upstream. Use the available text extracted from the document.",
+        ].join("\n"),
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Tool result for tool_pdf:",
+          },
           {
             type: "text",
             text: "screenshot",


### PR DESCRIPTION
## Summary

Images returned by a tool are invisible to every model that gets dispatched to Copilot's `/chat/completions` endpoint.

`translateToOpenAI` places them in the `role: "tool"` message as an `image_url` part, and that upstream silently discards image parts there — the image is neither billed as prompt tokens nor seen by the model. No error is raised, so the model just answers as if no image were attached.

This is most visible on the gemini family, which is what led me here ("vision doesn't work on gemini-3.7-flash"). The model name turned out to be a red herring: gemini models only advertise `supported_endpoints: ["/chat/completions"]`, so they *always* take this path, while models that also advertise `/responses` (gpt-5.4, ...) get dispatched to `handleWithResponsesApi` by `handler.ts`, where tool output images do work.

In practice this covers most of how images reach the model from Claude Code: `Read` on an image file, Playwright screenshots, MCP tools returning images.

## Evidence

Measured through a local instance (v2.3.7) against a 160x160 PNG whose left half is pure magenta and right half is pure cyan, asking the model to name the two halves:

**via `/v1/messages`, image pasted into a user message**

| model | answer | input_tokens | |
|---|---|---|---|
| gemini-3.7-flash | `magenta, cyan` | 1123 | ok |
| gpt-5.4 | `magenta, cyan` | 73 | ok |

**via `/v1/messages`, image returned by a tool**

| model | answer | input_tokens | |
|---|---|---|---|
| gemini-3.7-flash | `red, blue` | 431 | wrong |
| gemini-3.6-flash | `red, blue` | 431 | wrong |
| gpt-5.4 | `magenta, cyan` | 154 | ok — dispatched to `/responses` |

**via `/v1/chat/completions`, image left in the tool message (forces every model onto the affected path)**

| model | answer | prompt_tokens | |
|---|---|---|---|
| gemini-3.7-flash | `black, white` | 405 | wrong |
| kimi-k3 | `red, red` | 210 | wrong |
| gpt-5.4 | `NO_IMAGE` | 76 | wrong |

Two things worth pointing out:

- The `input_tokens` gap (431 vs 1123 for the same image) shows the image is not being counted at all, so it never reaches the model.
- gpt-5.4 answering `NO_IMAGE` on the third table confirms this is an endpoint limitation and not anything model-specific — the same model answers correctly when it goes through `/responses`.

## Fix

Drop `"image"` from `COPILOT_TOOL_CONTENT_SUPPORT_TYPE`.

That routes tool result images through the existing `createToolResultUserMessage` path, which re-attaches them to a user message emitted right after the tool message. The relocation machinery and its `tool_use -> tool_result -> user` ordering already existed and were simply never exercised for Copilot — only the capability flag changes, no logic is touched.

Sending the exact same conversation with the image on a user message instead returns `magenta, cyan` at `prompt_tokens=1164`, so the relocation restores vision.

`enableVision` in `create-chat-completions.ts` still detects the image after the move, because it scans every message for `image_url` parts — so `Copilot-Vision-Request` is still set.

## Tests

Two existing tests asserted the old placement and are updated to the new one. A new regression test pins the message ordering for a full Claude-Code-shaped conversation and asserts no `image_url` survives in the tool message.

```
bun test tests/            746 pass, 3 fail
bun run typecheck          clean
bun run lint <changed>     clean
coverage, src/routes/messages/non-stream-translation.ts
                           95.45% funcs / 90.51% lines
```

The 3 failures are pre-existing and unrelated — `tests/get-copilot-token.test.ts` fails the same way on `dev` without this change (745 pass / 3 fail), and passes when that file is run on its own. Looks like cross-test pollution in the full-suite run.

## Note

If some upstream/model on `/chat/completions` *does* read images inside tool messages and this regresses it, the alternative is to keep the constant as-is and pass `toolContentSupportType: ["array"]` explicitly from `handleWithChatCompletions` in `api-flows.ts`, leaving the provider paths untouched. I went with changing the default because `count-tokens-handler.ts` also relies on it and should count what actually gets sent. Happy to switch if you prefer the narrower change.
