### PR TITLE
feat: route image requests through configured providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,7 @@ Gateway API keys live under `auth.apiKeys` in `config.json`. Manage them with `c
 - **auth.apiKeys:** API keys used for request authentication on non-admin routes. Supports multiple keys for rotation. Requests can authenticate with either `x-api-key: <key>` or `Authorization: Bearer <key>`. If empty or omitted, authentication for non-admin routes is disabled.
 - **auth.adminApiKey:** Single admin key used only for `/admin/*` routes. If missing, the server generates a random key at startup and writes it back to `config.json`. Requests use the same `x-api-key` or `Authorization: Bearer` headers, but regular `auth.apiKeys` never grant access to `/admin/*`.
 - **modelMappings:** Exact `sourceModel -> targetModel` rewrites shared by top-level `POST /v1/messages`, `POST /v1/messages/count_tokens`, `POST /v1/responses`, and `POST /v1/chat/completions` requests. Omit it or leave it as `{}` to disable rewrites. Both the source and target must be non-empty strings. Targets can be regular model IDs or `provider/model` aliases such as `dashscope/qwen3.6-plus`, and the rewrite happens before provider alias parsing. These mappings are not split per interface. The admin endpoints `GET/POST /admin/config/model-mappings` read and update only this field.
+- **imageModel:** Optional `provider/model` target for top-level `POST /v1/images/generations` and `POST /v1/images/edits` requests. When configured, the gateway routes both endpoints through that provider and replaces the request model with the configured provider model or deployment name. When omitted, top-level image requests continue to use the Codex backend. Provider-scoped image routes are unaffected.
 - **extraPrompts:** Map of `model -> prompt` appended to the first system prompt when translating Anthropic-style requests to Responses API. Use this to inject guardrails or guidance per model. Missing default entries are auto-added without overwriting your custom prompts. For GPT-5.3+ models (e.g. `gpt-5.3-codex`, `gpt-5.4`, `gpt-5.5`), a built-in commentary prompt is used as fallback when not explicitly configured. The built-in prompts enable phase-aware commentary, which lets the model emit a short user-facing progress update before tools or deeper reasoning.
 - **providers:** Global upstream provider map. Each provider key (for example `dashscope`) becomes a route prefix (`/dashscope/v1/messages`). Supports `type: "anthropic"`, `type: "openai-compatible"`, and `type: "openai-responses"`. Top-level clients can also use `model: "dashscope/model-id"` with `/v1/messages`, `/v1/messages/count_tokens`, `/v1/responses`, and `/v1/chat/completions`; the gateway strips the `dashscope/` prefix before forwarding upstream. The `/v1/responses` route for `anthropic` and `openai-compatible` providers uses the Responses Lite → Messages adapter; `openai-compatible` providers then reuse the Messages → Chat translation. Codex clients (`User-Agent` starting with `codex`) also use the adapter for non-`gpt-*` models on `openai-responses` providers. `GET /v1/models` aggregates enabled provider models with `provider/model-id` IDs, while the top-level Codex-UA catalog also merges these adaptable models as `use_responses_lite` entries (except DeepSeek models, which use `use_responses_lite: false` and `tool_mode: null`). Use `GET /dashscope/v1/models` for a single provider's raw model list.
   - `enabled` defaults to `true` if omitted.
@@ -726,6 +727,25 @@ Gateway API keys live under `auth.apiKeys` in `config.json`. Manage them with `c
     - `reasoningEfforts` (optional): Reasoning levels advertised for Codex. Missing configured and upstream values use the built-in non-GPT model catalog before falling back to `["high", "xhigh", "max", "ultra"]`. Provider Responses requests with an unsupported effort are normalized to a supported level when these capabilities are known.
     - `defaultReasoningEffort` (optional): Default Codex reasoning level. Built-in model metadata may provide a known default; otherwise it defaults to `max` when available, then the first configured level. Synthetic Codex models always enable parallel tool calls.
     - `reasoningField` (optional): Assistant thinking field sent upstream on OpenAI-compatible `/v1/messages` requests. Supports `reasoning` and `reasoning_content`; defaults to `reasoning_content`. Use `reasoning` for OpenRouter-style models; the built-in catalog already does this for OpenCode Go `hy3` and `hy4-preview`.
+
+To route Codex-compatible image requests to a Microsoft Foundry deployment, configure it as an OpenAI-compatible provider and select its deployment with `imageModel`:
+
+```json
+{
+  "imageModel": "foundry/my-gpt-image-2-deployment",
+  "providers": {
+    "foundry": {
+      "type": "openai-compatible",
+      "baseUrl": "https://<resource-name>.openai.azure.com/openai",
+      "apiKey": "<azure-openai-api-key>",
+      "authType": "authorization"
+    }
+  }
+}
+```
+
+The provider base URL omits `/v1`; the gateway appends `/v1/images/generations` or `/v1/images/edits`. The model portion of `imageModel` must be the Foundry deployment name.
+
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests); defaults to gpt-5-mini. The gateway forces this small model on no-tool warmup or probe requests to avoid consuming premium requests. This behavior only applies to non-token-based-billing GitHub Copilot accounts (`token_based_billing` is false); for token-based-billing accounts the warmup small-model fallback is skipped since there is no premium-request quota to preserve.
 - **contextManagement:** Controls whether the proxy adds Responses API `context_management` compaction instructions. `messages` applies when Anthropic-style `/v1/messages` requests are translated to Responses API, including `openai-responses` provider message routes, and defaults to `true`. `responses` applies to native `/v1/responses` traffic, including `provider/model` aliases and the built-in `codex` provider, and defaults to `false`. Enable `responses` only after checking that your client supports context management compaction. When enabled, the request includes `context_management` in the body and keeps only the latest compaction carrier on follow-up turns. The proxy only adds context management and compacts history for `gpt-*` models; both configuration switches have no effect on non-GPT models such as Grok. **Note:** Context management is also forcibly disabled for GPT-5.6 and above models (e.g. `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) because enabling it breaks prompt cache hits on those models. These overrides take precedence over the `contextManagement` and `modelResponsesApiCompactThresholds` settings.
  - **modelResponsesApiCompactThresholds:** Per-model Responses API `compact_threshold` overrides used when the proxy adds `context_management`. These values take precedence over the fallback threshold from `resolveResponsesCompactThreshold` (`max_prompt_tokens * ratio`, or the default fallback). Defaults set `gpt-5.4` and `gpt-5.5` to `217600` (`272000 * 0.8`). Models not listed continue to use the normal fallback logic.
@@ -787,13 +807,13 @@ These endpoints mimic the OpenAI API structure.
 
 ### Codex Backend Endpoints
 
-These endpoints implement Codex backend APIs. Top-level image requests require an active Codex login; alpha search can use either the Codex backend or a Responses web-search adapter.
+These endpoints implement Codex-compatible backend APIs. Top-level image requests use the Codex backend by default, or the provider selected by `imageModel`; alpha search can use either the Codex backend or a Responses web-search adapter.
 
 | Endpoint                                                       | Method | Description                                                     |
 | -------------------------------------------------------------- | ------ | --------------------------------------------------------------- |
 | `POST /v1/alpha/search`                | `POST` | Routes Codex alpha-search requests to the Codex backend, or handles supported commands locally and through Responses web search. |
-| `POST /v1/images/generations` | `POST` | Forwards a JSON image generation request to the Codex Images upstream. When the request omits `Content-Type`, the gateway defaults it to `application/json`. |
-| `POST /v1/images/edits` | `POST` | Forwards an image edit request to the Codex Images upstream. Send this request as `multipart/form-data` and let the HTTP client generate the `boundary`; the gateway preserves the incoming content type and streams the upload body. |
+| `POST /v1/images/generations` | `POST` | Forwards a JSON image generation request to the Codex Images upstream, or to the provider configured by `imageModel`. When the request omits `Content-Type`, the Codex path defaults it to `application/json`. |
+| `POST /v1/images/edits` | `POST` | Forwards an image edit request to the Codex Images upstream, or to the provider configured by `imageModel`. Send this request as `multipart/form-data` and let the HTTP client generate the `boundary`. |
 
 For requests routed to the Codex backend, the gateway replaces client authorization and account headers with the active Codex login and preserves compatible request metadata. Responses-backed alpha search instead follows the selected Copilot or provider route.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -747,6 +747,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
 - **auth.apiKeys：** 用于普通非 admin 路由的 API key。支持多个 key 轮换使用。请求可通过 `x-api-key: <key>` 或 `Authorization: Bearer <key>` 进行认证。若为空或省略，则普通路由的认证会被禁用。
 - **auth.adminApiKey：** 仅用于 `/admin/*` 路由的单个 admin key。若未配置，服务会在启动时自动生成一个随机 key，并回写到 `config.json`。它同样使用 `x-api-key` 或 `Authorization: Bearer` 这两种头，但普通 `auth.apiKeys` 不能访问 `/admin/*`。
 - **modelMappings：** 用于顶层 `POST /v1/messages`、`POST /v1/messages/count_tokens`、`POST /v1/responses` 和 `POST /v1/chat/completions` 请求的精确 `sourceModel -> targetModel` 重写映射，这几类接口共用同一份规则。省略该字段或保留为 `{}` 时，不会做模型重写。`source` 和 `target` 都必须是非空字符串。`target` 可以是普通模型 ID，也可以是 `provider/model` 形式的别名，例如 `dashscope/qwen3.6-plus`；重写发生在 provider alias 解析之前。这些映射不再按接口区分。`GET/POST /admin/config/model-mappings` 管理接口读写的也只有这个字段。
+- **imageModel：** 顶层 `POST /v1/images/generations` 和 `POST /v1/images/edits` 请求可选的 `provider/model` 目标。配置后，网关会通过该 provider 转发两个端点，并将请求模型替换为配置的 provider 模型或部署名称。省略时，顶层图片请求仍使用 Codex 后端。带 provider 前缀的图片路由不受影响。
 - **extraPrompts：** `model -> prompt` 的映射。把 Anthropic 风格请求翻译为 Responses API 时，会将其附加到第一条 system prompt 后面。你可以借此为不同模型注入护栏或指引。缺失的默认项会自动补齐，但不会覆盖你自定义的 prompt。对于 GPT-5.3+ 模型（如 `gpt-5.3-codex`、`gpt-5.4`、`gpt-5.5`），未显式配置时会自动使用内置的 commentary prompt。内置 prompt 会启用带阶段感知的 commentary，让模型在工具调用或更深层推理前先发出简短的用户可见进度说明。
 - **providers：** 全局上游 provider 映射。每个 provider key（例如 `dashscope`）都会变成一个路由前缀（`/dashscope/v1/messages`）。支持 `type: "anthropic"`、`type: "openai-compatible"` 和 `type: "openai-responses"`。顶层客户端也可以在 `/v1/messages`、`/v1/messages/count_tokens`、`/v1/responses` 和 `/v1/chat/completions` 中使用 `model: "dashscope/model-id"`；AI gateway 会在转发上游前移除 `dashscope/` 前缀。`anthropic` 和 `openai-compatible` provider 的 `/v1/responses` 会通过 Responses Lite → Messages 适配；其中 `openai-compatible` provider 再复用 Messages → Chat 翻译。Codex 客户端（`User-Agent` 以 `codex` 开头）在 `openai-responses` provider 上请求非 `gpt-*` 模型时同样走该适配路径。`GET /v1/models` 会聚合已启用 provider 的模型，并以 `provider/model-id` 形式返回；Codex UA 的顶层模型列表还会把这些可适配模型合并为 `use_responses_lite` 模型（DeepSeek 模型除外，它们使用 `use_responses_lite: false` 和 `tool_mode: null`）。单个 provider 的原始模型列表仍可使用 `GET /dashscope/v1/models`。
   - `enabled`：可选，若省略则默认为 `true`。
@@ -770,6 +771,25 @@ Copilot API 现在使用子命令结构，主要命令包括：
     - `reasoningEfforts`：可选，Codex 支持的推理档位。配置和上游元数据均未提供时，会先使用非 GPT 模型的内置目录，再回退到 `["high", "xhigh", "max", "ultra"]`。已知模型能力时，Provider Responses 请求中的不支持档位会被归一化为支持的档位。
     - `defaultReasoningEffort`：可选，Codex 默认推理档位；内置模型元数据可以提供已知默认值，否则可用档位包含 `max` 时默认取 `max`，再回退到配置的第一个档位。合成 Codex 模型始终启用并行工具调用。
     - `reasoningField`：可选，OpenAI-compatible `/v1/messages` 转发 assistant 思考文本时使用的字段，支持 `reasoning` 与 `reasoning_content`，默认 `reasoning_content`；OpenRouter 风格模型设为 `reasoning`，内置目录已为 OpenCode Go `hy3`、`hy4-preview` 配置该值。
+
+如需将 Codex 兼容的图片请求路由到 Microsoft Foundry 部署，请将其配置为 OpenAI-compatible provider，并用 `imageModel` 选择对应部署：
+
+```json
+{
+  "imageModel": "foundry/my-gpt-image-2-deployment",
+  "providers": {
+    "foundry": {
+      "type": "openai-compatible",
+      "baseUrl": "https://<resource-name>.openai.azure.com/openai",
+      "apiKey": "<azure-openai-api-key>",
+      "authType": "authorization"
+    }
+  }
+}
+```
+
+provider 的 base URL 不包含 `/v1`；网关会追加 `/v1/images/generations` 或 `/v1/images/edits`。`imageModel` 中的模型部分必须填写 Foundry 部署名称。
+
 - **smallModel：** 无工具预热消息的回退模型（例如 Claude Code 的探测请求）；默认是 `gpt-5-mini`。网关会对无工具的预热或探测请求强制使用该小模型，以避免消耗 premium 请求。该行为仅在 GitHub Copilot 账户为非 token-based 计费时生效（`token_based_billing` 为 false）；对于 token-based 计费账户，预热小模型回退会被跳过，因为不存在需要节省的 premium 请求配额。
 - **contextManagement：** 控制代理是否为 Responses API 附加 `context_management` 压缩指令。`messages` 作用于被翻译成 Responses API 的 Anthropic 风格 `/v1/messages` 请求，包括 `openai-responses` provider 的 Messages 路由，默认值为 `true`。`responses` 作用于 native `/v1/responses` 流量，包括 `provider/model` 别名和内置 `codex` provider，默认值为 `false`。只有在确认客户端支持 context management compaction 后，才建议在 Responses API 下启用 `responses`。启用后，请求体会带上 `context_management`，并在后续轮次中仅保留最新的压缩承载内容。代理仅为 `gpt-*` 模型添加 context management 并压缩历史；这两个配置开关对 Grok 等非 GPT 模型不生效。**注意：** 对于 GPT-5.6 及以上模型（如 `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna`），context management 功能同样会被强制禁用，因为开启后会破坏这些模型的 prompt 缓存命中。这些强制覆盖优先于 `contextManagement` 和 `modelResponsesApiCompactThresholds` 配置。
  - **modelResponsesApiCompactThresholds：** 按模型覆盖 Responses API 的 `compact_threshold`，仅在代理自动附加 `context_management` 时使用。它的优先级高于 `resolveResponsesCompactThreshold` 基于 `max_prompt_tokens * ratio` 的兜底阈值。默认将 `gpt-5.4` 和 `gpt-5.5` 设为 `217600`（`272000 * 0.8`）。未列出的模型继续使用原有兜底逻辑。
@@ -835,13 +855,13 @@ curl http://localhost:4141/admin/config/model-mappings \
 
 ### Codex 后端端点
 
-这些端点实现 Codex 后端 API。顶层图片请求要求已有可用的 Codex 登录态；alpha-search 则可以使用 Codex 后端或 Responses web-search 适配器。
+这些端点实现 Codex 兼容的后端 API。顶层图片请求默认使用 Codex 后端，也可以使用 `imageModel` 选择的 provider；alpha-search 则可以使用 Codex 后端或 Responses web-search 适配器。
 
 | 端点                                                       | 方法 | 说明                                                                                                 |
 | ---------------------------------------------------------- | ---- | ---------------------------------------------------------------------------------------------------- |
 | `POST /v1/alpha/search`            | `POST` | 将 Codex alpha-search 请求路由到 Codex 后端，或在本地及通过 Responses web search 处理支持的命令。 |
-| `POST /v1/images/generations` | `POST` | 将 JSON 图片生成请求转发到 Codex Images 上游。请求未携带 `Content-Type` 时，网关默认补充 `application/json`。 |
-| `POST /v1/images/edits` | `POST` | 将图片编辑请求转发到 Codex Images 上游。请使用 `multipart/form-data`，并让 HTTP 客户端自动生成 `boundary`；网关会保留传入的 content type，并以流式方式转发上传请求体。 |
+| `POST /v1/images/generations` | `POST` | 将 JSON 图片生成请求转发到 Codex Images 上游，或转发到 `imageModel` 配置的 provider。请求未携带 `Content-Type` 时，Codex 路径默认补充 `application/json`。 |
+| `POST /v1/images/edits` | `POST` | 将图片编辑请求转发到 Codex Images 上游，或转发到 `imageModel` 配置的 provider。请使用 `multipart/form-data`，并让 HTTP 客户端自动生成 `boundary`。 |
 
 对于路由到 Codex 后端的请求，网关会使用当前 Codex 登录态覆盖客户端的 authorization 和 account header，并保留兼容的请求元数据。基于 Responses 的 alpha-search 则遵循所选 Copilot 或 provider 的路由。
 

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -14,6 +14,7 @@ export interface AppConfig {
   }
   providers?: Record<string, ProviderConfig>
   modelMappings?: Record<string, string>
+  imageModel?: string
   extraPrompts?: Record<string, string>
   smallModel?: string
   contextManagement?: ContextManagementConfig
@@ -512,6 +513,10 @@ export function isAlphaSearchCodexPriorityEnabled(): boolean {
 export function getAlphaSearchModel(): string | undefined {
   const model = getConfig().alphaSearchModel ?? "gpt-5-mini"
   return model.trim() || undefined
+}
+
+export function getImageModel(): string | undefined {
+  return getConfig().imageModel?.trim() || undefined
 }
 
 export function getMessageApiWebSearchModel(): string | undefined {

--- a/src/routes/images/route.ts
+++ b/src/routes/images/route.ts
@@ -1,14 +1,18 @@
 import { Hono, type Context } from "hono"
 
-import type { ResolvedProviderConfig } from "~/lib/config"
+import { getImageModel, type ResolvedProviderConfig } from "~/lib/config"
 import { forwardError } from "~/lib/error"
 import { createHandlerLogger, debugJson, debugJsonAsync } from "~/lib/logger"
+import { parseProviderModelAlias } from "~/lib/provider-model"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import {
   forwardCodexImages,
   type CodexImagesOperation,
 } from "~/services/codex/images"
-import { createProviderProxyResponse } from "~/services/providers/provider-proxy"
+import {
+  createProviderProxyResponse,
+  forwardProviderImages,
+} from "~/services/providers/provider-proxy"
 
 const logger = createHandlerLogger("images-handler")
 
@@ -74,5 +78,71 @@ export async function handleCodexImages(
   }
 }
 
-imageRoutes.post("/generations", (c) => handleCodexImages(c, "generations"))
-imageRoutes.post("/edits", (c) => handleCodexImages(c, "edits"))
+async function createImageRequest(
+  request: Request,
+  operation: CodexImagesOperation,
+  model: string,
+): Promise<Request> {
+  const headers = new Headers(request.headers)
+  headers.delete("content-length")
+  let body: unknown
+
+  if (operation === "generations") {
+    const payload = (await request.json()) as Record<string, unknown>
+    headers.set("content-type", "application/json")
+    body = JSON.stringify({ ...payload, model })
+  } else {
+    const formData = await request.formData()
+    formData.set("model", model)
+    headers.delete("content-type")
+    body = formData
+  }
+
+  return new Request(request.url, {
+    body: body as never,
+    headers,
+    method: request.method,
+  })
+}
+
+async function handleImages(
+  c: Context,
+  operation: CodexImagesOperation,
+): Promise<Response> {
+  const configuredImageModel = getImageModel()
+  if (!configuredImageModel) {
+    return await handleCodexImages(c, operation)
+  }
+
+  try {
+    const providerModelAlias = parseProviderModelAlias(configuredImageModel)
+    if (!providerModelAlias) {
+      throw new Error("imageModel must use the provider/model format")
+    }
+
+    const providerConfig = await resolveProviderConfig(
+      providerModelAlias.provider,
+    )
+    if (!providerConfig || providerConfig.name === "codex") {
+      throw new Error(
+        `Image provider '${providerModelAlias.provider}' not found, disabled, or unsupported`,
+      )
+    }
+
+    const upstreamResponse = await forwardProviderImages(
+      providerConfig,
+      await createImageRequest(c.req.raw, operation, providerModelAlias.model),
+      operation,
+    )
+    return createProviderProxyResponse(upstreamResponse)
+  } catch (error) {
+    logger.error(`images.${operation}.provider.error`, {
+      error,
+      imageModel: configuredImageModel,
+    })
+    return await forwardError(c, error)
+  }
+}
+
+imageRoutes.post("/generations", (c) => handleImages(c, "generations"))
+imageRoutes.post("/edits", (c) => handleImages(c, "edits"))

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono"
 import { streamSSE } from "hono/streaming"
 
 import {
+  getImageModel,
   isResponsesApiWebSearchEnabled as isConfiguredResponsesApiWebSearchEnabled,
   resolveMappedModel,
 } from "~/lib/config"
@@ -166,6 +167,8 @@ export const handleResponses = async (c: Context) => {
     )
   }
 
+  const bridgedImageGeneration =
+    Boolean(getImageModel()) && bridgeImageGenerationNamespace(payload)
   removeUnsupportedTools(payload)
   fillEmptyNamespaceToolDescriptions(payload)
 
@@ -239,11 +242,15 @@ export const handleResponses = async (c: Context) => {
             }
           }
 
-          const processedData = fixStreamIds(
+          let processedData = fixStreamIds(
             (chunk as { data?: string }).data ?? "",
             (chunk as { event?: string }).event,
             idTracker,
           )
+          if (bridgedImageGeneration) {
+            processedData =
+              restoreImageGenerationNamespaceInStream(processedData)
+          }
 
           await stream.writeSSE({
             id: (chunk as { id?: string }).id,
@@ -269,6 +276,9 @@ export const handleResponses = async (c: Context) => {
       result.copilot_usage?.total_nano_aiu,
     ),
   })
+  if (bridgedImageGeneration) {
+    restoreImageGenerationNamespace(result)
+  }
   return c.json(result)
 }
 
@@ -319,8 +329,67 @@ const removeWebSearchTool = (payload: ResponsesPayload): void => {
   })
 }
 
+const CODEX_IMAGE_GENERATION_NAMESPACE = "image_gen"
+const COPILOT_IMAGE_GENERATION_NAMESPACE = "copilot_api_image_gen"
 const COPILOT_UNSUPPORTED_TOOL_TYPES = new Set(["image_generation"])
-const COPILOT_UNSUPPORTED_TOOL_NAMESPACES = new Set(["image_gen"])
+const COPILOT_UNSUPPORTED_TOOL_NAMESPACES = new Set([
+  CODEX_IMAGE_GENERATION_NAMESPACE,
+])
+
+export const bridgeImageGenerationNamespace = (
+  payload: ResponsesPayload,
+): boolean =>
+  replaceImageGenerationNamespace(
+    payload,
+    CODEX_IMAGE_GENERATION_NAMESPACE,
+    COPILOT_IMAGE_GENERATION_NAMESPACE,
+  )
+
+export const restoreImageGenerationNamespace = (value: unknown): void => {
+  replaceImageGenerationNamespace(
+    value,
+    COPILOT_IMAGE_GENERATION_NAMESPACE,
+    CODEX_IMAGE_GENERATION_NAMESPACE,
+  )
+}
+
+const replaceImageGenerationNamespace = (
+  value: unknown,
+  from: string,
+  to: string,
+): boolean => {
+  if (Array.isArray(value)) {
+    let changed = false
+    for (const item of value) {
+      if (replaceImageGenerationNamespace(item, from, to)) changed = true
+    }
+    return changed
+  }
+  if (!value || typeof value !== "object") return false
+
+  const record = value as Record<string, unknown>
+  let changed = false
+  if (record.type === "namespace" && record.name === from) {
+    record.name = to
+    changed = true
+  }
+  if (record.type === "function_call" && record.namespace === from) {
+    record.namespace = to
+    changed = true
+  }
+  for (const key of ["tools", "input", "output", "item", "response"] as const) {
+    if (replaceImageGenerationNamespace(record[key], from, to)) changed = true
+  }
+  return changed
+}
+
+const restoreImageGenerationNamespaceInStream = (data: string): string => {
+  if (!data.includes(COPILOT_IMAGE_GENERATION_NAMESPACE)) return data
+
+  const event = JSON.parse(data) as ResponseStreamEvent
+  restoreImageGenerationNamespace(event)
+  return JSON.stringify(event)
+}
 
 export const removeUnsupportedTools = (payload: ResponsesPayload): void => {
   if (!Array.isArray(payload.tools) || payload.tools.length === 0) return

--- a/tests/codex-images.test.ts
+++ b/tests/codex-images.test.ts
@@ -8,9 +8,11 @@ const actualTokenModule = await import("~/lib/token")
 
 let codexProviderConfig: ResolvedProviderConfig | null = null
 let openrouterProviderConfig: ResolvedProviderConfig | null = null
+let imageModel: string | undefined
 
 await mock.module("~/lib/config", () => ({
   ...actualConfigModule,
+  getImageModel: () => imageModel,
   getProviderConfig: (provider: string) => {
     if (provider === "codex") return codexProviderConfig
     if (provider === "openrouter") return openrouterProviderConfig
@@ -96,6 +98,7 @@ beforeEach(() => {
     name: "openrouter",
     type: "openai-compatible",
   }
+  imageModel = undefined
   state.codexAccessToken = "codex-access-token"
   state.codexAccountId = "account-123"
   state.verbose = false
@@ -187,7 +190,8 @@ describe("Codex images forwarding", () => {
     expect(await new Response(init?.body).json()).toEqual(payload)
   })
 
-  test("preserves multipart fields and file bytes for image edits", async () => {
+  test("routes configured image edits to a provider and rewrites the model", async () => {
+    imageModel = "openrouter/foundry-image-deployment"
     state.verbose = true
     const formData = new FormData()
     formData.set("model", "gpt-image-2")
@@ -205,7 +209,7 @@ describe("Codex images forwarding", () => {
 
     expect(response.status).toBe(200)
     const [url, init] = fetchMock.mock.calls[0] ?? []
-    expect(url).toBe("https://chatgpt.com/backend-api/codex/images/edits")
+    expect(url).toBe("https://openrouter.example/v1/images/edits")
 
     const headers = new Headers(init?.headers)
     expect(headers.get("content-type")).toStartWith(
@@ -215,7 +219,7 @@ describe("Codex images forwarding", () => {
       headers,
     })
     const forwardedFormData = await forwardedResponse.formData()
-    expect(forwardedFormData.get("model")).toBe("gpt-image-2")
+    expect(forwardedFormData.get("model")).toBe("foundry-image-deployment")
     expect(forwardedFormData.get("prompt")).toBe(
       "Make the background transparent",
     )
@@ -325,11 +329,16 @@ describe("Codex images forwarding", () => {
     )
   })
 
-  test("proxies non-codex providers on the provider-scoped images route", async () => {
-    const payload = { prompt: "generic provider image" }
+  test("routes configured image generations to a provider and rewrites the model", async () => {
+    imageModel = "openrouter/foundry-image-deployment"
+    codexProviderConfig = null
+    const payload = {
+      model: "gpt-image-2",
+      prompt: "generic provider image",
+    }
 
     const response = await createApp().request(
-      "/openrouter/v1/images/generations?output=base64",
+      "/v1/images/generations?output=base64",
       {
         method: "POST",
         headers: {
@@ -352,7 +361,10 @@ describe("Codex images forwarding", () => {
     const headers = new Headers(init?.headers)
     expect(headers.get("authorization")).toBe("Bearer openrouter-key")
     expect(headers.get("content-type")).toBe("application/json")
-    expect(await new Response(init?.body).json()).toEqual(payload)
+    expect(await new Response(init?.body).json()).toEqual({
+      ...payload,
+      model: "foundry-image-deployment",
+    })
   })
 
   test("preserves multipart content-type for non-codex provider image edits", async () => {

--- a/tests/responses-remove-unsupported-tools.test.ts
+++ b/tests/responses-remove-unsupported-tools.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "bun:test"
 import type { ResponsesPayload } from "~/lib/types/responses"
 
 import {
+  bridgeImageGenerationNamespace,
   fillEmptyNamespaceToolDescriptions,
   removeUnsupportedTools,
+  restoreImageGenerationNamespace,
 } from "~/routes/responses/handler"
 
 const makePayload = (tools: ResponsesPayload["tools"]): ResponsesPayload =>
@@ -37,6 +39,49 @@ describe("removeUnsupportedTools", () => {
 
     expect(payload.tools).toHaveLength(1)
     expect((payload.tools as Array<{ name: string }>)[0].name).toBe("foo")
+  })
+
+  it("bridges configured image_gen namespace calls through Copilot", () => {
+    const payload = makePayload([
+      {
+        type: "namespace",
+        name: "image_gen",
+        tools: [{ type: "function", name: "imagegen" }],
+      },
+    ] as ResponsesPayload["tools"])
+    payload.input = [
+      {
+        type: "function_call",
+        call_id: "call_image",
+        name: "imagegen",
+        namespace: "image_gen",
+        arguments: "{}",
+      },
+    ]
+
+    expect(bridgeImageGenerationNamespace(payload)).toBe(true)
+    removeUnsupportedTools(payload)
+
+    const namespace = (payload.tools?.[0] as { name: string }).name
+    expect(namespace).not.toBe("image_gen")
+    expect((payload.input[0] as { namespace: string }).namespace).toBe(
+      namespace,
+    )
+
+    const response = {
+      output: [
+        {
+          type: "function_call",
+          call_id: "call_image",
+          name: "imagegen",
+          namespace,
+          arguments: "{}",
+        },
+      ],
+    }
+    restoreImageGenerationNamespace(response)
+
+    expect(response.output[0].namespace).toBe("image_gen")
   })
 
   it("leaves payload unchanged when no unsupported tools present", () => {


### PR DESCRIPTION
## Summary

Add an optional `imageModel` setting for routing Codex image generation and edit requests through an existing OpenAI-compatible provider.

Codex Desktop exposes image generation as an `image_gen` namespace, but GitHub Copilot reserves that name and rejects it when forwarded unchanged. When `imageModel` is configured, the proxy temporarily aliases that namespace for the Copilot Responses request and restores it in the response. Codex can then execute its built-in image tool, which calls the top-level image endpoint routed by this change.

The setting uses the existing `provider/model` format. The proxy resolves that provider, replaces the request model with the configured model or deployment name, and forwards the request through the provider image path. When `imageModel` is not configured, the existing compatibility filtering and Codex image backend remain unchanged.

Generation requests retain their JSON payload, edit requests retain multipart fields and file data, and both paths preserve query parameters. Provider-scoped image routes are unchanged.

## Configuration

```json
{
  "imageModel": "foundry/my-gpt-image-2-deployment",
  "providers": {
    "foundry": {
      "type": "openai-compatible",
      "baseUrl": "https://<resource-name>.openai.azure.com/openai",
      "apiKey": "<azure-openai-api-key>",
      "authType": "authorization"
    }
  }
}
```

The provider base URL omits `/v1`. The model portion of `imageModel` is the Foundry deployment name.

## Changes

- Add the top-level `imageModel` configuration field.
- Bridge Codex Desktop's reserved `image_gen` namespace through Copilot Responses when image routing is configured.
- Restore the original namespace in streaming and non-streaming responses.
- Route configured generation and edit requests through the existing provider image forwarding path.
- Rewrite the incoming model to the configured provider model.
- Keep the existing Codex behavior when `imageModel` is absent.
- Document Foundry image routing in both READMEs.
- Cover namespace bridging, JSON generation, and multipart edit forwarding.

## Testing

- `bun test` (767 tests passed)
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- Live GHCP Responses request using the aliased namespace
- `git diff --check`
