### PR TITLE
Add usage viewer statistics periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,16 +585,16 @@ The dashboard provides a user-friendly interface to view your Copilot usage data
 
 - **API Endpoint URL**: The dashboard is pre-configured to fetch data from your local server endpoint via a URL query parameter. You can manually switch this to any other compatible API endpoint.
 - **API Key Authentication**: If API Key authentication is enabled, enter a raw API key (sent as the `x-api-key` header) or `Authorization: Bearer <key>`. Credentials are remembered in the browser's local storage per endpoint origin, and switching to a different endpoint origin does not automatically send the previous credential.
-- **Period Selector**: Choose from Day, Week, or Month time ranges. The URL query parameter updates automatically when you switch, making it easy to bookmark and share.
+- **Period Selector**: Choose from six time ranges: `day` (the current local calendar day), `weekToDate` (Monday at 00:00 through now), `week` (the rolling seven calendar days including today), `monthToDate` (the first day of the current month at 00:00 through now), `month` (the rolling 30 calendar days including today), and `lifetime` (the earliest recorded event through now). Day is selected by default. The URL query parameter updates automatically when you switch, making it easy to bookmark and share.
 - **Fetch Data**: Click the "Refresh" button to load or refresh the usage data. The dashboard also fetches data automatically on page load.
 - **Copilot Quotas**: View quota usage for services such as Chat and Completions via progress bars. Hover over a card to see used/remaining details.
 - **Token Usage Metric Cards**: See a summary of Total, Input, Output, Cache Read, Cache Write, Requests, and estimated cost for the current period.
-- **Trend Chart (Week / Month)**: An interactive line chart with model and metric filters. Click a data point to inspect the usage breakdown for a specific day.
+- **Trend Chart**: An interactive line chart with model and metric filters for the selected period. Click a data point to inspect the usage breakdown for a day; Lifetime chart data is sampled from the daily buckets and capped at 180 points for readability.
 - **Model Breakdown Table**: A per-model summary of requests, input/output/cache tokens, and estimated cost for the selected period.
 - **Request Events (Paginated)**: A time-sorted list of request event records with pagination support, showing timestamps, models, request IDs, and token counts.
 - **Detailed Information**: See the full JSON response from the API for a detailed breakdown of all available usage statistics.
 - **URL-based Configuration**: You can also specify the API endpoint and period directly via `endpoint` and `period` query parameters. For example:
-  `http://localhost:4141/usage-viewer?endpoint=http://your-api-server/usage&period=week`
+  `http://localhost:4141/usage-viewer?endpoint=http://your-api-server/usage&period=weekToDate`
 
 ### Usage Viewer Screenshot
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -623,16 +623,16 @@ cp plugin/opencode/subagent-marker.js ~/.config/opencode/plugins/
 
 - **API Endpoint URL**：通过 URL 查询参数指定 API endpoints，默认指向本地服务。支持手动切换为其他兼容 endpoints。
 - **API Key 认证**：如果启用了 API Key 认证，可填入原始 API key（默认通过 `x-api-key` 请求头发送）或 `Authorization: Bearer <key>`。凭据会按 endpoint origin 保存在浏览器本地存储中；切换到不同 endpoint origin 时，不会自动携带其他 origin 的凭据。
-- **Period 选择器**：支持 Day / Week / Month 三种时间范围，切换时 URL 参数会自动同步，方便收藏和分享。
+- **Period 选择器**：支持六种时间范围：`day`（当前本地日历日）、`weekToDate`（本周一 00:00 至现在）、`week`（包含今天在内的滚动 7 个日历日）、`monthToDate`（本月 1 日 00:00 至现在）、`month`（包含今天在内的滚动 30 个日历日）和 `lifetime`（从最早记录事件至现在）。默认选择 Day，切换时 URL 参数会自动同步，方便收藏和分享。
 - **Fetch Data**：点击 "Refresh" 按钮加载或刷新使用数据。页面加载时也会自动拉取数据。
 - **Copilot Quotas 额度**：通过进度条展示 Chat、Completions 等不同服务的额度使用情况，悬停可查看已用/剩余详情。
 - **Token Usage 指标卡片**：汇总当前周期的 Total、Input、Output、Cache Read、Cache Write、Requests 和预估费用。
-- **趋势图（Week / Month）**：提供按模型和指标筛选的折线趋势图，点击数据点可查看单日用量明细。
+- **趋势图**：提供按所选周期、模型和指标筛选的折线趋势图，点击数据点可查看用量明细；Lifetime 图表数据从每日数据桶中采样，最多显示 180 个点，以便查看长期趋势。
 - **Model Breakdown 表格**：按模型维度列出周期内的请求数、输入/输出/缓存 token 和预计费用。
 - **Request Events 分页列表**：按时间排序的请求事件记录，支持分页浏览，含时间戳、模型、请求 ID 和 token 用量。
 - **Detailed Information**：展示 API 返回的完整 JSON 响应，便于深入分析所有可用统计数据。
 - **URL-based Configuration**：也可通过 `endpoint` 和 `period` 查询参数直接指定 API 端点与时间范围。例如：
-  `http://localhost:4141/usage-viewer?endpoint=http://your-api-server/usage&period=week`
+  `http://localhost:4141/usage-viewer?endpoint=http://your-api-server/usage&period=weekToDate`
 
 ### Usage Viewer 截图
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -468,6 +468,7 @@
         const DEFAULT_ENDPOINT = "http://localhost:4141/usage";
         const DEFAULT_TOKEN_USAGE_PERIOD = "day";
         const DEFAULT_TOKEN_USAGE_EVENTS_PAGE_SIZE = 20;
+        const MAX_LIFETIME_TREND_POINTS = 180;
         const ALL_METRICS_VALUE = "__all__";
         const ALL_MODELS_VALUE = "__all__";
         const LEGACY_API_KEY_STORAGE_KEY = "copilot-api.usage-viewer.x-api-key";
@@ -505,7 +506,7 @@
           tokenUsageSummaryError: null,
           tokenUsageEventsError: null,
           tokenUsagePeriod: DEFAULT_TOKEN_USAGE_PERIOD,
-          tokenUsageTrendDayIndex: null,
+          tokenUsageTrendDay: null,
           tokenUsageTrendMetric: ALL_METRICS_VALUE,
           tokenUsageTrendModel: ALL_MODELS_VALUE,
         };
@@ -1347,6 +1348,44 @@
           return parts.length === 3 ? `${parts[1]}/${parts[2]}` : value;
         }
 
+        function getTokenUsageTrendDays(dailySummary, selectedModel) {
+          const days = dailySummary?.days || [];
+          if (
+            state.tokenUsagePeriod !== "lifetime"
+            || days.length <= MAX_LIFETIME_TREND_POINTS
+          ) {
+            return days;
+          }
+
+          const usageIndexes = days.reduce((indexes, day, index) => {
+            if (getDailyTrendTotals(day, selectedModel).request_count > 0) {
+              indexes.push(index);
+            }
+            return indexes;
+          }, []);
+          if (usageIndexes.length >= MAX_LIFETIME_TREND_POINTS) {
+            const step =
+              (usageIndexes.length - 1) / (MAX_LIFETIME_TREND_POINTS - 1);
+            return Array.from(
+              { length: MAX_LIFETIME_TREND_POINTS },
+              (_, index) => days[usageIndexes[Math.round(index * step)]]
+            );
+          }
+          const indexes = new Set(usageIndexes);
+          const sampleCount = Math.max(
+            1,
+            MAX_LIFETIME_TREND_POINTS - usageIndexes.length
+          );
+          const step = (days.length - 1) / (sampleCount - 1 || 1);
+          for (let index = 0; index < sampleCount; index += 1) {
+            indexes.add(Math.round(index * step));
+          }
+          return [...indexes]
+            .sort((left, right) => left - right)
+            .slice(0, MAX_LIFETIME_TREND_POINTS)
+            .map((index) => days[index]);
+        }
+
         function renderTokenUsageDailyTrend(dailySummary, error) {
           if (state.tokenUsagePeriod === "day") {
             return "";
@@ -1448,7 +1487,6 @@
         }
 
         function renderTokenUsageTrendChart(dailySummary, selectedModel) {
-          const days = dailySummary?.days || [];
           const metrics = getTokenUsageTrendMetrics();
           const visibleMetrics =
             state.tokenUsageTrendMetric === ALL_METRICS_VALUE
@@ -1456,6 +1494,7 @@
               : metrics.filter(
                   (metric) => metric.key === state.tokenUsageTrendMetric
                 );
+          const days = getTokenUsageTrendDays(dailySummary, selectedModel);
           const hasUsage = days.some(
             (day) => getDailyTrendTotals(day, selectedModel).request_count > 0
           );
@@ -1464,11 +1503,12 @@
               ? index
               : latest;
           }, -1);
+          const selectedDayIndex = days.findIndex(
+            (day) => day.date === state.tokenUsageTrendDay
+          );
           const activeIndex =
-            Number.isInteger(state.tokenUsageTrendDayIndex)
-              && state.tokenUsageTrendDayIndex >= 0
-              && state.tokenUsageTrendDayIndex < days.length
-              ? state.tokenUsageTrendDayIndex
+            selectedDayIndex >= 0
+              ? selectedDayIndex
               : latestUsageIndex >= 0
                 ? latestUsageIndex
                 : Math.max(0, days.length - 1);
@@ -1557,7 +1597,7 @@
                     value
                   )}" r="2.5" fill="${
                     metric.color
-                  }" data-trend-day-index="${index}">
+                  }" data-trend-day="${day.date}">
                     <title>${escapeHtml(
                       `${formatChartDate(day.date)} ${metric.label}: ${formatNumber(
                         value
@@ -1601,7 +1641,7 @@
               ].join("\n");
               return `<rect x="${hitStart}" y="${padding.top}" width="${
                 hitEnd - hitStart
-              }" height="${plotHeight}" fill="transparent" style="cursor: pointer;" data-trend-day-index="${index}">
+              }" height="${plotHeight}" fill="transparent" style="cursor: pointer;" data-trend-day="${day.date}">
                 <title>${escapeHtml(title)}</title>
               </rect>`;
             })
@@ -2166,14 +2206,11 @@
             return;
           }
 
-          const trendPoint = event.target.closest("[data-trend-day-index]");
+          const trendPoint = event.target.closest("[data-trend-day]");
           if (trendPoint) {
-            const index = Number.parseInt(
-              trendPoint.getAttribute("data-trend-day-index") || "",
-              10
-            );
-            if (Number.isFinite(index) && index >= 0) {
-              state.tokenUsageTrendDayIndex = index;
+            const day = trendPoint.getAttribute("data-trend-day");
+            if (day) {
+              state.tokenUsageTrendDay = day;
               render();
             }
             return;

--- a/pages/index.html
+++ b/pages/index.html
@@ -424,8 +424,11 @@
                 class="select-control input-focus"
               >
                 <option value="day">Day</option>
+                <option value="weekToDate">Week to date</option>
                 <option value="week">Week</option>
+                <option value="monthToDate">Month to date</option>
                 <option value="month">Month</option>
+                <option value="lifetime">Lifetime</option>
               </select>
             </div>
             <button id="fetch-button" type="submit" class="primary-action">
@@ -469,7 +472,14 @@
         const ALL_MODELS_VALUE = "__all__";
         const LEGACY_API_KEY_STORAGE_KEY = "copilot-api.usage-viewer.x-api-key";
         const CREDENTIAL_STORAGE_PREFIX = "copilot-api.usage-viewer.credential.";
-        const VALID_PERIODS = new Set(["day", "week", "month"]);
+        const VALID_PERIODS = new Set([
+          "day",
+          "weekToDate",
+          "week",
+          "monthToDate",
+          "month",
+          "lifetime",
+        ]);
         const EMPTY_TOKEN_USAGE_TOTALS = {
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,
@@ -898,8 +908,11 @@
         function renderTokenUsageRangeText(period, range) {
           const labels = {
             day: "Day window",
+            weekToDate: "Week to date",
             week: "Last 7 days",
+            monthToDate: "Month to date",
             month: "Last 30 days",
+            lifetime: "Lifetime",
           };
 
           if (!range) {

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -18,7 +18,13 @@ export type TokenUsageEndpoint =
   | "provider_messages"
   | "responses"
 
-export type TokenUsagePeriod = "day" | "week" | "month"
+export type TokenUsagePeriod =
+  | "day"
+  | "weekToDate"
+  | "week"
+  | "monthToDate"
+  | "month"
+  | "lifetime"
 
 export interface UsageTokens {
   cache_creation_input_tokens?: number | null
@@ -349,6 +355,14 @@ async function flushTokenUsageEvents(): Promise<void> {
 }
 
 function getPeriodRange(period: TokenUsagePeriod, now = new Date()) {
+  if (period === "lifetime") {
+    const nowMs = now.getTime()
+    return {
+      endMs: nowMs,
+      startMs: nowMs,
+    }
+  }
+
   const start = new Date(now)
   start.setHours(0, 0, 0, 0)
 
@@ -356,8 +370,17 @@ function getPeriodRange(period: TokenUsagePeriod, now = new Date()) {
     case "day": {
       break
     }
+    case "weekToDate": {
+      const daysSinceMonday = (start.getDay() + 6) % 7
+      start.setDate(start.getDate() - daysSinceMonday)
+      break
+    }
     case "week": {
       start.setDate(start.getDate() - 6)
+      break
+    }
+    case "monthToDate": {
+      start.setDate(1)
       break
     }
     case "month": {
@@ -373,6 +396,11 @@ function getPeriodRange(period: TokenUsagePeriod, now = new Date()) {
   switch (period) {
     case "day": {
       end.setDate(end.getDate() + 1)
+      break
+    }
+    case "weekToDate":
+    case "monthToDate": {
+      end.setTime(now.getTime() + 1)
       break
     }
     case "week": {
@@ -394,6 +422,36 @@ function getPeriodRange(period: TokenUsagePeriod, now = new Date()) {
   }
 }
 
+function getPeriodRangeFromDb(
+  db: SqliteDatabase,
+  period: TokenUsagePeriod,
+  now = new Date(),
+) {
+  if (period !== "lifetime") {
+    return getPeriodRange(period, now)
+  }
+
+  const nowMs = now.getTime()
+  const row = db
+    .prepare(
+      `
+    SELECT MIN(created_at_ms) AS start_ms
+    FROM token_usage_events
+    WHERE created_at_ms <= ?
+  `,
+    )
+    .get(nowMs) as Record<string, unknown> | undefined
+  const earliestEventMs = row?.start_ms
+  const hasEarliestEvent =
+    typeof earliestEventMs === "number" && Number.isFinite(earliestEventMs)
+  const startMs = hasEarliestEvent ? earliestEventMs : nowMs + 1
+
+  return {
+    endMs: nowMs + 1,
+    startMs,
+  }
+}
+
 function formatLocalDate(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, "0")
@@ -408,18 +466,21 @@ function createDailyIntervals(range: { endMs: number; startMs: number }) {
     startMs: number
   }> = []
   const cursor = new Date(range.startMs)
+  cursor.setHours(0, 0, 0, 0)
 
   while (cursor.getTime() < range.endMs) {
-    const startMs = cursor.getTime()
+    const startMs = Math.max(cursor.getTime(), range.startMs)
     const next = new Date(cursor)
     next.setDate(next.getDate() + 1)
     const endMs = Math.min(next.getTime(), range.endMs)
-    intervals.push({
-      date: formatLocalDate(cursor),
-      endMs,
-      startMs,
-    })
-    cursor.setTime(endMs)
+    if (startMs < endMs) {
+      intervals.push({
+        date: formatLocalDate(cursor),
+        endMs,
+        startMs,
+      })
+    }
+    cursor.setTime(next.getTime())
   }
 
   return intervals
@@ -826,8 +887,8 @@ export async function getTokenUsageSummary(
   }
 
   await flushTokenUsageEvents()
-  const range = getPeriodRange(period)
   const db = await getDb()
+  const range = getPeriodRangeFromDb(db, period)
   const totalsRow = getTotalsRow(db, range)
 
   return {
@@ -846,8 +907,8 @@ export async function getTokenUsageDailySummary(
   }
 
   await flushTokenUsageEvents()
-  const range = getPeriodRange(period)
   const db = await getDb()
+  const range = getPeriodRangeFromDb(db, period)
   const intervals = createDailyIntervals(range)
 
   return {
@@ -871,11 +932,11 @@ export async function getTokenUsageEventsPage(input: {
   }
 
   await flushTokenUsageEvents()
-  const range = getPeriodRange(input.period)
   const page = Math.max(1, Math.floor(input.page))
   const pageSize = Math.min(100, Math.max(1, Math.floor(input.pageSize)))
   const offset = (page - 1) * pageSize
   const db = await getDb()
+  const range = getPeriodRangeFromDb(db, input.period)
 
   const totalRow = db
     .prepare(

--- a/src/lib/token-usage/store.ts
+++ b/src/lib/token-usage/store.ts
@@ -861,6 +861,87 @@ function getModelSummaries(
   })
 }
 
+function getDailyModelSummaries(
+  db: SqliteDatabase,
+  range: { endMs: number; startMs: number },
+): Map<string, Array<TokenUsageModelSummary>> {
+  const usageDate =
+    "strftime('%Y-%m-%d', created_at_ms / 1000.0, 'unixepoch', 'localtime')"
+  const rows = db
+    .prepare(
+      `
+    SELECT
+      ${usageDate} AS usage_date,
+      model,
+      COUNT(*) AS request_count,
+      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+      COALESCE(SUM(cache_read_input_tokens), 0) AS cache_read_input_tokens,
+      COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+      SUM(total_nano_aiu) AS total_nano_aiu,
+      COALESCE(SUM(total_tokens), 0) AS total_tokens
+    FROM token_usage_events
+    WHERE created_at_ms >= ? AND created_at_ms < ?
+    GROUP BY usage_date, model
+    ORDER BY usage_date ASC, total_tokens DESC, model ASC
+  `,
+    )
+    .all(range.startMs, range.endMs) as Array<Record<string, unknown>>
+  const costRows = db
+    .prepare(
+      `
+    SELECT
+      ${usageDate} AS usage_date,
+      model,
+      cost_currency,
+      COALESCE(SUM(total_cost_nanos), 0) AS total_cost_nanos
+    FROM token_usage_events
+    WHERE created_at_ms >= ?
+      AND created_at_ms < ?
+      AND cost_currency IS NOT NULL
+      AND total_cost_nanos IS NOT NULL
+    GROUP BY usage_date, model, cost_currency
+    ORDER BY usage_date ASC, model ASC, cost_currency ASC
+  `,
+    )
+    .all(range.startMs, range.endMs) as Array<Record<string, unknown>>
+  const costsByDateAndModel = new Map<string, Array<TokenUsageCost>>()
+  for (const row of costRows) {
+    const date = stringFromRow(row, "usage_date")
+    const model = stringFromRow(row, "model") || "unknown"
+    const cost = costFromRow(row)
+    if (!date || !cost) {
+      continue
+    }
+
+    const key = `${date}\u0000${model}`
+    costsByDateAndModel.set(key, [
+      ...(costsByDateAndModel.get(key) ?? []),
+      cost,
+    ])
+  }
+
+  const summariesByDate = new Map<string, Array<TokenUsageModelSummary>>()
+  for (const row of rows) {
+    const date = stringFromRow(row, "usage_date")
+    if (!date) {
+      continue
+    }
+
+    const model = stringFromRow(row, "model") || "unknown"
+    const summaries = summariesByDate.get(date) ?? []
+    summaries.push(
+      modelSummaryFromRow(
+        row,
+        costsByDateAndModel.get(`${date}\u0000${model}`) ?? [],
+      ),
+    )
+    summariesByDate.set(date, summaries)
+  }
+
+  return summariesByDate
+}
+
 function createDailyBucket(
   interval: { date: string; endMs: number; startMs: number },
   byModel: Array<TokenUsageModelSummary>,
@@ -910,11 +991,12 @@ export async function getTokenUsageDailySummary(
   const db = await getDb()
   const range = getPeriodRangeFromDb(db, period)
   const intervals = createDailyIntervals(range)
+  const dailySummaries = getDailyModelSummaries(db, range)
 
   return {
     byModel: getModelSummaries(db, range),
     days: intervals.map((interval) =>
-      createDailyBucket(interval, getModelSummaries(db, interval)),
+      createDailyBucket(interval, dailySummaries.get(interval.date) ?? []),
     ),
     period,
     range: rangePayload(range),

--- a/src/routes/token-usage/route.ts
+++ b/src/routes/token-usage/route.ts
@@ -9,7 +9,14 @@ import {
 
 export const tokenUsageRoute = new Hono()
 
-const periods = new Set<TokenUsagePeriod>(["day", "week", "month"])
+const periods = new Set<TokenUsagePeriod>([
+  "day",
+  "weekToDate",
+  "week",
+  "monthToDate",
+  "month",
+  "lifetime",
+])
 const DEFAULT_EVENTS_PAGE_SIZE = 20
 
 function parsePeriod(value: string | undefined): TokenUsagePeriod {

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -53,8 +53,14 @@ async function fetchEventsPage(pageSize = 20): Promise<TokenUsageEventsPage> {
   return (await response.json()) as TokenUsageEventsPage
 }
 
-function localDate(year: number, month: number, day: number, hour = 12): Date {
-  return new Date(year, month, day, hour, 0, 0, 0)
+function localDate(
+  year: number,
+  month: number,
+  day: number,
+  hour = 12,
+  minute = 0,
+): Date {
+  return new Date(year, month, day, hour, minute, 0, 0)
 }
 
 function localDateLabel(date: Date): string {
@@ -549,6 +555,278 @@ describe("token usage storage", () => {
     expect(page.items[1]?.session_id).toBe("interaction-session")
   })
 
+  test("returns the current calendar week from Monday through today", async () => {
+    setSystemTime(localDate(2026, 3, 12, 23))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 99,
+      model: "before-week-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 3, 13, 0))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 10,
+      model: "monday-week-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 3, 15, 15, 30))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 20,
+      model: "today-week-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 3, 15, 18))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 30,
+      model: "future-week-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 3, 15, 15, 30))
+    const app = createTokenUsageApp()
+    const summaryResponse = await app.request("/token-usage?period=weekToDate")
+    expect(summaryResponse.status).toBe(200)
+
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    expect(summary.period).toBe("weekToDate")
+    expect(summary.range.start_ms).toBe(localDate(2026, 3, 13, 0).getTime())
+    expect(summary.range.end_ms).toBe(
+      localDate(2026, 3, 15, 15, 30).getTime() + 1,
+    )
+    expect(summary.totals.request_count).toBe(2)
+    expect(summary.totals.input_tokens).toBe(30)
+    expect(summary.byModel.map((model) => model.model)).toEqual([
+      "today-week-to-date",
+      "monday-week-to-date",
+    ])
+
+    const dailyResponse = await app.request(
+      "/token-usage/daily?period=weekToDate",
+    )
+    expect(dailyResponse.status).toBe(200)
+    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
+    expect(daily.period).toBe("weekToDate")
+    expect(daily.days.map((day) => day.date)).toEqual([
+      localDateLabel(localDate(2026, 3, 13)),
+      localDateLabel(localDate(2026, 3, 14)),
+      localDateLabel(localDate(2026, 3, 15)),
+    ])
+    expect(daily.days[2]?.totals.input_tokens).toBe(20)
+
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=weekToDate&page=1&page_size=1",
+    )
+    expect(eventsResponse.status).toBe(200)
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
+    expect(events.period).toBe("weekToDate")
+    expect(events.range.start_ms).toBe(summary.range.start_ms)
+    expect(events.range.end_ms).toBe(summary.range.end_ms)
+    expect(events.total).toBe(2)
+    expect(events.page).toBe(1)
+    expect(events.page_size).toBe(1)
+    expect(events.total_pages).toBe(2)
+    expect(events.items).toHaveLength(1)
+    expect(events.items[0]?.model).toBe("today-week-to-date")
+  })
+
+  test("returns the current calendar month from the first day through today", async () => {
+    setSystemTime(localDate(2026, 4, 30, 23))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 99,
+      model: "before-month-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 5, 1, 0))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 10,
+      model: "first-day-month-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 5, 3, 15, 30))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 20,
+      model: "today-month-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 5, 3, 18))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 30,
+      model: "future-month-to-date",
+      source: "copilot",
+    })
+
+    setSystemTime(localDate(2026, 5, 3, 15, 30))
+    const app = createTokenUsageApp()
+    const summaryResponse = await app.request("/token-usage?period=monthToDate")
+    expect(summaryResponse.status).toBe(200)
+
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    expect(summary.period).toBe("monthToDate")
+    expect(summary.range.start_ms).toBe(localDate(2026, 5, 1, 0).getTime())
+    expect(summary.range.end_ms).toBe(
+      localDate(2026, 5, 3, 15, 30).getTime() + 1,
+    )
+    expect(summary.totals.request_count).toBe(2)
+    expect(summary.totals.input_tokens).toBe(30)
+    expect(summary.byModel.map((model) => model.model)).toEqual([
+      "today-month-to-date",
+      "first-day-month-to-date",
+    ])
+
+    const dailyResponse = await app.request(
+      "/token-usage/daily?period=monthToDate",
+    )
+    expect(dailyResponse.status).toBe(200)
+    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
+    expect(daily.period).toBe("monthToDate")
+    expect(daily.days).toHaveLength(3)
+    expect(daily.days.map((day) => day.date)).toEqual([
+      localDateLabel(localDate(2026, 5, 1)),
+      localDateLabel(localDate(2026, 5, 2)),
+      localDateLabel(localDate(2026, 5, 3)),
+    ])
+    expect(daily.days[2]?.totals.input_tokens).toBe(20)
+
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=monthToDate&page=1&page_size=1",
+    )
+    expect(eventsResponse.status).toBe(200)
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
+    expect(events.period).toBe("monthToDate")
+    expect(events.total).toBe(2)
+    expect(events.page).toBe(1)
+    expect(events.page_size).toBe(1)
+    expect(events.total_pages).toBe(2)
+    expect(events.items[0]?.model).toBe("today-month-to-date")
+  })
+
+  test("keeps calendar-to-date starts at Monday and the first of the month", async () => {
+    const app = createTokenUsageApp()
+
+    setSystemTime(localDate(2026, 2, 16, 0, 0))
+    const mondayResponse = await app.request("/token-usage?period=weekToDate")
+    const mondaySummary = (await mondayResponse.json()) as TokenUsageSummary
+    expect(mondaySummary.range.start_ms).toBe(
+      localDate(2026, 2, 16, 0, 0).getTime(),
+    )
+
+    setSystemTime(localDate(2026, 3, 1, 0, 0))
+    const monthResponse = await app.request("/token-usage?period=monthToDate")
+    const monthSummary = (await monthResponse.json()) as TokenUsageSummary
+    expect(monthSummary.range.start_ms).toBe(
+      localDate(2026, 3, 1, 0, 0).getTime(),
+    )
+  })
+
+  test("returns lifetime usage from the earliest event through now", async () => {
+    const earliestEvent = localDate(2026, 1, 10, 9)
+    const currentMoment = localDate(2026, 3, 15, 14, 30)
+
+    setSystemTime(earliestEvent)
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 11,
+      model: "lifetime-earliest",
+      output_tokens: 1,
+      source: "copilot",
+    })
+
+    setSystemTime(currentMoment)
+    recordTokenUsageEvent({
+      endpoint: "messages",
+      input_tokens: 22,
+      model: "lifetime-current",
+      output_tokens: 2,
+      source: "copilot",
+    })
+
+    const app = createTokenUsageApp()
+    const summaryResponse = await app.request("/token-usage?period=lifetime")
+    expect(summaryResponse.status).toBe(200)
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    expect(summary.period).toBe("lifetime")
+    expect(summary.range.start_ms).toBe(earliestEvent.getTime())
+    expect(summary.range.end_ms).toBe(currentMoment.getTime() + 1)
+    expect(summary.totals.request_count).toBe(2)
+    expect(summary.totals.input_tokens).toBe(33)
+    expect(summary.byModel.map((model) => model.model)).toEqual([
+      "lifetime-current",
+      "lifetime-earliest",
+    ])
+
+    const dailyResponse = await app.request(
+      "/token-usage/daily?period=lifetime",
+    )
+    expect(dailyResponse.status).toBe(200)
+    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
+    expect(daily.period).toBe("lifetime")
+    expect(daily.range.start_ms).toBe(summary.range.start_ms)
+    expect(daily.range.end_ms).toBe(summary.range.end_ms)
+    expect(daily.totals.request_count).toBe(2)
+    expect(
+      daily.days.find((day) => day.date === localDateLabel(earliestEvent))
+        ?.totals.request_count,
+    ).toBe(1)
+    expect(
+      daily.days.find((day) => day.date === localDateLabel(currentMoment))
+        ?.totals.request_count,
+    ).toBe(1)
+
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=lifetime&page=1&page_size=10",
+    )
+    expect(eventsResponse.status).toBe(200)
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
+    expect(events.period).toBe("lifetime")
+    expect(events.range.start_ms).toBe(summary.range.start_ms)
+    expect(events.range.end_ms).toBe(summary.range.end_ms)
+    expect(events.total).toBe(2)
+    expect(events.items.map((item) => item.model)).toEqual([
+      "lifetime-current",
+      "lifetime-earliest",
+    ])
+  })
+
+  test("returns an empty lifetime range when there are no events", async () => {
+    setSystemTime(localDate(2026, 4, 15, 12))
+    const app = createTokenUsageApp()
+
+    const summaryResponse = await app.request("/token-usage?period=lifetime")
+    const dailyResponse = await app.request(
+      "/token-usage/daily?period=lifetime",
+    )
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=lifetime",
+    )
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
+
+    expect(summary.period).toBe("lifetime")
+    expect(summary.range.start_ms).toBe(summary.range.end_ms)
+    expect(summary.totals.request_count).toBe(0)
+    expect(daily.period).toBe("lifetime")
+    expect(daily.range.start_ms).toBe(daily.range.end_ms)
+    expect(daily.days).toEqual([])
+    expect(events.period).toBe("lifetime")
+    expect(events.range.start_ms).toBe(events.range.end_ms)
+    expect(events.total).toBe(0)
+    expect(events.items).toEqual([])
+  })
+
   test("returns daily token usage buckets by model with total tokens", async () => {
     setSystemTime(localDate(2026, 4, 8))
     recordTokenUsageEvent({
@@ -661,13 +939,22 @@ describe("token usage storage", () => {
 
   test("returns empty daily buckets and falls back invalid period to day", async () => {
     setSystemTime(localDate(2026, 4, 15))
-    const response = await createTokenUsageApp().request(
-      "/token-usage/daily?period=invalid",
+    const app = createTokenUsageApp()
+    const response = await app.request("/token-usage/daily?period=invalid")
+    const summaryResponse = await app.request("/token-usage?period=invalid")
+    const eventsResponse = await app.request(
+      "/token-usage/events?period=invalid",
     )
     expect(response.status).toBe(200)
+    expect(summaryResponse.status).toBe(200)
+    expect(eventsResponse.status).toBe(200)
 
     const daily = (await response.json()) as TokenUsageDailySummary
+    const summary = (await summaryResponse.json()) as TokenUsageSummary
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
     expect(daily.period).toBe("day")
+    expect(summary.period).toBe("day")
+    expect(events.period).toBe("day")
     expect(daily.days).toHaveLength(1)
     expect(daily.days[0]?.date).toBe(localDateLabel(localDate(2026, 4, 15)))
     expect(daily.days[0]?.totals.total_tokens).toBe(0)

--- a/tests/token-usage.test.ts
+++ b/tests/token-usage.test.ts
@@ -555,276 +555,105 @@ describe("token usage storage", () => {
     expect(page.items[1]?.session_id).toBe("interaction-session")
   })
 
-  test("returns the current calendar week from Monday through today", async () => {
-    setSystemTime(localDate(2026, 3, 12, 23))
+  test("supports calendar-to-date and lifetime periods", async () => {
+    const outside = localDate(2026, 3, 30, 23)
+    const monthStart = localDate(2026, 4, 1, 0)
+    const weekEvent = localDate(2026, 4, 12)
+    const now = localDate(2026, 4, 15, 15, 30)
+
+    setSystemTime(outside)
     recordTokenUsageEvent({
       endpoint: "responses",
-      input_tokens: 99,
-      model: "before-week-to-date",
+      input_tokens: 1,
+      model: "outside",
       source: "copilot",
     })
-
-    setSystemTime(localDate(2026, 3, 13, 0))
+    setSystemTime(monthStart)
     recordTokenUsageEvent({
       endpoint: "responses",
-      input_tokens: 10,
-      model: "monday-week-to-date",
+      input_tokens: 2,
+      model: "month-start",
       source: "copilot",
     })
-
-    setSystemTime(localDate(2026, 3, 15, 15, 30))
+    setSystemTime(weekEvent)
     recordTokenUsageEvent({
       endpoint: "responses",
-      input_tokens: 20,
-      model: "today-week-to-date",
+      input_tokens: 4,
+      model: "week-event",
       source: "copilot",
     })
-
-    setSystemTime(localDate(2026, 3, 15, 18))
+    setSystemTime(now)
     recordTokenUsageEvent({
       endpoint: "responses",
-      input_tokens: 30,
-      model: "future-week-to-date",
+      input_tokens: 8,
+      model: "now",
       source: "copilot",
     })
+    setSystemTime(localDate(2026, 4, 15, 18))
+    recordTokenUsageEvent({
+      endpoint: "responses",
+      input_tokens: 16,
+      model: "future",
+      source: "copilot",
+    })
+    setSystemTime(now)
 
-    setSystemTime(localDate(2026, 3, 15, 15, 30))
     const app = createTokenUsageApp()
-    const summaryResponse = await app.request("/token-usage?period=weekToDate")
-    expect(summaryResponse.status).toBe(200)
-
-    const summary = (await summaryResponse.json()) as TokenUsageSummary
-    expect(summary.period).toBe("weekToDate")
-    expect(summary.range.start_ms).toBe(localDate(2026, 3, 13, 0).getTime())
-    expect(summary.range.end_ms).toBe(
-      localDate(2026, 3, 15, 15, 30).getTime() + 1,
-    )
-    expect(summary.totals.request_count).toBe(2)
-    expect(summary.totals.input_tokens).toBe(30)
-    expect(summary.byModel.map((model) => model.model)).toEqual([
-      "today-week-to-date",
-      "monday-week-to-date",
-    ])
+    const summary = async (period: string) => {
+      const response = await app.request(`/token-usage?period=${period}`)
+      expect(response.status).toBe(200)
+      return (await response.json()) as TokenUsageSummary
+    }
+    const week = await summary("weekToDate")
+    expect(week.range.start_ms).toBe(localDate(2026, 4, 11, 0).getTime())
+    expect(week.range.end_ms).toBe(now.getTime() + 1)
+    expect(week.totals.input_tokens).toBe(12)
+    const month = await summary("monthToDate")
+    expect(month.range.start_ms).toBe(monthStart.getTime())
+    expect(month.range.end_ms).toBe(now.getTime() + 1)
+    expect(month.totals.input_tokens).toBe(14)
+    const lifetime = await summary("lifetime")
+    expect(lifetime.range.start_ms).toBe(outside.getTime())
+    expect(lifetime.range.end_ms).toBe(now.getTime() + 1)
+    expect(lifetime.totals.input_tokens).toBe(15)
 
     const dailyResponse = await app.request(
       "/token-usage/daily?period=weekToDate",
     )
-    expect(dailyResponse.status).toBe(200)
     const daily = (await dailyResponse.json()) as TokenUsageDailySummary
-    expect(daily.period).toBe("weekToDate")
-    expect(daily.days.map((day) => day.date)).toEqual([
-      localDateLabel(localDate(2026, 3, 13)),
-      localDateLabel(localDate(2026, 3, 14)),
-      localDateLabel(localDate(2026, 3, 15)),
-    ])
-    expect(daily.days[2]?.totals.input_tokens).toBe(20)
+    expect(daily.days).toHaveLength(5)
+    expect(daily.days[1]?.totals.input_tokens).toBe(4)
+    expect(daily.days[4]?.totals.input_tokens).toBe(8)
 
-    const eventsResponse = await app.request(
-      "/token-usage/events?period=weekToDate&page=1&page_size=1",
-    )
-    expect(eventsResponse.status).toBe(200)
-    const events = (await eventsResponse.json()) as TokenUsageEventsPage
-    expect(events.period).toBe("weekToDate")
-    expect(events.range.start_ms).toBe(summary.range.start_ms)
-    expect(events.range.end_ms).toBe(summary.range.end_ms)
-    expect(events.total).toBe(2)
-    expect(events.page).toBe(1)
-    expect(events.page_size).toBe(1)
-    expect(events.total_pages).toBe(2)
-    expect(events.items).toHaveLength(1)
-    expect(events.items[0]?.model).toBe("today-week-to-date")
-  })
-
-  test("returns the current calendar month from the first day through today", async () => {
-    setSystemTime(localDate(2026, 4, 30, 23))
-    recordTokenUsageEvent({
-      endpoint: "responses",
-      input_tokens: 99,
-      model: "before-month-to-date",
-      source: "copilot",
-    })
-
-    setSystemTime(localDate(2026, 5, 1, 0))
-    recordTokenUsageEvent({
-      endpoint: "responses",
-      input_tokens: 10,
-      model: "first-day-month-to-date",
-      source: "copilot",
-    })
-
-    setSystemTime(localDate(2026, 5, 3, 15, 30))
-    recordTokenUsageEvent({
-      endpoint: "responses",
-      input_tokens: 20,
-      model: "today-month-to-date",
-      source: "copilot",
-    })
-
-    setSystemTime(localDate(2026, 5, 3, 18))
-    recordTokenUsageEvent({
-      endpoint: "responses",
-      input_tokens: 30,
-      model: "future-month-to-date",
-      source: "copilot",
-    })
-
-    setSystemTime(localDate(2026, 5, 3, 15, 30))
-    const app = createTokenUsageApp()
-    const summaryResponse = await app.request("/token-usage?period=monthToDate")
-    expect(summaryResponse.status).toBe(200)
-
-    const summary = (await summaryResponse.json()) as TokenUsageSummary
-    expect(summary.period).toBe("monthToDate")
-    expect(summary.range.start_ms).toBe(localDate(2026, 5, 1, 0).getTime())
-    expect(summary.range.end_ms).toBe(
-      localDate(2026, 5, 3, 15, 30).getTime() + 1,
-    )
-    expect(summary.totals.request_count).toBe(2)
-    expect(summary.totals.input_tokens).toBe(30)
-    expect(summary.byModel.map((model) => model.model)).toEqual([
-      "today-month-to-date",
-      "first-day-month-to-date",
-    ])
-
-    const dailyResponse = await app.request(
+    const monthDailyResponse = await app.request(
       "/token-usage/daily?period=monthToDate",
     )
-    expect(dailyResponse.status).toBe(200)
-    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
-    expect(daily.period).toBe("monthToDate")
-    expect(daily.days).toHaveLength(3)
-    expect(daily.days.map((day) => day.date)).toEqual([
-      localDateLabel(localDate(2026, 5, 1)),
-      localDateLabel(localDate(2026, 5, 2)),
-      localDateLabel(localDate(2026, 5, 3)),
-    ])
-    expect(daily.days[2]?.totals.input_tokens).toBe(20)
+    const monthDaily =
+      (await monthDailyResponse.json()) as TokenUsageDailySummary
+    expect(monthDaily.days).toHaveLength(15)
+    expect(monthDaily.days[0]?.totals.input_tokens).toBe(2)
 
-    const eventsResponse = await app.request(
-      "/token-usage/events?period=monthToDate&page=1&page_size=1",
-    )
-    expect(eventsResponse.status).toBe(200)
-    const events = (await eventsResponse.json()) as TokenUsageEventsPage
-    expect(events.period).toBe("monthToDate")
-    expect(events.total).toBe(2)
-    expect(events.page).toBe(1)
-    expect(events.page_size).toBe(1)
-    expect(events.total_pages).toBe(2)
-    expect(events.items[0]?.model).toBe("today-month-to-date")
-  })
-
-  test("keeps calendar-to-date starts at Monday and the first of the month", async () => {
-    const app = createTokenUsageApp()
-
-    setSystemTime(localDate(2026, 2, 16, 0, 0))
-    const mondayResponse = await app.request("/token-usage?period=weekToDate")
-    const mondaySummary = (await mondayResponse.json()) as TokenUsageSummary
-    expect(mondaySummary.range.start_ms).toBe(
-      localDate(2026, 2, 16, 0, 0).getTime(),
-    )
-
-    setSystemTime(localDate(2026, 3, 1, 0, 0))
-    const monthResponse = await app.request("/token-usage?period=monthToDate")
-    const monthSummary = (await monthResponse.json()) as TokenUsageSummary
-    expect(monthSummary.range.start_ms).toBe(
-      localDate(2026, 3, 1, 0, 0).getTime(),
-    )
-  })
-
-  test("returns lifetime usage from the earliest event through now", async () => {
-    const earliestEvent = localDate(2026, 1, 10, 9)
-    const currentMoment = localDate(2026, 3, 15, 14, 30)
-
-    setSystemTime(earliestEvent)
-    recordTokenUsageEvent({
-      endpoint: "responses",
-      input_tokens: 11,
-      model: "lifetime-earliest",
-      output_tokens: 1,
-      source: "copilot",
-    })
-
-    setSystemTime(currentMoment)
-    recordTokenUsageEvent({
-      endpoint: "messages",
-      input_tokens: 22,
-      model: "lifetime-current",
-      output_tokens: 2,
-      source: "copilot",
-    })
-
-    const app = createTokenUsageApp()
-    const summaryResponse = await app.request("/token-usage?period=lifetime")
-    expect(summaryResponse.status).toBe(200)
-    const summary = (await summaryResponse.json()) as TokenUsageSummary
-    expect(summary.period).toBe("lifetime")
-    expect(summary.range.start_ms).toBe(earliestEvent.getTime())
-    expect(summary.range.end_ms).toBe(currentMoment.getTime() + 1)
-    expect(summary.totals.request_count).toBe(2)
-    expect(summary.totals.input_tokens).toBe(33)
-    expect(summary.byModel.map((model) => model.model)).toEqual([
-      "lifetime-current",
-      "lifetime-earliest",
-    ])
-
-    const dailyResponse = await app.request(
-      "/token-usage/daily?period=lifetime",
-    )
-    expect(dailyResponse.status).toBe(200)
-    const daily = (await dailyResponse.json()) as TokenUsageDailySummary
-    expect(daily.period).toBe("lifetime")
-    expect(daily.range.start_ms).toBe(summary.range.start_ms)
-    expect(daily.range.end_ms).toBe(summary.range.end_ms)
-    expect(daily.totals.request_count).toBe(2)
-    expect(
-      daily.days.find((day) => day.date === localDateLabel(earliestEvent))
-        ?.totals.request_count,
-    ).toBe(1)
-    expect(
-      daily.days.find((day) => day.date === localDateLabel(currentMoment))
-        ?.totals.request_count,
-    ).toBe(1)
-
-    const eventsResponse = await app.request(
-      "/token-usage/events?period=lifetime&page=1&page_size=10",
-    )
-    expect(eventsResponse.status).toBe(200)
-    const events = (await eventsResponse.json()) as TokenUsageEventsPage
-    expect(events.period).toBe("lifetime")
-    expect(events.range.start_ms).toBe(summary.range.start_ms)
-    expect(events.range.end_ms).toBe(summary.range.end_ms)
-    expect(events.total).toBe(2)
-    expect(events.items.map((item) => item.model)).toEqual([
-      "lifetime-current",
-      "lifetime-earliest",
-    ])
-  })
-
-  test("returns an empty lifetime range when there are no events", async () => {
-    setSystemTime(localDate(2026, 4, 15, 12))
-    const app = createTokenUsageApp()
-
-    const summaryResponse = await app.request("/token-usage?period=lifetime")
-    const dailyResponse = await app.request(
-      "/token-usage/daily?period=lifetime",
-    )
     const eventsResponse = await app.request(
       "/token-usage/events?period=lifetime",
     )
+    const events = (await eventsResponse.json()) as TokenUsageEventsPage
+    expect(events.total).toBe(4)
+  })
+
+  test("returns an empty lifetime range when there are no events", async () => {
+    setSystemTime(localDate(2026, 4, 15))
+    const app = createTokenUsageApp()
+    const summaryResponse = await app.request("/token-usage?period=lifetime")
+    const dailyResponse = await app.request(
+      "/token-usage/daily?period=lifetime",
+    )
     const summary = (await summaryResponse.json()) as TokenUsageSummary
     const daily = (await dailyResponse.json()) as TokenUsageDailySummary
-    const events = (await eventsResponse.json()) as TokenUsageEventsPage
 
-    expect(summary.period).toBe("lifetime")
     expect(summary.range.start_ms).toBe(summary.range.end_ms)
     expect(summary.totals.request_count).toBe(0)
-    expect(daily.period).toBe("lifetime")
     expect(daily.range.start_ms).toBe(daily.range.end_ms)
     expect(daily.days).toEqual([])
-    expect(events.period).toBe("lifetime")
-    expect(events.range.start_ms).toBe(events.range.end_ms)
-    expect(events.total).toBe(0)
-    expect(events.items).toEqual([])
   })
 
   test("returns daily token usage buckets by model with total tokens", async () => {
@@ -939,22 +768,13 @@ describe("token usage storage", () => {
 
   test("returns empty daily buckets and falls back invalid period to day", async () => {
     setSystemTime(localDate(2026, 4, 15))
-    const app = createTokenUsageApp()
-    const response = await app.request("/token-usage/daily?period=invalid")
-    const summaryResponse = await app.request("/token-usage?period=invalid")
-    const eventsResponse = await app.request(
-      "/token-usage/events?period=invalid",
+    const response = await createTokenUsageApp().request(
+      "/token-usage/daily?period=invalid",
     )
     expect(response.status).toBe(200)
-    expect(summaryResponse.status).toBe(200)
-    expect(eventsResponse.status).toBe(200)
 
     const daily = (await response.json()) as TokenUsageDailySummary
-    const summary = (await summaryResponse.json()) as TokenUsageSummary
-    const events = (await eventsResponse.json()) as TokenUsageEventsPage
     expect(daily.period).toBe("day")
-    expect(summary.period).toBe("day")
-    expect(events.period).toBe("day")
     expect(daily.days).toHaveLength(1)
     expect(daily.days[0]?.date).toBe(localDateLabel(localDate(2026, 4, 15)))
     expect(daily.days[0]?.totals.total_tokens).toBe(0)

--- a/tests/usage-viewer.test.ts
+++ b/tests/usage-viewer.test.ts
@@ -8,17 +8,13 @@ async function readUsageViewerPage(): Promise<string> {
 }
 
 describe("usage viewer period contract", () => {
-  test("offers calendar-to-date periods in the documented order", async () => {
+  test("supports all periods in the selector and usage requests", async () => {
     const html = await readUsageViewerPage()
-    const periodSelect = html.match(
-      /<select\s+id="token-usage-period"[\s\S]*?<\/select>/,
-    )?.[0]
-
-    expect(periodSelect).toBeDefined()
     const options = [
-      ...(periodSelect ?? "").matchAll(
-        /<option value="([^"]+)">([^<]+)<\/option>/g,
-      ),
+      ...(
+        html.match(/<select\s+id="token-usage-period"[\s\S]*?<\/select>/)?.[0]
+        ?? ""
+      ).matchAll(/<option value="([^"]+)">([^<]+)<\/option>/g),
     ].map((match) => [match[1], match[2]])
 
     expect(options).toEqual([
@@ -29,20 +25,14 @@ describe("usage viewer period contract", () => {
       ["month", "Month"],
       ["lifetime", "Lifetime"],
     ])
-  })
 
-  test("normalizes new period values and propagates the selection to requests", async () => {
-    const html = await readUsageViewerPage()
-
-    expect(html).toMatch(
-      /const DEFAULT_TOKEN_USAGE_PERIOD = "day";[\s\S]*?const VALID_PERIODS = new Set\(\[\s*"day",\s*"weekToDate",\s*"week",\s*"monthToDate",\s*"month",\s*"lifetime",\s*\]\);/,
+    expect(html).toContain("return VALID_PERIODS.has(value)")
+    expect(html).toContain("const MAX_LIFETIME_TREND_POINTS = 180")
+    expect(html).toContain(
+      "getDailyTrendTotals(day, selectedModel).request_count > 0",
     )
-    expect(html).toMatch(
-      /function normalizePeriod\(value\)\s*\{[\s\S]*?return VALID_PERIODS\.has\(value\)[\s\S]*?\? value\s*:\s*DEFAULT_TOKEN_USAGE_PERIOD;/,
-    )
-    expect(html).toContain('weekToDate: "Week to date"')
-    expect(html).toContain('monthToDate: "Month to date"')
-    expect(html).toContain('lifetime: "Lifetime"')
+    expect(html).toContain("tokenUsageTrendDay: null")
+    expect(html).toContain('data-trend-day="${day.date}"')
     expect(html).toContain(
       "fetchJson(buildTokenUsageSummaryUrl(usageUrl, period))",
     )
@@ -56,13 +46,8 @@ describe("usage viewer period contract", () => {
       "buildTokenUsageEventsUrl(usageUrl, getSelectedPeriod(), page)",
     )
 
-    const requestBuilders = [
-      "buildTokenUsageSummaryUrl",
-      "buildTokenUsageDailyUrl",
-      "buildTokenUsageEventsUrl",
-    ]
-    for (const builder of requestBuilders) {
-      expect(html).toContain(`function ${builder}`)
+    for (const builder of ["Summary", "Daily", "Events"]) {
+      expect(html).toContain(`function buildTokenUsage${builder}Url`)
       expect(html).toContain('url.searchParams.set("period", period)')
     }
   })

--- a/tests/usage-viewer.test.ts
+++ b/tests/usage-viewer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+
+const pagePath = new URL("../pages/index.html", import.meta.url)
+
+async function readUsageViewerPage(): Promise<string> {
+  return readFile(pagePath, "utf8")
+}
+
+describe("usage viewer period contract", () => {
+  test("offers calendar-to-date periods in the documented order", async () => {
+    const html = await readUsageViewerPage()
+    const periodSelect = html.match(
+      /<select\s+id="token-usage-period"[\s\S]*?<\/select>/,
+    )?.[0]
+
+    expect(periodSelect).toBeDefined()
+    const options = [
+      ...(periodSelect ?? "").matchAll(
+        /<option value="([^"]+)">([^<]+)<\/option>/g,
+      ),
+    ].map((match) => [match[1], match[2]])
+
+    expect(options).toEqual([
+      ["day", "Day"],
+      ["weekToDate", "Week to date"],
+      ["week", "Week"],
+      ["monthToDate", "Month to date"],
+      ["month", "Month"],
+      ["lifetime", "Lifetime"],
+    ])
+  })
+
+  test("normalizes new period values and propagates the selection to requests", async () => {
+    const html = await readUsageViewerPage()
+
+    expect(html).toMatch(
+      /const DEFAULT_TOKEN_USAGE_PERIOD = "day";[\s\S]*?const VALID_PERIODS = new Set\(\[\s*"day",\s*"weekToDate",\s*"week",\s*"monthToDate",\s*"month",\s*"lifetime",\s*\]\);/,
+    )
+    expect(html).toMatch(
+      /function normalizePeriod\(value\)\s*\{[\s\S]*?return VALID_PERIODS\.has\(value\)[\s\S]*?\? value\s*:\s*DEFAULT_TOKEN_USAGE_PERIOD;/,
+    )
+    expect(html).toContain('weekToDate: "Week to date"')
+    expect(html).toContain('monthToDate: "Month to date"')
+    expect(html).toContain('lifetime: "Lifetime"')
+    expect(html).toContain(
+      "fetchJson(buildTokenUsageSummaryUrl(usageUrl, period))",
+    )
+    expect(html).toContain(
+      "fetchJson(buildTokenUsageDailyUrl(usageUrl, period))",
+    )
+    expect(html).toContain(
+      "fetchJson(buildTokenUsageEventsUrl(usageUrl, period, page))",
+    )
+    expect(html).toContain(
+      "buildTokenUsageEventsUrl(usageUrl, getSelectedPeriod(), page)",
+    )
+
+    const requestBuilders = [
+      "buildTokenUsageSummaryUrl",
+      "buildTokenUsageDailyUrl",
+      "buildTokenUsageEventsUrl",
+    ]
+    for (const builder of requestBuilders) {
+      expect(html).toContain(`function ${builder}`)
+      expect(html).toContain('url.searchParams.set("period", period)')
+    }
+  })
+})


### PR DESCRIPTION
Adds calendar-based and lifetime usage periods to the localhost usage viewer and token-usage API.

I wanted to keep your current logic as is, so I just added more options without changing too much. I think there is lots of repetition/duplication in the original code, so you might want to refactor that part.

- Adds Week to date, Month to date, and Lifetime viewer options.
- Preserves existing Day, rolling Week, and rolling Month periods.
- Keeps Day as the default period.
- Adds API support for all 3 options.
- Week to date starts Monday at 00:00.
- Month to date starts on the first day at 00:00.
- Lifetime starts at the earliest recorded event.