### PR TITLE
fix(responses): isolate reasoning by transport

### DIFF
--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -35,6 +35,7 @@ import type {
 import { createResponses as createCopilotResponses } from "~/services/copilot/create-responses"
 
 import { handleResponsesViaMessages } from "./messages-handler"
+import { isMessagesReasoningId } from "./messages-translation"
 import { createStreamIdTracker, fixStreamIds } from "./stream-id-sync"
 import {
   applyResponsesApiContextManagement,
@@ -119,6 +120,7 @@ export const handleResponses = async (c: Context) => {
     responsesTransport,
   )
   if (useMessagesFallback) {
+    filterReasoningForTransport(payload, true)
     return await handleResponsesViaMessages(c, {
       payload,
       publicModel: requestedModel,
@@ -141,6 +143,8 @@ export const handleResponses = async (c: Context) => {
       400,
     )
   }
+
+  filterReasoningForTransport(payload, false)
 
   const recordUsage = createCopilotTokenUsageRecorder({
     endpoint: "responses",
@@ -270,6 +274,18 @@ export const handleResponses = async (c: Context) => {
 
 const isStreamingRequested = (payload: ResponsesPayload): boolean =>
   Boolean(payload.stream)
+
+const filterReasoningForTransport = (
+  payload: ResponsesPayload,
+  useMessagesFallback: boolean,
+): void => {
+  if (!Array.isArray(payload.input)) return
+
+  payload.input = payload.input.filter((item) => {
+    if (item.type !== "reasoning") return true
+    return isMessagesReasoningId(item.id) === useMessagesFallback
+  })
+}
 
 const shouldFallbackToMessages = (
   c: Context,

--- a/src/routes/responses/messages-stream-translation.ts
+++ b/src/routes/responses/messages-stream-translation.ts
@@ -17,6 +17,7 @@ import { CustomToolInputStreamDecoder } from "./custom-tool-input-stream-decoder
 import {
   createMessagesBackedResponsesResult,
   encodeMessagesCompaction,
+  markMessagesReasoningId,
   resolveToolDescriptor,
   ResponsesMessagesTranslationError,
   toResponseId,
@@ -440,7 +441,9 @@ function* startContentBlock(
 
   if (block.type === "thinking") {
     const item: ResponseOutputReasoning = {
-      id: `rs_${state.responseId.slice(-18)}_${event.index}`,
+      id: markMessagesReasoningId(
+        `rs_${state.responseId.slice(-18)}_${event.index}`,
+      ),
       type: "reasoning",
       status: "in_progress",
       summary: [],

--- a/src/routes/responses/messages-translation.ts
+++ b/src/routes/responses/messages-translation.ts
@@ -34,6 +34,13 @@ import type {
 } from "~/lib/types/responses"
 
 export const MESSAGES_COMPACTION_PREFIX = "copilot-api:messages-compaction:v1:"
+const MESSAGES_REASONING_ID_SUFFIX = "__a1"
+
+export const markMessagesReasoningId = (id: string): string =>
+  `${id}${MESSAGES_REASONING_ID_SUFFIX}`
+
+export const isMessagesReasoningId = (id: unknown): boolean =>
+  typeof id === "string" && id.endsWith(MESSAGES_REASONING_ID_SUFFIX)
 
 export const MESSAGES_COMPACTION_PROMPT = [
   "You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another LLM that will resume the task.",
@@ -940,7 +947,9 @@ function translateAssistantOutput(
   for (const [index, block] of response.content.entries()) {
     if (block.type === "thinking") {
       output.push({
-        id: `rs_${createStableHash(`${response.id}:${index}:reasoning`)}`,
+        id: markMessagesReasoningId(
+          `rs_${createStableHash(`${response.id}:${index}:reasoning`)}`,
+        ),
         type: "reasoning",
         status: "completed",
         ...(block.thinking && block.thinking !== "Thinking..." ?

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 import { Hono, type Context } from "hono"
 
-import type { AnthropicMessagesPayload } from "~/lib/types/anthropic"
+import type {
+  AnthropicMessagesPayload,
+  AnthropicResponse,
+} from "~/lib/types/anthropic"
+import type { ResponsesResult } from "~/lib/types/responses"
 import type { CompletionPayloadOptions } from "~/routes/messages/handler"
 import { MESSAGES_TOOL_CALL_TIPS } from "~/routes/responses/messages-translation"
 import type { createResponses as createCopilotResponses } from "~/services/copilot/create-responses"
@@ -30,6 +34,63 @@ const createResponsesResult = (model: string) => ({
   top_p: null,
   usage: null,
 })
+
+const createReasoningResult = (
+  model: string,
+  id: string,
+  encryptedContent: string,
+): ResponsesResult => ({
+  ...createResponsesResult(model),
+  output: [
+    {
+      id,
+      type: "reasoning",
+      status: "completed",
+      summary: [],
+      encrypted_content: encryptedContent,
+    },
+    {
+      id: `msg-${id}`,
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [
+        { type: "output_text", text: `Answer from ${model}`, annotations: [] },
+      ],
+    },
+  ],
+})
+
+const getMessageBlocks = (
+  payload: AnthropicMessagesPayload | undefined,
+): Array<Record<string, unknown>> =>
+  payload?.messages.flatMap(
+    (message): Array<Record<string, unknown>> =>
+      Array.isArray(message.content) ?
+        (message.content as unknown as Array<Record<string, unknown>>)
+      : [],
+  ) ?? []
+
+const getThinkingSignatures = (
+  payload: AnthropicMessagesPayload | undefined,
+): Array<unknown> =>
+  getMessageBlocks(payload)
+    .filter((block) => block.type === "thinking")
+    .map((block) => block.signature)
+
+const createMessagesResponse = (
+  content: AnthropicResponse["content"],
+): Response =>
+  Response.json({
+    content,
+    id: "msg-switch",
+    model: "claude-test",
+    role: "assistant",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    type: "message",
+    usage: { input_tokens: 8, output_tokens: 2 },
+  })
 
 const { state } = await import("~/lib/state")
 const { closeUsageStore } = await import("~/lib/token-usage")
@@ -142,6 +203,188 @@ afterEach(async () => {
     defaultResponsesMessagesDependencies,
   )
   Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
+})
+
+describe("responses reasoning transport isolation", () => {
+  test("keeps only Messages reasoning when switching to a Messages model", async () => {
+    state.models = {
+      object: "list",
+      data: [
+        {
+          capabilities: { limits: { max_prompt_tokens: 128000 } },
+          id: "claude-test",
+          supported_endpoints: ["/v1/messages"],
+        },
+      ],
+    } as typeof state.models
+    const handleMessages = mock(
+      (_context: Context, _payload: AnthropicMessagesPayload) =>
+        Promise.resolve(
+          createMessagesResponse([{ type: "text", text: "done" }]),
+        ),
+    )
+    responsesMessagesDependencies.handleCompletionPayload = handleMessages
+
+    const response = await createApp().request("/v1/responses", {
+      body: JSON.stringify({
+        model: "claude-test",
+        input: [
+          {
+            id: "rs_native",
+            type: "reasoning",
+            summary: [],
+            encrypted_content: "native-reasoning",
+          },
+          {
+            role: "assistant",
+            type: "message",
+            content: "Visible answer",
+          },
+          {
+            id: "rs_messages__a1",
+            type: "reasoning",
+            summary: [],
+            encrypted_content: "messages-reasoning",
+          },
+          {
+            type: "function_call",
+            call_id: "call-1",
+            name: "read_file",
+            arguments: '{"path":"README.md"}',
+          },
+          {
+            type: "function_call_output",
+            call_id: "call-1",
+            output: "file contents",
+          },
+          { role: "user", type: "message", content: "Continue" },
+        ],
+        tools: [
+          {
+            type: "function",
+            name: "read_file",
+            description: "Read a file",
+            parameters: { type: "object" },
+            strict: false,
+          },
+        ],
+      }),
+      headers: {
+        "content-type": "application/json",
+        "session-id": "switch-session",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    const forwarded = handleMessages.mock.calls[0]?.[1]
+    const blocks = getMessageBlocks(forwarded)
+    expect(getThinkingSignatures(forwarded)).toEqual(["messages-reasoning"])
+    expect(blocks).toContainEqual({ type: "text", text: "Visible answer" })
+    expect(
+      blocks.some(
+        (block) => block.type === "tool_use" && block.id === "call-1",
+      ),
+    ).toBe(true)
+    expect(
+      blocks.some(
+        (block) =>
+          block.type === "tool_result" && block.content === "file contents",
+      ),
+    ).toBe(true)
+  })
+
+  for (const [name, models] of [
+    [
+      "Responses to Messages to Responses",
+      ["gpt-test", "claude-test", "gpt-test"],
+    ],
+    [
+      "Messages to Responses to Messages",
+      ["claude-test", "gpt-test", "claude-test"],
+    ],
+  ] as const) {
+    test(`round-trips retained client history from ${name}`, async () => {
+      state.models = {
+        object: "list",
+        data: [
+          {
+            capabilities: { limits: { max_prompt_tokens: 128000 } },
+            id: "gpt-test",
+            supported_endpoints: ["/responses"],
+          },
+          {
+            capabilities: { limits: { max_prompt_tokens: 128000 } },
+            id: "claude-test",
+            supported_endpoints: ["/v1/messages"],
+          },
+        ],
+      } as typeof state.models
+      createResponses.mockImplementation((payload) =>
+        Promise.resolve(
+          createReasoningResult(payload.model, "rs_native", "native-reasoning"),
+        ),
+      )
+      const handleMessages = mock(
+        (_context: Context, _payload: AnthropicMessagesPayload) =>
+          Promise.resolve(
+            createMessagesResponse([
+              {
+                type: "thinking",
+                thinking: "Messages reasoning",
+                signature: "messages-reasoning",
+              },
+              { type: "text", text: "Answer from claude-test" },
+            ]),
+          ),
+      )
+      responsesMessagesDependencies.handleCompletionPayload = handleMessages
+
+      const history: Array<unknown> = []
+      for (const [index, model] of models.entries()) {
+        history.push({
+          role: "user",
+          type: "message",
+          content: `Turn ${index + 1}`,
+        })
+        const response = await createApp().request("/v1/responses", {
+          body: JSON.stringify({ model, input: history }),
+          headers: {
+            "content-type": "application/json",
+            "session-id": "round-trip-session",
+          },
+          method: "POST",
+        })
+
+        expect(response.status).toBe(200)
+        const result = (await response.json()) as ResponsesResult
+        history.push(...result.output)
+      }
+
+      if (models[0] === "gpt-test") {
+        const replayedInput = createResponses.mock.calls[1]?.[0].input
+        expect(
+          Array.isArray(replayedInput) ?
+            replayedInput
+              .filter((item) => item.type === "reasoning")
+              .map((item) => item.encrypted_content)
+          : [],
+        ).toEqual(["native-reasoning"])
+        expect(
+          getThinkingSignatures(handleMessages.mock.calls[0]?.[1]),
+        ).toEqual([])
+      } else {
+        const switchedInput = createResponses.mock.calls[0]?.[0].input
+        expect(
+          Array.isArray(switchedInput)
+            && switchedInput.some((item) => item.type === "reasoning"),
+        ).toBe(false)
+        expect(
+          getThinkingSignatures(handleMessages.mock.calls[1]?.[1]),
+        ).toEqual(["messages-reasoning"])
+      }
+    })
+  }
 })
 
 describe("responses handler token usage", () => {

--- a/tests/responses-messages-translation.test.ts
+++ b/tests/responses-messages-translation.test.ts
@@ -873,6 +873,35 @@ describe("Responses Lite to Messages translation", () => {
     ).toEqual({ effort: "max" })
   })
 
+  test("marks reasoning translated from a Messages response", () => {
+    const translation = translate({ input: "Explain the result" })
+    const result = translateAnthropicToResponses(
+      {
+        content: [
+          {
+            type: "thinking",
+            thinking: "Check the result.",
+            signature: "claude-signature",
+          },
+        ],
+        id: "msg_reasoning",
+        model: "claude-sonnet-4.6",
+        role: "assistant",
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        type: "message",
+        usage: { input_tokens: 8, output_tokens: 3 },
+      },
+      translation,
+    )
+
+    expect(result.output[0]).toMatchObject({
+      type: "reasoning",
+      encrypted_content: "claude-signature",
+    })
+    expect(result.output[0]?.id?.endsWith("__a1")).toBe(true)
+  })
+
   test("translates an apply_patch tool use back to a custom tool call", () => {
     const translation = translate({
       input: [
@@ -1091,6 +1120,8 @@ describe("Responses Lite to Messages translation", () => {
     })
 
     expect(reasoningItems).toHaveLength(4)
+    expect(new Set(reasoningItems.map((item) => item.id)).size).toBe(2)
+    expect(reasoningItems.every((item) => item.id.endsWith("__a1"))).toBe(true)
     expect(reasoningItems[0]?.encrypted_content).toBe("")
     expect(reasoningItems[1]?.encrypted_content).toBe("")
     expect(reasoningItems[2]?.encrypted_content).toBe("")


### PR DESCRIPTION
Closes #378

## Summary

Fix model switching in multi-turn `/v1/responses` conversations without introducing a general reasoning carrier.

The failure occurs when native Responses reasoning is replayed through the Messages fallback and its opaque `encrypted_content` is treated as an Anthropic `thinking.signature`. Claude rejects that foreign signature. The reverse switch can likewise send synthetic Claude reasoning to a native Responses target.

## Fix

This PR follows the transport marker approach suggested in review:

- append the reserved `__a1` suffix only to reasoning IDs synthesized by Messages → Responses
- keep native Responses reasoning IDs and `encrypted_content` unchanged
- after transport selection, filter only `type: "reasoning"` items in the current upstream request
  - Messages fallback keeps marked reasoning
  - native Responses keeps unmarked reasoning
- leave visible messages, tool calls, tool results, and compaction items untouched
- retain complete client history, allowing `GPT → Claude → GPT` and `Claude → GPT → Claude` round trips

Legacy unmarked Claude reasoning is dropped once because it cannot be distinguished safely from native reasoning.

## Scope

The implementation is intentionally limited to five files: three production files and two focused test files.

It does not change:

- opaque `encrypted_content`
- native reasoning IDs
- provider-prefixed Responses routes
- direct `/v1/messages` or `/chat/completions`
- warmup/model routing
- provider proxy headers or body rewriting
- logging
- compaction format
- custom-tool item IDs

The existing synthesized terminal SSE response continues to use `output: []`; SSE marker consistency is verified on the added/done item events.

## Cache behavior

This change makes switching valid; it does not promise a cache hit across models. A first request after switching can miss the prompt cache, particularly in a very large session. That cost is an inherent product tradeoff of model switching rather than something the gateway should hide or emulate.

Within the same transport category, reasoning is preserved and the upstream remains responsible for cache compatibility.

## Tests

Focused tests cover:

- GPT/native → Claude/Messages filtering
- Claude/Messages → GPT/native filtering
- three-request `GPT → Claude → GPT` round trip
- three-request `Claude → GPT → Claude` round trip
- replay of the actual prior `response.output` under one `session-id`
- same-transport reasoning preservation
- visible assistant messages, function calls, and tool results
- non-stream Messages reasoning IDs and unchanged signatures
- SSE added/done events using the same marked reasoning ID
- legacy unmarked reasoning being removed from Messages requests

Validation for commit `9e2baea`:

- focused tests: 75 passed, 0 failed
- full `bun test`: 762 passed, 0 failed
- `bun run typecheck`: passed
- changed-file lint fix and full read-only lint: passed
- `bun run build`: passed
- `git diff --check`: passed

The focused coverage run directly exercises both new filtering branches and both JSON/SSE marker paths.

## Live smoke

The marker-only implementation was exercised through an isolated local instance while reusing one `session-id`. Successful round trips included:

- `gpt-5.6-sol → claude-opus-5 → gpt-5.6-sol`
- `claude-opus-5 → gpt-5.6-sol → claude-opus-5`
- `gpt-5.6-sol → grok-4.6 → gpt-5.6-sol`
- `gpt-5.6-sol → gpt-5.6-luna → gpt-5.6-sol`

The smoke test logged only status and reasoning presence, not opaque reasoning contents. Native-to-native replay remained accepted; cross-transport requests no longer forwarded an invalid foreign Claude signature.


